### PR TITLE
Cross-Platform Functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/sqweek/dialog v0.0.0-20260123140253-64c163d53aac
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
+	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.37.0
 )
@@ -68,8 +70,6 @@ require (
 	golang.org/x/exp/shiny v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/image v0.26.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,6 +24,10 @@ type App struct {
 	rtr         router.Router
 	homeDir     string
 	configFiles embed.FS
+
+	// provider is the cached Docker daemon identification, populated by
+	// Initialize once Ping has succeeded. Reads via Provider() are
+	// concurrency-safe — pmu in *Docker guards the underlying cache.
 }
 
 func New(configFiles embed.FS, d *docker.Docker, homeDir string, rtr router.Router) *App {
@@ -46,6 +50,22 @@ func (a *App) Initialize(ctx context.Context) error {
 	}
 	if err := a.d.CheckDockerAvailable(ctx); err != nil {
 		return err
+	}
+
+	// Identify the daemon up front so health checks can read a cached
+	// answer without each one re-issuing `docker info`. Failure to
+	// identify is non-fatal — we'll fall back to a "name unknown"
+	// finding rather than block startup.
+	if pi, err := a.d.ProviderInfo(ctx); err == nil {
+		slog.Info("docker daemon identified",
+			"provider", pi.Name,
+			"server_version", pi.ServerVersion,
+			"os_type", pi.OSType,
+			"arch", pi.Architecture,
+			"rootless", pi.Rootless,
+		)
+	} else {
+		slog.Warn("docker: ProviderInfo failed; health checks may be degraded", "err", err.Error())
 	}
 
 	// Wipe leftover Locorum-owned resources from prior sessions before
@@ -144,6 +164,21 @@ func (a *App) IsDockerAvailable(ctx context.Context) error {
 
 func (a *App) GetClient() *client.Client { return a.cli }
 func (a *App) GetHomeDir() string        { return a.homeDir }
+
+// Provider returns the cached Docker daemon identification. If Initialize
+// has not yet run (or the ProviderInfo call failed), the returned
+// ProviderInfo carries the engine-side default values plus an empty Name
+// — callers should treat that as "unknown" and not branch on specifics.
+func (a *App) Provider(ctx context.Context) docker.ProviderInfo {
+	pi, err := a.d.ProviderInfo(ctx)
+	if err != nil {
+		// The cache is set in Initialize; an error here means
+		// Initialize hasn't run successfully yet. Return zero so
+		// callers don't need to check.
+		return docker.ProviderInfo{}
+	}
+	return pi
+}
 
 func (a *App) SetupFilesystem() error {
 	for _, p := range []string{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,12 @@ func allKeys() []string {
 		KeyTelemetryClient,
 		KeyUpdateCheckEnabled,
 		KeyUpdateCheckChannel,
+		KeyHealthEnabled,
+		KeyHealthCadenceMinutes,
+		KeyHealthDiskCadenceMinutes,
+		KeyHealthDiskWarnGB,
+		KeyHealthDiskBlockerGB,
+		KeyHealthLastSeen,
 	}
 }
 
@@ -335,6 +341,93 @@ func (c *Config) SetPerformanceMode(v string) error {
 		return fmt.Errorf("config: invalid performance mode %q (allowed: %s)", v, strings.Join(allowedPerformance, ", "))
 	}
 	return c.Set(KeyPerformanceMode, v)
+}
+
+// ── System Health ───────────────────────────────────────────────────
+
+// HealthEnabled reports whether the System Health runner should publish
+// snapshots. Default true. When false, the UI hides the badge, modal,
+// toasts, and panel findings.
+func (c *Config) HealthEnabled() bool {
+	return parseBool(c.raw(KeyHealthEnabled), DefaultHealthEnabled)
+}
+
+// SetHealthEnabled persists the on/off switch.
+func (c *Config) SetHealthEnabled(v bool) error {
+	return c.Set(KeyHealthEnabled, formatBool(v))
+}
+
+// HealthCadenceMinutes is the global health-check cadence in minutes.
+// Default 5. Returns the default for invalid stored values.
+func (c *Config) HealthCadenceMinutes() int {
+	return parseInt(c.raw(KeyHealthCadenceMinutes), DefaultHealthCadenceMinutes)
+}
+
+// SetHealthCadenceMinutes persists the cadence; rejects ≤0.
+func (c *Config) SetHealthCadenceMinutes(v int) error {
+	if v <= 0 {
+		return fmt.Errorf("config: cadence must be positive (got %d)", v)
+	}
+	return c.Set(KeyHealthCadenceMinutes, strconv.Itoa(v))
+}
+
+// HealthDiskCadenceMinutes is the cadence for the expensive disk-usage
+// check. Default 15.
+func (c *Config) HealthDiskCadenceMinutes() int {
+	return parseInt(c.raw(KeyHealthDiskCadenceMinutes), DefaultHealthDiskCadenceMinutes)
+}
+
+// SetHealthDiskCadenceMinutes persists the disk-check cadence; rejects ≤0.
+func (c *Config) SetHealthDiskCadenceMinutes(v int) error {
+	if v <= 0 {
+		return fmt.Errorf("config: disk cadence must be positive (got %d)", v)
+	}
+	return c.Set(KeyHealthDiskCadenceMinutes, strconv.Itoa(v))
+}
+
+// HealthDiskWarnGB is the threshold below which we surface a warning
+// finding. Default 5.
+func (c *Config) HealthDiskWarnGB() int {
+	return parseInt(c.raw(KeyHealthDiskWarnGB), DefaultHealthDiskWarnGB)
+}
+
+// SetHealthDiskWarnGB persists the warn threshold; rejects ≤0.
+func (c *Config) SetHealthDiskWarnGB(v int) error {
+	if v <= 0 {
+		return fmt.Errorf("config: warn threshold must be positive (got %d)", v)
+	}
+	return c.Set(KeyHealthDiskWarnGB, strconv.Itoa(v))
+}
+
+// HealthDiskBlockerGB is the threshold below which we escalate to a
+// blocker. Default 1.
+func (c *Config) HealthDiskBlockerGB() int {
+	return parseInt(c.raw(KeyHealthDiskBlockerGB), DefaultHealthDiskBlockerGB)
+}
+
+// SetHealthDiskBlockerGB persists the blocker threshold; rejects ≤0 and
+// any value ≥ the warn threshold (since blocker must be tighter).
+func (c *Config) SetHealthDiskBlockerGB(v int) error {
+	if v <= 0 {
+		return fmt.Errorf("config: blocker threshold must be positive (got %d)", v)
+	}
+	warn := c.HealthDiskWarnGB()
+	if v >= warn {
+		return fmt.Errorf("config: blocker threshold (%d GB) must be smaller than warn threshold (%d GB)", v, warn)
+	}
+	return c.Set(KeyHealthDiskBlockerGB, strconv.Itoa(v))
+}
+
+// HealthLastSeen returns the persisted last-seen-finding-keys JSON blob.
+// Empty string on first run. The value is opaque to the config package;
+// the UI's toast handler parses it.
+func (c *Config) HealthLastSeen() string {
+	return c.raw(KeyHealthLastSeen)
+}
+
+// SetHealthLastSeen persists the JSON blob.
+func (c *Config) SetHealthLastSeen(v string) error {
+	return c.Set(KeyHealthLastSeen, v)
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -57,6 +57,15 @@ const (
 	// Update check. Reserved for LEARNINGS §7.4.
 	KeyUpdateCheckEnabled = "update_check.enabled"
 	KeyUpdateCheckChannel = "update_check.channel"
+
+	// System Health (CROSS-PLATFORM.md). All optional — sensible
+	// defaults apply when unset.
+	KeyHealthEnabled            = "health.enabled"         // bool, default true
+	KeyHealthCadenceMinutes     = "health.cadence_minutes" // int, default 5
+	KeyHealthDiskCadenceMinutes = "health.disk_check_cadence_minutes"
+	KeyHealthDiskWarnGB         = "health.disk_warn_gb"    // int, default 5
+	KeyHealthDiskBlockerGB      = "health.disk_blocker_gb" // int, default 1
+	KeyHealthLastSeen           = "health.last_seen"       // json, internal
 )
 
 // Documented default values for every accessor. Centralising these
@@ -71,6 +80,12 @@ const (
 	DefaultRouterHTTPS   = 443
 	DefaultPerformance   = "auto"
 	DefaultUpdateChannel = "stable"
+
+	DefaultHealthEnabled            = true
+	DefaultHealthCadenceMinutes     = 5
+	DefaultHealthDiskCadenceMinutes = 15
+	DefaultHealthDiskWarnGB         = 5
+	DefaultHealthDiskBlockerGB      = 1
 )
 
 // Allowed enum values. Used by Set* validation.

--- a/internal/docker/dockerpath_audit_test.go
+++ b/internal/docker/dockerpath_audit_test.go
@@ -1,0 +1,85 @@
+package docker
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PeterBooker/locorum/internal/platform"
+	"github.com/PeterBooker/locorum/internal/types"
+)
+
+// TestSpecBuildersBindMountsAreSlashSafe runs every spec-builder under
+// realistic input and confirms each BindMount.Source survives a round-trip
+// through platform.DockerPath unchanged. If a future spec edit introduces
+// an unsanitised Windows-shaped path or a `filepath.Join` that surfaces
+// backslashes on the build host, this test fails — replacing the manual
+// audit pass that decays over time.
+//
+// We deliberately don't compare against the *exact* output of
+// platform.DockerPath in production-realistic Linux fixtures because all
+// the existing builders already pass paths through filepath.Join (which
+// renders forward slashes on Linux). The test is the regression bar:
+// builders must produce strings that DockerPath leaves alone, which is
+// the contract every "production" path satisfies.
+func TestSpecBuildersBindMountsAreSlashSafe(t *testing.T) {
+	site := &types.Site{
+		ID:       "1",
+		Slug:     "demo",
+		Name:     "Demo",
+		FilesDir: filepath.Join("/home/u", "locorum", "sites", "demo"),
+	}
+	homeDir := "/home/u"
+
+	specs := []ContainerSpec{
+		NginxWebSpec(site, homeDir),
+		ApacheWebSpec(site, homeDir),
+		WebSpec(site, homeDir),
+		PHPSpec(site, homeDir),
+		RedisSpec(site),
+		MailSpec(),
+		AdminerSpec(),
+	}
+	for _, s := range specs {
+		for i, m := range s.Mounts {
+			if m.Bind == nil {
+				continue
+			}
+			src := m.Bind.Source
+			if strings.ContainsRune(src, '\\') {
+				t.Errorf("%s mount[%d]: contains backslash %q — wrap in platform.DockerPath", s.Name, i, src)
+			}
+			if got := platform.DockerPath(src); got != src {
+				t.Errorf("%s mount[%d]: not slash-canonical: src=%q DockerPath=%q", s.Name, i, src, got)
+			}
+		}
+	}
+}
+
+// TestBuildMountsCallsDockerPath is the canary for the central
+// translation point. We hand a Windows-shaped path through buildMounts and
+// confirm the result has no backslashes — even on a Linux test runner
+// where filepath.ToSlash is otherwise a no-op.
+func TestBuildMountsCallsDockerPath(t *testing.T) {
+	in := []Mount{
+		{Bind: &BindMount{Source: `C:\Users\Peter\sites\demo`, Target: "/var/www/html"}},
+		{Bind: &BindMount{Source: `D:\config\nginx.conf`, Target: "/etc/nginx/nginx.conf", ReadOnly: true}},
+	}
+	binds, _ := buildMounts(in)
+	if len(binds) != 2 {
+		t.Fatalf("expected 2 binds, got %d", len(binds))
+	}
+	for _, b := range binds {
+		if strings.ContainsRune(b, '\\') {
+			t.Errorf("buildMounts left a backslash in %q", b)
+		}
+	}
+	want := "C:/Users/Peter/sites/demo:/var/www/html"
+	if binds[0] != want {
+		t.Errorf("first bind = %q, want %q", binds[0], want)
+	}
+	wantRO := "D:/config/nginx.conf:/etc/nginx/nginx.conf:ro"
+	if binds[1] != wantRO {
+		t.Errorf("second bind = %q, want %q", binds[1], wantRO)
+	}
+}

--- a/internal/docker/engine.go
+++ b/internal/docker/engine.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"context"
 	"time"
+
+	"github.com/PeterBooker/locorum/internal/version"
 )
 
 // Engine is the surface every consumer above internal/docker uses. *Docker
@@ -103,6 +105,12 @@ type Engine interface {
 	// EnsureMarkerStep to inspect a volume before the service container
 	// owning it has booted.
 	RunOneShotCapture(ctx context.Context, name, image string, cmd []string, mounts []OneShotMount) (OneShotResult, error)
+
+	// DiskUsage returns a high-level summary of `docker system df`. Slow
+	// (multi-second on busy hosts); callers should pass a context with
+	// a deadline (~30s) and gate via a circuit breaker if they call it
+	// repeatedly. Concurrent callers are coalesced via singleflight.
+	DiskUsage(ctx context.Context) (DiskReport, error)
 }
 
 // PullProgress is one tick of image-pull progress. Aggregated across layers
@@ -144,7 +152,8 @@ type ProviderInfo struct {
 	OperatingSystem string
 	OSType          string // "linux", "windows"
 	Architecture    string
-	ServerVersion   string
+	ServerVersion   string                      // raw, as the daemon reports it
+	ServerVersionP  version.DockerServerVersion // parsed view; .IsZero() if unparseable
 	Rootless        bool
 	IsDockerDesktop bool
 	NCPU            int

--- a/internal/docker/engine_chown.go
+++ b/internal/docker/engine_chown.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
+
+	"github.com/PeterBooker/locorum/internal/platform"
 )
 
 // chownImage is the small alpine image used by the one-shot chown helper.
@@ -54,14 +56,17 @@ func (d *Docker) runChown(ctx context.Context, name, source, target string, uid,
 	hostCfg := &container.HostConfig{
 		AutoRemove: true,
 	}
+	// Normalise host-path separators for Docker on every platform.
+	// platform.DockerPath is a no-op for Linux paths and named volumes —
+	// volume names are not paths and pass through unchanged.
+	src := source
 	if bindMount {
-		hostCfg.Binds = []string{source + ":" + target}
-	} else {
-		hostCfg.Binds = []string{source + ":" + target}
-		// Same syntax — Docker treats "<volume-name>:<target>" as a volume
-		// mount when the source is a known volume name. We could also use
-		// hostCfg.Mounts but the bind syntax is identical for our needs.
+		src = platform.DockerPath(source)
 	}
+	hostCfg.Binds = []string{src + ":" + target}
+	// Same syntax for both branches — Docker treats "<volume-name>:<target>"
+	// as a volume mount when the source is a known volume name. We could
+	// also use hostCfg.Mounts but the bind syntax is identical for our needs.
 
 	resp, err := d.cli.ContainerCreate(ctx, cfg, hostCfg, nil, nil, name)
 	if err != nil {

--- a/internal/docker/engine_container.go
+++ b/internal/docker/engine_container.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
+
+	"github.com/PeterBooker/locorum/internal/platform"
 )
 
 // EnsureContainer creates the container described by spec if absent, or
@@ -337,7 +339,13 @@ func buildMounts(in []Mount) ([]string, []mount.Mount) {
 	for _, m := range in {
 		switch {
 		case m.Bind != nil:
-			s := m.Bind.Source + ":" + m.Bind.Target
+			// platform.DockerPath normalises slashes for every supported
+			// host. Centralising it here means every code path that
+			// reaches Docker via a ContainerSpec gets the same treatment
+			// — call sites can pass `filepath.Join(...)` results without
+			// worrying about Windows backslashes leaking through.
+			src := platform.DockerPath(m.Bind.Source)
+			s := src + ":" + m.Bind.Target
 			if m.Bind.ReadOnly {
 				s += ":ro"
 			}

--- a/internal/docker/engine_disk.go
+++ b/internal/docker/engine_disk.go
@@ -1,0 +1,96 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"golang.org/x/sync/singleflight"
+)
+
+// DiskReport is the engine-level summary of `docker system df`. We expose a
+// small, stable struct rather than the SDK's full DiskUsage so the health
+// package doesn't end up depending on docker/api/types.
+//
+// All sizes are bytes. A field of zero is "no data on this kind of object",
+// not "we failed to look it up" — DiskUsage as a whole returns an error in
+// the failure case and empties this struct.
+type DiskReport struct {
+	// LayersSize is the on-disk footprint of all Docker image layers.
+	LayersSize int64
+
+	// BuildCacheSize is the BuildKit cache size (separate from layers).
+	BuildCacheSize int64
+
+	// VolumeSize is the *reported* size of all named volumes — only
+	// populated when the daemon's volume driver implements the
+	// optional size measurement (the local driver does for Linux,
+	// not on macOS). Zero on platforms where it's unavailable.
+	VolumeSize int64
+
+	// ImageCount is the number of unique tagged images.
+	ImageCount int
+
+	// ContainerCount is the number of containers (running or stopped).
+	ContainerCount int
+
+	// VolumeCount is the number of named volumes.
+	VolumeCount int
+}
+
+// diskUsageGroup deduplicates concurrent DiskUsage callers — see DiskUsage.
+var diskUsageGroup singleflight.Group
+
+// DiskUsage returns the daemon's `system df` report. The call is **slow**:
+// the daemon walks every container/image/volume/build-cache record, and on a
+// busy workstation it can take >5 s. We mitigate via:
+//
+//   - singleflight: concurrent callers share one in-flight RPC.
+//   - context propagation: the caller's deadline bounds the call.
+//   - shape conversion: the caller never sees the full SDK types, so
+//     adding a field doesn't break the contract.
+//
+// The 30-second outer deadline mentioned in the plan is enforced by the
+// **caller**, not here — the health.disk-low check passes a context with
+// that deadline. This keeps DiskUsage usable from other call sites that
+// have their own timing budget.
+func (d *Docker) DiskUsage(ctx context.Context) (DiskReport, error) {
+	v, err, _ := diskUsageGroup.Do("system-df", func() (any, error) {
+		return d.diskUsageInner(ctx)
+	})
+	if err != nil {
+		return DiskReport{}, err
+	}
+	return v.(DiskReport), nil
+}
+
+func (d *Docker) diskUsageInner(ctx context.Context) (DiskReport, error) {
+	if d.cli == nil {
+		return DiskReport{}, fmt.Errorf("docker: client not initialised")
+	}
+	du, err := d.cli.DiskUsage(ctx, types.DiskUsageOptions{})
+	if err != nil {
+		return DiskReport{}, fmt.Errorf("docker system df: %w", err)
+	}
+	out := DiskReport{
+		LayersSize:     du.LayersSize,
+		ImageCount:     len(du.Images),
+		ContainerCount: len(du.Containers),
+		VolumeCount:    len(du.Volumes),
+	}
+	for _, bc := range du.BuildCache {
+		if bc == nil {
+			continue
+		}
+		out.BuildCacheSize += bc.Size
+	}
+	for _, v := range du.Volumes {
+		if v == nil || v.UsageData == nil {
+			continue
+		}
+		if v.UsageData.Size > 0 {
+			out.VolumeSize += v.UsageData.Size
+		}
+	}
+	return out, nil
+}

--- a/internal/docker/engine_provider.go
+++ b/internal/docker/engine_provider.go
@@ -3,8 +3,17 @@ package docker
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
+	"sync"
+
+	"github.com/PeterBooker/locorum/internal/version"
 )
+
+// providerLogOnce ensures the "could not parse Docker server version" warning
+// fires at most once per process. The pure-text path is fine to ignore on
+// the second-and-later calls; we already logged it.
+var providerLogOnce sync.Once
 
 // ProviderInfo returns Docker daemon identification, cached after first
 // successful call. Concurrent callers share the same lookup; cache misses
@@ -22,12 +31,20 @@ func (d *Docker) ProviderInfo(ctx context.Context) (ProviderInfo, error) {
 		return ProviderInfo{}, fmt.Errorf("docker info: %w", err)
 	}
 
+	parsed := version.ParseDockerServer(info.ServerVersion)
+	if parsed.IsZero() && info.ServerVersion != "" {
+		providerLogOnce.Do(func() {
+			slog.Warn("docker: could not parse server version", "raw", info.ServerVersion)
+		})
+	}
+
 	pi := ProviderInfo{
 		Name:            classifyProviderName(info.Name, info.OperatingSystem),
 		OperatingSystem: info.OperatingSystem,
 		OSType:          info.OSType,
 		Architecture:    info.Architecture,
 		ServerVersion:   info.ServerVersion,
+		ServerVersionP:  parsed,
 		Rootless:        isRootless(info.SecurityOptions),
 		IsDockerDesktop: isDockerDesktop(info.OperatingSystem, info.Name),
 		NCPU:            info.NCPU,

--- a/internal/docker/engine_provider_test.go
+++ b/internal/docker/engine_provider_test.go
@@ -1,0 +1,70 @@
+package docker
+
+import "testing"
+
+func TestClassifyProviderName(t *testing.T) {
+	cases := []struct {
+		name, daemon, os string
+		want             string
+	}{
+		{"docker desktop linux", "docker-desktop", "Docker Desktop", "Docker Desktop"},
+		{"docker desktop mac", "docker-desktop", "Docker Desktop (Mac)", "Docker Desktop"},
+		{"orbstack", "orbstack", "OrbStack 1.7", "OrbStack"},
+		{"rancher desktop", "rancher-desktop", "Rancher Desktop WSL", "Rancher Desktop"},
+		{"colima", "colima", "Ubuntu 22.04 (Colima)", "Colima"},
+		{"podman", "podman", "Podman 4.7.2 / Linux", "Podman"},
+		{"plain docker engine", "moby", "Ubuntu 22.04.3 LTS", "moby"},
+		{"unknown name fallback to literal", "weird-daemon", "SomeUnknownOS", "weird-daemon"},
+		{"empty everything", "", "", "docker"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classifyProviderName(c.daemon, c.os)
+			if got != c.want {
+				t.Errorf("classifyProviderName(%q, %q) = %q; want %q", c.daemon, c.os, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsRootless(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []string
+		want bool
+	}{
+		{"rootless name", []string{"name=rootless"}, true},
+		{"rootless mixed case", []string{"Name=ROOTLESS"}, true},
+		{"contains rootless substring", []string{"foo=rootless,bar=baz"}, true},
+		{"non-rootless", []string{"name=seccomp,profile=builtin", "selinux"}, false},
+		{"empty", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isRootless(c.opts)
+			if got != c.want {
+				t.Errorf("isRootless(%v) = %v; want %v", c.opts, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsDockerDesktop(t *testing.T) {
+	cases := []struct {
+		name, os, daemon string
+		want             bool
+	}{
+		{"explicit docker desktop os", "Docker Desktop", "docker", true},
+		{"explicit docker desktop daemon", "macOS", "docker-desktop", true},
+		{"orbstack", "OrbStack", "orbstack", false},
+		{"empty", "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isDockerDesktop(c.os, c.daemon)
+			if got != c.want {
+				t.Errorf("isDockerDesktop(%q, %q) = %v; want %v", c.os, c.daemon, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/docker/fake/engine.go
+++ b/internal/docker/fake/engine.go
@@ -43,6 +43,10 @@ type Engine struct {
 	// One-shot helpers for §7 of DATABASE.md (volume marker).
 	OneShotCalls  []OneShotCall
 	OneShotScript []OneShotScripted
+
+	// Disk-usage scripting for the health package's disk-low check.
+	DiskReport docker.DiskReport
+	DiskErr    error
 }
 
 // Container is the fake's record of a created container.
@@ -306,7 +310,37 @@ func (e *Engine) ProviderInfo(_ context.Context) (docker.ProviderInfo, error) {
 	return e.Provider, nil
 }
 
+// SetProvider replaces the cached provider info under lock. Health-check
+// tests use this to drive the "what daemon are we talking to" branch
+// without having to construct an engine_provider.go pipeline.
+func (e *Engine) SetProvider(p docker.ProviderInfo) {
+	e.mu.Lock()
+	e.Provider = p
+	e.mu.Unlock()
+}
+
+// SetPingErr replaces the ping error under lock. Health-check tests use
+// this to simulate "Docker is down" branches without racing with the
+// PingErr field directly.
+func (e *Engine) SetPingErr(err error) {
+	e.mu.Lock()
+	e.PingErr = err
+	e.mu.Unlock()
+}
+
 func (e *Engine) Ping(_ context.Context) error { return e.PingErr }
+
+// DiskUsage returns the scripted DiskReport. Tests can set DiskReport and
+// DiskErr to drive behaviour in the disk-low health check without a real
+// daemon.
+func (e *Engine) DiskUsage(_ context.Context) (docker.DiskReport, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.DiskErr != nil {
+		return docker.DiskReport{}, e.DiskErr
+	}
+	return e.DiskReport, nil
+}
 
 // RunOneShotCapture is a recorded one-shot run. Tests pre-load
 // OneShotScript with the responses to return for each call in order.

--- a/internal/docker/oneshot.go
+++ b/internal/docker/oneshot.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/pkg/stdcopy"
+
+	"github.com/PeterBooker/locorum/internal/platform"
 )
 
 // OneShotMount describes one mount attached to a transient run-and-remove
@@ -52,9 +54,15 @@ func (d *Docker) RunOneShotCapture(ctx context.Context, name, image string, cmd 
 
 	binds := make([]string, 0, len(mounts))
 	for _, m := range mounts {
-		src := m.Volume
-		if src == "" {
-			src = m.Bind
+		// Volume mounts pass the name through unchanged; bind mounts go
+		// via platform.DockerPath so a Windows path doesn't reach Docker
+		// with backslashes the bind syntax can't tolerate.
+		var src string
+		switch {
+		case m.Volume != "":
+			src = m.Volume
+		case m.Bind != "":
+			src = platform.DockerPath(m.Bind)
 		}
 		if src == "" || m.Target == "" {
 			return res, fmt.Errorf("oneshot: mount missing source or target: %+v", m)

--- a/internal/health/actions.go
+++ b/internal/health/actions.go
@@ -1,0 +1,137 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ErrAlreadyRunning is returned by [Runner.SubmitAction] when the same
+// finding ID already has an action in flight. UI code can ignore this
+// silently; the second click is a duplicate.
+var ErrAlreadyRunning = errors.New("health: action already running")
+
+// actionExecutor runs Action.Run on a bounded worker pool. Per-finding-ID
+// re-entrancy is enforced so the same fix can't run twice concurrently.
+//
+// The done callback fires *on the executor goroutine*. UI subscribers
+// must not block — the convention is to invalidate the window and store
+// the error in UIState.
+type actionExecutor struct {
+	sem      chan struct{}
+	inflight sync.Map // string → *atomic.Bool
+	log      *slog.Logger
+	metrics  MetricsSink
+
+	closeOnce sync.Once
+	closeCh   chan struct{}
+	wg        sync.WaitGroup
+}
+
+func newActionExecutor(cap int, log *slog.Logger, metrics MetricsSink) *actionExecutor {
+	if cap <= 0 {
+		cap = defaultActionPool
+	}
+	return &actionExecutor{
+		sem:     make(chan struct{}, cap),
+		log:     log,
+		metrics: metrics,
+		closeCh: make(chan struct{}),
+	}
+}
+
+// submit kicks off Action.Run for a given finding ID. Returns
+// ErrAlreadyRunning if the same ID is already in flight.
+func (e *actionExecutor) submit(ctx context.Context, id string, a Action, done func(error)) error {
+	if a.Run == nil {
+		return errors.New("health: action has no Run func")
+	}
+
+	guard, _ := e.inflight.LoadOrStore(id, &atomic.Bool{})
+	bg := guard.(*atomic.Bool)
+	if !bg.CompareAndSwap(false, true) {
+		return ErrAlreadyRunning
+	}
+
+	timeout := a.Timeout
+	if timeout <= 0 {
+		timeout = DefaultActionTimeout
+	}
+
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+
+		// Bound concurrency. Bail if Close is in flight.
+		select {
+		case e.sem <- struct{}{}:
+		case <-e.closeCh:
+			bg.Store(false)
+			return
+		case <-ctx.Done():
+			bg.Store(false)
+			if done != nil {
+				done(ctx.Err())
+			}
+			return
+		}
+		defer func() { <-e.sem }()
+		defer bg.Store(false)
+
+		actCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		start := time.Now()
+		err := safeRunAction(actCtx, a)
+		dur := time.Since(start)
+
+		outcome := "ok"
+		switch {
+		case errors.Is(err, context.DeadlineExceeded):
+			outcome = "timeout"
+		case err != nil:
+			outcome = "err"
+		}
+		e.log.Info("health: action complete",
+			"action", id,
+			"trigger", "user",
+			"outcome", outcome,
+			"duration_ms", dur.Milliseconds(),
+			"err", errOrEmpty(err),
+		)
+		e.metrics.ObserveAction(id, dur, err)
+
+		if done != nil {
+			done(err)
+		}
+	}()
+	return nil
+}
+
+func safeRunAction(ctx context.Context, a Action) (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = errors.New("action panicked")
+		}
+	}()
+	return a.Run(ctx)
+}
+
+func errOrEmpty(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// close drains in-flight actions and prevents future submits from starting
+// new ones. Idempotent.
+func (e *actionExecutor) close() {
+	e.closeOnce.Do(func() {
+		close(e.closeCh)
+		e.wg.Wait()
+	})
+}

--- a/internal/health/breaker.go
+++ b/internal/health/breaker.go
@@ -1,0 +1,102 @@
+package health
+
+import (
+	"sync"
+	"time"
+)
+
+// Breaker is a tiny circuit breaker for the disk-usage check. After
+// [Breaker.MaxFailures] consecutive timeouts it opens; while open, calls
+// fail fast for [Breaker.Cooldown] before half-opening for one trial.
+//
+// Stand-alone, no goroutine, lock-only-while-state-changes. Safe for
+// concurrent use.
+type Breaker struct {
+	// MaxFailures is the threshold at which the breaker opens. Default
+	// 3 — enough to avoid one-off flakes opening the circuit.
+	MaxFailures int
+
+	// Cooldown is how long the breaker stays open before trialling
+	// half-open. Default 1 hour for the disk-usage breaker.
+	Cooldown time.Duration
+
+	// Now overrides time.Now for tests.
+	Now func() time.Time
+
+	mu       sync.Mutex
+	failures int
+	openedAt time.Time
+}
+
+// State returns "closed", "open", or "half-open" — the latter is the
+// transient state where exactly one trial is allowed.
+func (b *Breaker) State() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.stateLocked()
+}
+
+func (b *Breaker) stateLocked() string {
+	if b.failures < b.maxFailuresOrDefault() {
+		return "closed"
+	}
+	if b.timeNow().Sub(b.openedAt) > b.cooldownOrDefault() {
+		return "half-open"
+	}
+	return "open"
+}
+
+// Allow reports whether the call should proceed. Returns true when closed
+// or half-open. The caller must record the outcome via [Breaker.OnSuccess]
+// or [Breaker.OnFailure] so the breaker advances correctly.
+func (b *Breaker) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	state := b.stateLocked()
+	return state != "open"
+}
+
+// OnSuccess resets the failure counter. Call after a successful trial in
+// half-open or any successful call in closed.
+func (b *Breaker) OnSuccess() {
+	b.mu.Lock()
+	b.failures = 0
+	b.openedAt = time.Time{}
+	b.mu.Unlock()
+}
+
+// OnFailure increments the failure counter; opens the breaker on the
+// transition past MaxFailures.
+func (b *Breaker) OnFailure() {
+	b.mu.Lock()
+	b.failures++
+	if b.failures == b.maxFailuresOrDefault() {
+		b.openedAt = b.timeNow()
+	} else if b.failures > b.maxFailuresOrDefault() {
+		// In half-open, a failure resets the cooldown clock so we
+		// don't immediately try again.
+		b.openedAt = b.timeNow()
+	}
+	b.mu.Unlock()
+}
+
+func (b *Breaker) timeNow() time.Time {
+	if b.Now != nil {
+		return b.Now()
+	}
+	return time.Now()
+}
+
+func (b *Breaker) maxFailuresOrDefault() int {
+	if b.MaxFailures > 0 {
+		return b.MaxFailures
+	}
+	return 3
+}
+
+func (b *Breaker) cooldownOrDefault() time.Duration {
+	if b.Cooldown > 0 {
+		return b.Cooldown
+	}
+	return time.Hour
+}

--- a/internal/health/bundled.go
+++ b/internal/health/bundled.go
@@ -1,0 +1,106 @@
+package health
+
+import (
+	"context"
+
+	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/platform"
+	tlspkg "github.com/PeterBooker/locorum/internal/tls"
+)
+
+// BundledOpts is the constructor input for [Bundled]. Each field maps to one
+// or more bundled checks; passing nil for a dependency disables the checks
+// that need it (so the runner can be partly wired up early in startup
+// before all subsystems are ready).
+type BundledOpts struct {
+	// Platform is the *Info from internal/platform. Required for the
+	// rosetta / WSL / Windows path checks.
+	Platform *platform.Info
+
+	// Engine is the docker engine. Required for the docker /
+	// disk / port / virtiofs checks.
+	Engine docker.Engine
+
+	// Mkcert is the TLS provider. Optional — when nil the mkcert check
+	// is omitted (the notice banner handles it instead).
+	Mkcert tlspkg.Provider
+
+	// MkcertInstaller is the one-click action. Pass nil to render the
+	// finding without an action button.
+	MkcertInstaller func(context.Context) error
+
+	// Sites is the registered-sites lister. Optional — when nil the
+	// path-shape checks (mnt-c, longpath) are omitted.
+	Sites SiteRootLister
+
+	// HostStatfsPath is the directory passed to platform.HostFreeBytes
+	// for the disk-low check. Typically platform.Get().HomeDir; on
+	// Windows native callers may want to pass the drive root.
+	HostStatfsPath string
+
+	// RouterContainerName is the docker container name the port-conflict
+	// check inspects to identify "this is our router". Pass
+	// traefik.ContainerName.
+	RouterContainerName string
+
+	// DiskWarnBytes / DiskBlockerBytes override the disk thresholds.
+	// Zero values fall back to DefaultDiskWarnBytes /
+	// DefaultDiskBlockerBytes.
+	DiskWarnBytes    int64
+	DiskBlockerBytes int64
+}
+
+// Bundled returns the production set of system-health checks. Wire-up:
+//
+//	runner := health.NewRunner(opts, health.Bundled(health.BundledOpts{
+//	    Platform: plat,
+//	    Engine:   d,
+//	    Mkcert:   mkcert,
+//	    MkcertInstaller: mkcertInstall,
+//	    Sites:    sm,
+//	    HostStatfsPath:      plat.HomeDir,
+//	    RouterContainerName: traefik.ContainerName,
+//	})...)
+//
+// Tests typically construct individual checks directly rather than going
+// through Bundled.
+func Bundled(opts BundledOpts) []Check {
+	var out []Check
+
+	if opts.Platform != nil {
+		out = append(out, NewRosettaCheck(opts.Platform))
+		if opts.Sites != nil {
+			out = append(out,
+				NewWSLMntCCheck(opts.Platform, opts.Sites),
+				NewWindowsLongPathCheck(opts.Platform, opts.Sites),
+			)
+		}
+	}
+
+	if opts.Engine != nil {
+		out = append(out,
+			NewDockerDownCheck(opts.Engine),
+			NewDockerOldCheck(opts.Engine),
+		)
+		if opts.Platform != nil {
+			out = append(out, NewProviderVirtioFSCheck(opts.Engine, opts.Platform.OS))
+		}
+		out = append(out, NewDiskLowCheck(opts.Engine, DiskLowConfig{
+			WarnBytes:    opts.DiskWarnBytes,
+			BlockerBytes: opts.DiskBlockerBytes,
+			Path:         opts.HostStatfsPath,
+		}))
+		if opts.RouterContainerName != "" {
+			out = append(out,
+				NewPortConflictCheck(opts.Engine, 80, opts.RouterContainerName),
+				NewPortConflictCheck(opts.Engine, 443, opts.RouterContainerName),
+			)
+		}
+	}
+
+	if opts.Mkcert != nil {
+		out = append(out, NewMkcertCheck(opts.Mkcert, opts.MkcertInstaller))
+	}
+
+	return out
+}

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -1,0 +1,240 @@
+// Package health is Locorum's system-health surface. Each Check is a small
+// pure-ish function that returns a slice of Findings; the Runner schedules
+// checks on a typed cadence and publishes the aggregated Snapshot via an
+// atomic.Pointer that the UI layer can read on every frame without locking.
+//
+// # Adding a new check
+//
+// Implement [Check] in a new file:
+//
+//	type ratelimitCheck struct{ engine docker.Engine }
+//	func (ratelimitCheck) ID() string                  { return "docker-ratelimit" }
+//	func (ratelimitCheck) Cadence() time.Duration       { return 0 } // use runner default
+//	func (ratelimitCheck) Budget() time.Duration        { return 5 * time.Second }
+//	func (c ratelimitCheck) Run(ctx context.Context) ([]Finding, error) { ... }
+//
+// Then add an instance to [Bundled] so it ships by default.
+//
+// # Concurrency model
+//
+//   - The runner runs each check in its own goroutine inside a fixed-size
+//     semaphore (cap 8). Long checks don't starve short ones.
+//   - Each check call gets a per-call context with the check's [Check.Budget]
+//     deadline. A check that exceeds budget twice in a row is marked
+//     [Finding.Stale] in the published snapshot; three breaches → suspended
+//     for one cycle.
+//   - The published [Snapshot] is read via [Runner.Snapshot] which loads an
+//     atomic.Pointer — no lock, lock-free for callers.
+//   - Checks must NOT capture or share mutable state across runs. Pass the
+//     world in via the constructor; the [Run] method is otherwise pure.
+package health
+
+import (
+	"context"
+	"time"
+)
+
+// Severity is the urgency of a Finding. Ordered: Info < Warn < Blocker.
+// The runner sorts findings descending by severity so the UI panel renders
+// blockers first.
+type Severity int8
+
+const (
+	// SeverityInfo is for informational signals — provider name, mutagen
+	// recommendation. No badge in the nav rail; appears in the panel only.
+	SeverityInfo Severity = 1
+
+	// SeverityWarn surfaces an amber dot in the nav rail and a toast on
+	// first detection. The user can keep using the app.
+	SeverityWarn Severity = 2
+
+	// SeverityBlocker is "you cannot use Locorum right now" — Rosetta,
+	// Docker down. Surfaces a modal on the very first frame after detection.
+	SeverityBlocker Severity = 3
+)
+
+// String renders the severity as a lowercase token. Suitable for slog
+// fields and JSON output.
+func (s Severity) String() string {
+	switch s {
+	case SeverityInfo:
+		return "info"
+	case SeverityWarn:
+		return "warn"
+	case SeverityBlocker:
+		return "blocker"
+	default:
+		return "unknown"
+	}
+}
+
+// Finding is the unit of system-health output. Two Findings are treated as
+// the same observation across runs when their (ID, Severity, DedupKey)
+// triple matches — the runner preserves [Finding.Detected] in that case so
+// the UI can render "noticed 3m ago" without falsely re-minting on detail
+// churn.
+//
+// Checks return a slice of these. They MUST NOT set [Finding.Detected] —
+// the runner sets it during snapshot publication.
+type Finding struct {
+	// ID is a stable identifier for this *kind* of finding, e.g.
+	// "rosetta", "disk-low", "port-conflict-80". Never includes a
+	// per-instance suffix; use [DedupKey] for that.
+	ID string
+
+	// Severity is the urgency band.
+	Severity Severity
+
+	// DedupKey is an optional discriminator within a single ID — e.g.
+	// "/var/lib/docker" for a per-volume warning. Two findings with the
+	// same ID but different DedupKey are independent rows in the panel.
+	DedupKey string
+
+	// Title is the short rendering ("Docker is not running"). One line,
+	// max ~40 chars.
+	Title string
+
+	// Detail is the single-sentence explanation. Plain text; the UI
+	// wraps and styles. No newlines.
+	Detail string
+
+	// Remediation is the imperative one-line "what to do next". Verbs
+	// in present tense ("Install mkcert", not "You should install
+	// mkcert"). UI may render this prefixed with → or ↳.
+	Remediation string
+
+	// HelpURL is an optional documentation link. The UI renders a small
+	// "Learn more" affordance when set. Empty when no docs apply.
+	HelpURL string
+
+	// Action is an optional one-click fix. Nil for findings the user
+	// must resolve outside Locorum.
+	Action *Action
+
+	// Detected is the wall-clock time this finding was first observed
+	// in the *current process*. Set by the runner; checks must leave
+	// it zero. Preserved across runs when (ID, Severity, DedupKey)
+	// matches the previous snapshot.
+	Detected time.Time
+
+	// Stale is set by the runner when the producing check exceeded its
+	// budget on the most recent run. The UI renders a clock icon next
+	// to the finding so the user knows the data may be stale.
+	Stale bool
+}
+
+// Action is an optional one-click remediation attached to a Finding.
+// [Run] is invoked from a bounded worker pool; the runner enforces the
+// timeout and re-entrancy guard so implementations only need to do the
+// work itself.
+type Action struct {
+	// Label is the button text ("Install mkcert", "Open Docker Desktop").
+	Label string
+
+	// Run performs the remediation. Returns nil on success; an error
+	// surfaces as a transient toast plus a slog ERROR. Must not block
+	// indefinitely — the runner enforces [Action.Timeout].
+	Run func(context.Context) error
+
+	// Timeout caps Run's wall-clock cost. Zero falls back to
+	// [DefaultActionTimeout] (30 s).
+	Timeout time.Duration
+}
+
+// DefaultActionTimeout caps Run when [Action.Timeout] is zero. Picked to
+// be generous enough for an mkcert -install on cold cache without the
+// user thinking the app froze.
+const DefaultActionTimeout = 30 * time.Second
+
+// Check is the contract every system-health probe satisfies.
+//
+// [Run] should be cheap on the hot path; expensive checks (disk usage)
+// declare a slower [Cadence]. Errors returned by [Run] are *not* findings
+// — they're internal failures the runner logs at ERROR and surfaces as a
+// generic `check-failed:<id>` warn finding so the user still sees that
+// something is wrong with the platform.
+type Check interface {
+	// ID returns a stable identifier. Must match [Finding.ID] for the
+	// findings this check produces; the runner uses it for dedup,
+	// logging, and the suspension state machine.
+	ID() string
+
+	// Cadence is the minimum interval between runs. Zero means "use
+	// the runner default" (typically 5 minutes).
+	Cadence() time.Duration
+
+	// Budget is the per-call wall-clock budget. The runner attaches a
+	// context with this deadline to every Run call. A check returning
+	// late marks the resulting findings Stale and may be suspended.
+	Budget() time.Duration
+
+	// Run produces zero or more findings. Returning (nil, nil) means
+	// "all clear for this concern". Errors are logged + surfaced via
+	// the check-failed envelope.
+	Run(ctx context.Context) ([]Finding, error)
+}
+
+// Snapshot is the published view of system health. The Runner publishes
+// these via [atomic.Pointer]; subscribers compare [Snapshot.Generation]
+// to detect "anything changed since the last frame".
+type Snapshot struct {
+	// Findings is sorted by Severity desc, then ID asc, then DedupKey
+	// asc. Stable across runs that produce the same set.
+	Findings []Finding
+
+	// LastRun is the wall-clock time the most recent batch completed.
+	// Zero when the runner has never published.
+	LastRun time.Time
+
+	// Running is true while a RunNow batch is in flight. The UI
+	// disables the Re-check button when set.
+	Running bool
+
+	// Generation is a monotonic counter that increments on every
+	// publication. UI subscribers compare against their last-seen
+	// value to skip redundant invalidates.
+	Generation uint64
+}
+
+// Has reports whether any finding with id (any DedupKey) is present.
+// Convenience for UI code asking "is there a blocker right now?".
+func (s *Snapshot) Has(id string) bool {
+	if s == nil {
+		return false
+	}
+	for _, f := range s.Findings {
+		if f.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// HighestSeverity returns the worst severity present, or 0 (no findings).
+func (s *Snapshot) HighestSeverity() Severity {
+	if s == nil {
+		return 0
+	}
+	var max Severity
+	for _, f := range s.Findings {
+		if f.Severity > max {
+			max = f.Severity
+		}
+	}
+	return max
+}
+
+// CountAt counts findings of the given severity. Convenience for UI badge
+// logic ("show amber if ≥1 warn AND no blocker").
+func (s *Snapshot) CountAt(level Severity) int {
+	if s == nil {
+		return 0
+	}
+	n := 0
+	for _, f := range s.Findings {
+		if f.Severity == level {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/health/checks_disk.go
+++ b/internal/health/checks_disk.go
@@ -1,0 +1,203 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/platform"
+)
+
+// DiskLowDefaults are the default thresholds. The user can override via the
+// health.disk_warn_gb / health.disk_blocker_gb settings.
+const (
+	DefaultDiskWarnBytes    int64 = 5 * 1024 * 1024 * 1024 // 5 GB
+	DefaultDiskBlockerBytes int64 = 1 * 1024 * 1024 * 1024 // 1 GB
+)
+
+// DiskLowConfig is the per-check tuning. All fields have sensible defaults.
+type DiskLowConfig struct {
+	WarnBytes    int64 // 0 → DefaultDiskWarnBytes
+	BlockerBytes int64 // 0 → DefaultDiskBlockerBytes
+
+	// Path is the host filesystem path to statfs. Typically the user's
+	// HomeDir; ~/.locorum lives there too. Empty path → no host check.
+	Path string
+}
+
+// DiskLowCheck reports the daemon's `system df` total + the host
+// filesystem's free bytes at the configured Path. Two thresholds:
+// WarnBytes (default 5 GB) → warn; BlockerBytes (default 1 GB) → blocker.
+//
+// The check is **expensive** (`docker system df` walks every container,
+// image, volume, build-cache record). To avoid making Docker slow for
+// other callers we:
+//
+//   - Default to a 15-minute cadence.
+//   - Wrap the engine call in a [Breaker] (3 timeouts → open for 1 hour).
+//   - Pass a 30s deadline via the per-check Budget.
+type DiskLowCheck struct {
+	engine  docker.Engine
+	cfg     DiskLowConfig
+	breaker *Breaker
+
+	mu          sync.Mutex
+	lastReport  docker.DiskReport
+	lastFree    int64
+	lastReadErr error
+}
+
+// NewDiskLowCheck builds the check. Pass platform.Get().HomeDir as the
+// statfs path in production.
+func NewDiskLowCheck(engine docker.Engine, cfg DiskLowConfig) *DiskLowCheck {
+	if cfg.WarnBytes <= 0 {
+		cfg.WarnBytes = DefaultDiskWarnBytes
+	}
+	if cfg.BlockerBytes <= 0 {
+		cfg.BlockerBytes = DefaultDiskBlockerBytes
+	}
+	if cfg.BlockerBytes >= cfg.WarnBytes {
+		// Blocker must be tighter than warn; correct silently rather
+		// than surfacing a config error to the user — the wrong order
+		// is almost certainly a typo.
+		cfg.BlockerBytes = cfg.WarnBytes / 5
+	}
+	return &DiskLowCheck{
+		engine:  engine,
+		cfg:     cfg,
+		breaker: &Breaker{MaxFailures: 3, Cooldown: time.Hour},
+	}
+}
+
+func (*DiskLowCheck) ID() string             { return "disk-low" }
+func (*DiskLowCheck) Cadence() time.Duration { return 15 * time.Minute }
+func (*DiskLowCheck) Budget() time.Duration  { return 30 * time.Second }
+
+func (c *DiskLowCheck) Run(ctx context.Context) ([]Finding, error) {
+	// 1. Cheap host statfs first. Always populated; survives a slow
+	//    docker daemon.
+	free, freeErr := c.readHostFree()
+
+	// 2. Docker disk usage, gated by the breaker.
+	report, dockerErr := c.readDocker(ctx)
+
+	// Build the finding from the cheaper of the two thresholds.
+	if free > 0 && free < c.cfg.BlockerBytes {
+		return []Finding{c.blockerFinding(free, report)}, nil
+	}
+	if free > 0 && free < c.cfg.WarnBytes {
+		return []Finding{c.warnFinding(free, report)}, nil
+	}
+
+	// Both signals report "ok" or unavailable — no finding.
+	if errors.Is(dockerErr, ErrCircuitOpen) {
+		// Surface a small Info row so the user understands why the
+		// disk-bytes line is missing, not a Warn.
+		return []Finding{{
+			ID:          "disk-check-skipped",
+			Severity:    SeverityInfo,
+			Title:       "Skipped Docker disk-usage probe",
+			Detail:      "Repeated timeouts on `docker system df`; will retry next cycle.",
+			Remediation: "Restart Docker if this persists.",
+		}}, nil
+	}
+
+	if freeErr != nil && dockerErr != nil {
+		// Both broken — keep the Run-error path (translated to
+		// check-failed by the runner).
+		return nil, fmt.Errorf("disk check: host=%v docker=%v", freeErr, dockerErr)
+	}
+	return nil, nil
+}
+
+// readHostFree returns bytes available at cfg.Path (empty → 0, nil).
+func (c *DiskLowCheck) readHostFree() (int64, error) {
+	if c.cfg.Path == "" {
+		return 0, nil
+	}
+	free, err := platform.HostFreeBytes(c.cfg.Path)
+	c.mu.Lock()
+	c.lastFree = free
+	c.lastReadErr = err
+	c.mu.Unlock()
+	return free, err
+}
+
+// readDocker calls engine.DiskUsage gated by the breaker.
+func (c *DiskLowCheck) readDocker(ctx context.Context) (docker.DiskReport, error) {
+	if !c.breaker.Allow() {
+		return docker.DiskReport{}, ErrCircuitOpen
+	}
+	rep, err := c.engine.DiskUsage(ctx)
+	if err != nil {
+		c.breaker.OnFailure()
+		return docker.DiskReport{}, err
+	}
+	c.breaker.OnSuccess()
+	c.mu.Lock()
+	c.lastReport = rep
+	c.mu.Unlock()
+	return rep, nil
+}
+
+// LastSnapshot returns the last successful host-free + disk-report read.
+// Used by the UI status-bar segment so it doesn't have to wait for a
+// fresh check.
+func (c *DiskLowCheck) LastSnapshot() (free int64, report docker.DiskReport) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastFree, c.lastReport
+}
+
+func (c *DiskLowCheck) warnFinding(free int64, report docker.DiskReport) Finding {
+	_ = report // currently informational; future: include in detail
+	return Finding{
+		ID:          c.ID(),
+		Severity:    SeverityWarn,
+		Title:       "Low disk space",
+		Detail:      fmt.Sprintf("Only %s free at %s.", humanBytes(free), c.cfg.Path),
+		Remediation: "Free disk space; consider `docker system prune` to reclaim image cache.",
+	}
+}
+
+func (c *DiskLowCheck) blockerFinding(free int64, report docker.DiskReport) Finding {
+	_ = report
+	return Finding{
+		ID:          c.ID(),
+		Severity:    SeverityBlocker,
+		Title:       "Critically low disk space",
+		Detail:      fmt.Sprintf("Only %s free at %s; site operations will fail.", humanBytes(free), c.cfg.Path),
+		Remediation: "Free disk space immediately. Run `docker system prune --all` to reclaim Docker's footprint.",
+	}
+}
+
+// ErrCircuitOpen is returned by the breaker-gated docker.DiskUsage when
+// the circuit is open. Callers translate this into a "skipped" finding
+// rather than treating it as a hard failure.
+var ErrCircuitOpen = errors.New("health: disk-usage circuit open")
+
+// humanBytes renders bytes as a short human string with at most one
+// decimal. Avoids pulling in dustin/go-humanize for one call site.
+func humanBytes(n int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+		TB = GB * 1024
+	)
+	switch {
+	case n >= TB:
+		return fmt.Sprintf("%.1f TB", float64(n)/float64(TB))
+	case n >= GB:
+		return fmt.Sprintf("%.1f GB", float64(n)/float64(GB))
+	case n >= MB:
+		return fmt.Sprintf("%.0f MB", float64(n)/float64(MB))
+	case n >= KB:
+		return fmt.Sprintf("%.0f KB", float64(n)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/health/checks_docker.go
+++ b/internal/health/checks_docker.go
@@ -1,0 +1,137 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/version"
+)
+
+// DockerDownCheck pings the Docker daemon. A single ping failure is not
+// enough to declare Docker down — daemons restart, sockets glitch, transient
+// network errors happen. We require two consecutive failures to surface a
+// blocker. The state machine is internal to the check and reset on a
+// successful ping.
+type DockerDownCheck struct {
+	engine docker.Engine
+
+	// failures is the consecutive-fail counter. Atomic so the runner's
+	// goroutine can race against an in-flight RunNow without locking.
+	failures atomic.Int32
+}
+
+// NewDockerDownCheck builds the check.
+func NewDockerDownCheck(engine docker.Engine) *DockerDownCheck {
+	return &DockerDownCheck{engine: engine}
+}
+
+func (*DockerDownCheck) ID() string             { return "docker-down" }
+func (*DockerDownCheck) Cadence() time.Duration { return 0 }
+func (*DockerDownCheck) Budget() time.Duration  { return 3 * time.Second }
+
+func (c *DockerDownCheck) Run(ctx context.Context) ([]Finding, error) {
+	err := c.engine.Ping(ctx)
+	if err == nil {
+		c.failures.Store(0)
+		return nil, nil
+	}
+	n := c.failures.Add(1)
+	if n < 2 {
+		// First failure — silent so a daemon restart blip doesn't
+		// surface a transient blocker.
+		return nil, nil
+	}
+	return []Finding{{
+		ID:          c.ID(),
+		Severity:    SeverityBlocker,
+		Title:       "Docker is not running",
+		Detail:      fmt.Sprintf("Locorum could not reach the Docker daemon: %s", err.Error()),
+		Remediation: "Start Docker Desktop / OrbStack / your Docker engine and re-check.",
+		HelpURL:     "https://docs.locorum.dev/install/docker",
+	}}, nil
+}
+
+// DockerOldCheck warns when the daemon is older than [version.MinSupported*].
+// Patch-level differences are ignored; we only care about Major.Minor.
+type DockerOldCheck struct {
+	engine docker.Engine
+}
+
+// NewDockerOldCheck builds the check.
+func NewDockerOldCheck(engine docker.Engine) *DockerOldCheck {
+	return &DockerOldCheck{engine: engine}
+}
+
+func (*DockerOldCheck) ID() string             { return "docker-old" }
+func (*DockerOldCheck) Cadence() time.Duration { return 30 * time.Minute }
+func (*DockerOldCheck) Budget() time.Duration  { return 2 * time.Second }
+
+func (c *DockerOldCheck) Run(ctx context.Context) ([]Finding, error) {
+	pi, err := c.engine.ProviderInfo(ctx)
+	if err != nil {
+		// Don't surface "old daemon" when we don't even know the
+		// version — that's docker-down territory.
+		return nil, nil
+	}
+	if pi.ServerVersionP.IsZero() {
+		return nil, nil
+	}
+	if !pi.ServerVersionP.LessThan(version.MinSupportedDockerServerMajor, version.MinSupportedDockerServerMinor) {
+		return nil, nil
+	}
+	return []Finding{{
+		ID:       c.ID(),
+		Severity: SeverityWarn,
+		Title:    "Docker is older than recommended",
+		Detail: fmt.Sprintf("Daemon reports version %s; Locorum is tested against %d.%d and newer.",
+			pi.ServerVersion, version.MinSupportedDockerServerMajor, version.MinSupportedDockerServerMinor),
+		Remediation: "Update Docker Desktop / OrbStack / your engine.",
+		HelpURL:     "https://docs.docker.com/engine/release-notes/",
+	}}, nil
+}
+
+// ProviderVirtioFSCheck warns macOS Docker Desktop users about VirtioFS's
+// slow-bind-mount behaviour for the WordPress workload. Stage 1 of the
+// LEARNINGS §6.3 mutagen roadmap — detection + advisory only.
+type ProviderVirtioFSCheck struct {
+	engine docker.Engine
+	info   func() *struct{ OS string }
+}
+
+// NewProviderVirtioFSCheck builds the check using a docker.Engine.
+func NewProviderVirtioFSCheck(engine docker.Engine, hostOS string) *ProviderVirtioFSCheck {
+	c := &ProviderVirtioFSCheck{engine: engine}
+	hostOSCopy := hostOS
+	c.info = func() *struct{ OS string } { return &struct{ OS string }{OS: hostOSCopy} }
+	return c
+}
+
+func (*ProviderVirtioFSCheck) ID() string             { return "provider-virtiofs" }
+func (*ProviderVirtioFSCheck) Cadence() time.Duration { return 30 * time.Minute }
+func (*ProviderVirtioFSCheck) Budget() time.Duration  { return 2 * time.Second }
+
+func (c *ProviderVirtioFSCheck) Run(ctx context.Context) ([]Finding, error) {
+	host := c.info()
+	if host == nil || host.OS != "darwin" {
+		return nil, nil
+	}
+	pi, err := c.engine.ProviderInfo(ctx)
+	if err != nil {
+		return nil, nil
+	}
+	if !pi.IsDockerDesktop {
+		return nil, nil
+	}
+	return []Finding{{
+		ID:       c.ID(),
+		Severity: SeverityInfo,
+		Title:    "macOS Docker Desktop: slow filesystem for WordPress",
+		Detail: "Docker Desktop on macOS uses VirtioFS for bind mounts, " +
+			"which is much slower than native ext4 for WordPress's many-small-files workload.",
+		Remediation: "Consider switching to OrbStack or Colima for faster bind-mount performance.",
+		HelpURL:     "https://docs.locorum.dev/macos-performance",
+	}}, nil
+}

--- a/internal/health/checks_mkcert.go
+++ b/internal/health/checks_mkcert.go
@@ -1,0 +1,64 @@
+package health
+
+import (
+	"context"
+	"time"
+
+	tlspkg "github.com/PeterBooker/locorum/internal/tls"
+)
+
+// MkcertCheck warns when mkcert is missing or its local CA isn't installed
+// — sites still serve over HTTPS, but browsers show an untrusted-cert
+// warning until the user runs `mkcert -install`.
+//
+// This is essentially the same data the persistent notice banner already
+// surfaces (see main.go:refreshTLSNotice), but living in the health
+// system means the System Health panel can show it alongside everything
+// else, with the same dismiss / re-check mechanics.
+type MkcertCheck struct {
+	prov tlspkg.Provider
+
+	// installer is an optional callback that performs the mkcert
+	// install. When non-nil the finding gains a one-click Action.
+	installer func(context.Context) error
+}
+
+// NewMkcertCheck builds the check. Pass nil for installer to skip the
+// inline action button (the persistent notice banner has its own).
+func NewMkcertCheck(prov tlspkg.Provider, installer func(context.Context) error) *MkcertCheck {
+	return &MkcertCheck{prov: prov, installer: installer}
+}
+
+func (*MkcertCheck) ID() string             { return "mkcert-missing" }
+func (*MkcertCheck) Cadence() time.Duration { return 5 * time.Minute }
+func (*MkcertCheck) Budget() time.Duration  { return 2 * time.Second }
+
+func (c *MkcertCheck) Run(ctx context.Context) ([]Finding, error) {
+	if c.prov == nil {
+		return nil, nil
+	}
+	status, err := c.prov.Available(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if status.Installed && status.CATrusted {
+		return nil, nil
+	}
+
+	f := Finding{
+		ID:          c.ID(),
+		Severity:    SeverityWarn,
+		Title:       "Trusted HTTPS not configured",
+		Detail:      status.Message,
+		Remediation: "Install mkcert and run `mkcert -install` so browsers trust Locorum-issued certificates.",
+		HelpURL:     "https://github.com/FiloSottile/mkcert#installation",
+	}
+	if c.installer != nil {
+		f.Action = &Action{
+			Label:   "Set up trusted HTTPS",
+			Run:     c.installer,
+			Timeout: 60 * time.Second,
+		}
+	}
+	return []Finding{f}, nil
+}

--- a/internal/health/checks_paths.go
+++ b/internal/health/checks_paths.go
@@ -1,0 +1,102 @@
+package health
+
+import (
+	"context"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/platform"
+)
+
+// SiteRootLister is the read-only interface the path-shape checks need.
+// SiteManager satisfies it via a tiny method (Roots(ctx) → []string).
+//
+// Defining this interface here (rather than importing
+// *sites.SiteManager) keeps the health package decoupled from the
+// site-lifecycle subsystem; production wiring is one line in main.go.
+type SiteRootLister interface {
+	Roots(ctx context.Context) []string
+}
+
+// WSLMntCCheck warns when any registered site lives under /mnt/c (or any
+// /mnt/<letter>/) — DrvFS is roughly 10× slower than native ext4 for the
+// many-small-files WordPress workload.
+type WSLMntCCheck struct {
+	platformInfo *platform.Info
+	sites        SiteRootLister
+}
+
+// NewWSLMntCCheck builds the check.
+func NewWSLMntCCheck(info *platform.Info, sites SiteRootLister) *WSLMntCCheck {
+	return &WSLMntCCheck{platformInfo: info, sites: sites}
+}
+
+func (*WSLMntCCheck) ID() string             { return "wsl-mnt-c" }
+func (*WSLMntCCheck) Cadence() time.Duration { return 30 * time.Minute }
+func (*WSLMntCCheck) Budget() time.Duration  { return time.Second }
+
+func (c *WSLMntCCheck) Run(ctx context.Context) ([]Finding, error) {
+	if c.platformInfo == nil || !c.platformInfo.WSL.Active {
+		return nil, nil
+	}
+	if c.sites == nil {
+		return nil, nil
+	}
+	var out []Finding
+	for _, root := range c.sites.Roots(ctx) {
+		if !platform.IsMntC(root) {
+			continue
+		}
+		out = append(out, Finding{
+			ID:          c.ID(),
+			DedupKey:    root,
+			Severity:    SeverityWarn,
+			Title:       "Site stored on slow Windows-mounted drive",
+			Detail:      "The site at " + root + " lives under /mnt/c (DrvFS), which is much slower than native WSL ext4.",
+			Remediation: "Move the site to a path under /home/<user>/ for native filesystem speed.",
+			HelpURL:     "https://docs.locorum.dev/wsl-performance",
+		})
+	}
+	return out, nil
+}
+
+// WindowsLongPathCheck warns when any registered site root would breach
+// Windows' MAX_PATH limit once WordPress's deepest plugin path is appended.
+type WindowsLongPathCheck struct {
+	platformInfo *platform.Info
+	sites        SiteRootLister
+}
+
+// NewWindowsLongPathCheck builds the check.
+func NewWindowsLongPathCheck(info *platform.Info, sites SiteRootLister) *WindowsLongPathCheck {
+	return &WindowsLongPathCheck{platformInfo: info, sites: sites}
+}
+
+func (*WindowsLongPathCheck) ID() string             { return "windows-longpath" }
+func (*WindowsLongPathCheck) Cadence() time.Duration { return 30 * time.Minute }
+func (*WindowsLongPathCheck) Budget() time.Duration  { return time.Second }
+
+func (c *WindowsLongPathCheck) Run(ctx context.Context) ([]Finding, error) {
+	if c.platformInfo == nil || c.platformInfo.OS != "windows" {
+		return nil, nil
+	}
+	if c.sites == nil {
+		return nil, nil
+	}
+	var out []Finding
+	for _, root := range c.sites.Roots(ctx) {
+		if !platform.IsLongPath(root) {
+			continue
+		}
+		out = append(out, Finding{
+			ID:       c.ID(),
+			DedupKey: root,
+			Severity: SeverityWarn,
+			Title:    "Path may exceed Windows 260-character limit",
+			Detail: "The site at " + root + " is long enough that some WordPress plugin assets " +
+				"may exceed Windows MAX_PATH.",
+			Remediation: "Move the site under a shorter path, or enable LongPathsEnabled in the registry.",
+			HelpURL:     "https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation",
+		})
+	}
+	return out, nil
+}

--- a/internal/health/checks_port.go
+++ b/internal/health/checks_port.go
@@ -1,0 +1,64 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/docker"
+)
+
+// PortConflictCheck warns when 80 or 443 is held by a process that isn't
+// our router. The flow is described in CROSS-PLATFORM.md note v2 #1:
+//
+//  1. dial 127.0.0.1:port. No listener → no finding.
+//  2. listener present. Ask docker engine whether
+//     locorum-global-router is running. If yes, the port is ours by
+//     design — no finding. If no, somebody else holds it; emit a warning.
+//
+// Cheap (one TCP SYN + one container-list lookup) and never binds the port.
+type PortConflictCheck struct {
+	engine    docker.Engine
+	port      int
+	routerCN  string // container name to attribute the bind to (locorum-global-router)
+	humanPort string // for finding text ("80", "443")
+}
+
+// NewPortConflictCheck constructs a check for a single port. The router's
+// container name is a parameter so the health package doesn't depend on
+// internal/router/traefik (which would drag genmark + tls + docker spec
+// templating into our import graph). The Bundled() factory passes
+// traefik.ContainerName.
+func NewPortConflictCheck(engine docker.Engine, port int, routerContainerName string) *PortConflictCheck {
+	return &PortConflictCheck{
+		engine:    engine,
+		port:      port,
+		routerCN:  routerContainerName,
+		humanPort: fmt.Sprintf("%d", port),
+	}
+}
+
+func (c *PortConflictCheck) ID() string           { return "port-conflict-" + c.humanPort }
+func (*PortConflictCheck) Cadence() time.Duration { return 5 * time.Minute }
+func (*PortConflictCheck) Budget() time.Duration  { return time.Second }
+
+func (c *PortConflictCheck) Run(ctx context.Context) ([]Finding, error) {
+	if !portInUse(ctx, c.port) {
+		return nil, nil
+	}
+	// Listener present. Is it our router?
+	running, err := c.engine.ContainerIsRunning(ctx, c.routerCN)
+	if err == nil && running {
+		// Locorum's own bind. Nothing to warn about.
+		return nil, nil
+	}
+	return []Finding{{
+		ID:       c.ID(),
+		Severity: SeverityWarn,
+		Title:    "Port " + c.humanPort + " is held by another process",
+		Detail: "Another process is listening on 127.0.0.1:" + c.humanPort +
+			". Locorum's router cannot bind it; sites may be unreachable.",
+		Remediation: "Stop the conflicting service (`lsof -iTCP:" + c.humanPort + "` lists candidates), then re-check.",
+		HelpURL:     "https://docs.locorum.dev/troubleshooting/ports",
+	}}, nil
+}

--- a/internal/health/checks_rosetta.go
+++ b/internal/health/checks_rosetta.go
@@ -1,0 +1,46 @@
+package health
+
+import (
+	"context"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/platform"
+)
+
+// RosettaCheck reports a Blocker if a macOS amd64 binary is being executed
+// under Rosetta on an arm64 host. Mostly redundant with the preflight
+// hard-fail (preflight_darwin.go) — the preflight runs **before** Gio
+// loads, so this UI-side check covers cases the preflight skipped (e.g.
+// `osascript` failed; we kept running with stderr only) and gives the
+// settings panel a stable "yes you should fix this" row.
+type RosettaCheck struct {
+	platformInfo *platform.Info
+}
+
+// NewRosettaCheck constructs a check using the given platform info. Pass
+// platform.Get() in production; tests inject a synthetic Info.
+func NewRosettaCheck(info *platform.Info) *RosettaCheck {
+	return &RosettaCheck{platformInfo: info}
+}
+
+func (*RosettaCheck) ID() string             { return "rosetta" }
+func (*RosettaCheck) Cadence() time.Duration { return 0 } // runner default
+func (*RosettaCheck) Budget() time.Duration  { return time.Second }
+
+func (c *RosettaCheck) Run(_ context.Context) ([]Finding, error) {
+	if c.platformInfo == nil {
+		return nil, nil
+	}
+	if !c.platformInfo.UnderRosetta {
+		return nil, nil
+	}
+	return []Finding{{
+		ID:       c.ID(),
+		Severity: SeverityBlocker,
+		Title:    "Running under Rosetta translation",
+		Detail: "This is the amd64 build of Locorum running on an Apple Silicon (arm64) Mac via Rosetta. " +
+			"Docker volume performance and container compatibility will be unreliable.",
+		Remediation: "Quit Locorum and reinstall the arm64 build for native performance.",
+		HelpURL:     "https://docs.locorum.dev/install/macos",
+	}}, nil
+}

--- a/internal/health/checks_test.go
+++ b/internal/health/checks_test.go
@@ -1,0 +1,223 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/docker/fake"
+	"github.com/PeterBooker/locorum/internal/platform"
+	"github.com/PeterBooker/locorum/internal/version"
+)
+
+func TestRosettaCheckFiresOnAmd64UnderRosetta(t *testing.T) {
+	info := &platform.Info{OS: "darwin", Arch: "amd64", UnderRosetta: true}
+	c := NewRosettaCheck(info)
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(out))
+	}
+	if out[0].Severity != SeverityBlocker {
+		t.Errorf("expected blocker, got %v", out[0].Severity)
+	}
+}
+
+func TestRosettaCheckSilentOnArm64Native(t *testing.T) {
+	info := &platform.Info{OS: "darwin", Arch: "arm64", UnderRosetta: false}
+	c := NewRosettaCheck(info)
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected no findings, got %v", out)
+	}
+}
+
+func TestDockerDownCheckRequiresTwoFailures(t *testing.T) {
+	e := fake.New()
+	e.SetPingErr(errors.New("connection refused"))
+	c := NewDockerDownCheck(e)
+
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("first run err: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("first failure should be silent, got %d findings", len(out))
+	}
+
+	out, err = c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("second run err: %v", err)
+	}
+	if len(out) != 1 || out[0].Severity != SeverityBlocker {
+		t.Errorf("second failure should produce a blocker; got %+v", out)
+	}
+
+	// Recovery resets the counter.
+	e.SetPingErr(nil)
+	out, _ = c.Run(context.Background())
+	if len(out) != 0 {
+		t.Errorf("after recovery, should be silent; got %d", len(out))
+	}
+}
+
+func TestDockerOldCheck(t *testing.T) {
+	e := fake.New()
+	e.SetProvider(docker.ProviderInfo{
+		ServerVersion:  "20.10.21",
+		ServerVersionP: version.ParseDockerServer("20.10.21"),
+	})
+	c := NewDockerOldCheck(e)
+
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(out) != 1 || out[0].ID != "docker-old" {
+		t.Errorf("expected one docker-old finding for 20.10.21; got %+v", out)
+	}
+
+	// Newer version → no finding.
+	e.SetProvider(docker.ProviderInfo{
+		ServerVersion:  "26.0.0",
+		ServerVersionP: version.ParseDockerServer("26.0.0"),
+	})
+	out, _ = c.Run(context.Background())
+	if len(out) != 0 {
+		t.Errorf("expected no findings for newer; got %+v", out)
+	}
+}
+
+func TestProviderVirtioFSCheckOnlyFiresOnDarwinDockerDesktop(t *testing.T) {
+	cases := []struct {
+		name           string
+		os             string
+		dockerDesktop  bool
+		expectFindings bool
+	}{
+		{"darwin docker desktop", "darwin", true, true},
+		{"darwin orbstack", "darwin", false, false},
+		{"linux docker desktop is impossible", "linux", true, false},
+		{"linux native", "linux", false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := fake.New()
+			e.SetProvider(docker.ProviderInfo{IsDockerDesktop: c.dockerDesktop})
+			check := NewProviderVirtioFSCheck(e, c.os)
+			out, _ := check.Run(context.Background())
+			if (len(out) > 0) != c.expectFindings {
+				t.Errorf("got %d findings, expectFindings=%v", len(out), c.expectFindings)
+			}
+		})
+	}
+}
+
+func TestPortConflictCheckOurRouter(t *testing.T) {
+	// Spin up a local listener — that's our "port in use".
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	e := fake.New()
+	// Pretend our router is running. This means the bind is "ours".
+	_, _ = e.EnsureContainer(context.Background(), docker.ContainerSpec{
+		Name:   "locorum-global-router",
+		Image:  "fake",
+		Labels: map[string]string{"x": "y"},
+	})
+	_ = e.StartContainer(context.Background(), "locorum-global-router")
+
+	c := NewPortConflictCheck(e, port, "locorum-global-router")
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected no finding when router is ours; got %+v", out)
+	}
+}
+
+func TestPortConflictCheckForeignBind(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	e := fake.New() // no router container
+
+	c := NewPortConflictCheck(e, port, "locorum-global-router")
+	out, _ := c.Run(context.Background())
+	if len(out) != 1 {
+		t.Fatalf("expected 1 conflict warning; got %d", len(out))
+	}
+	if out[0].Severity != SeverityWarn {
+		t.Errorf("expected warn; got %v", out[0].Severity)
+	}
+	if out[0].ID != "port-conflict-"+strconv.Itoa(port) {
+		t.Errorf("ID mismatch: %q", out[0].ID)
+	}
+}
+
+func TestPortConflictCheckNoListener(t *testing.T) {
+	// Pick a high port nothing is on by listening then closing.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	e := fake.New()
+	c := NewPortConflictCheck(e, port, "locorum-global-router")
+	out, _ := c.Run(context.Background())
+	if len(out) != 0 {
+		t.Errorf("expected no finding when nothing listens; got %+v", out)
+	}
+}
+
+// fakeRoots satisfies SiteRootLister.
+type fakeRoots struct{ list []string }
+
+func (f *fakeRoots) Roots(_ context.Context) []string { return f.list }
+
+func TestWSLMntCCheck(t *testing.T) {
+	wsl := &platform.Info{OS: "linux", WSL: platform.WSLInfo{Active: true}}
+	restore := platform.NewForTest(wsl)
+	defer restore()
+
+	c := NewWSLMntCCheck(wsl, &fakeRoots{list: []string{
+		"/mnt/c/Users/foo/sites/a",
+		"/home/foo/sites/b",
+		"/mnt/d/projects/c",
+	}})
+	out, _ := c.Run(context.Background())
+	if len(out) != 2 {
+		t.Errorf("expected 2 mnt-c findings, got %d", len(out))
+	}
+}
+
+func TestWSLMntCCheckSilentOutsideWSL(t *testing.T) {
+	notWSL := &platform.Info{OS: "linux", WSL: platform.WSLInfo{Active: false}}
+	restore := platform.NewForTest(notWSL)
+	defer restore()
+
+	c := NewWSLMntCCheck(notWSL, &fakeRoots{list: []string{"/mnt/c/x"}})
+	out, _ := c.Run(context.Background())
+	if len(out) != 0 {
+		t.Errorf("expected no findings when not in WSL; got %+v", out)
+	}
+}

--- a/internal/health/portprobe.go
+++ b/internal/health/portprobe.go
@@ -1,0 +1,35 @@
+package health
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"time"
+)
+
+// portProbeTimeout caps the dial step. We don't want a flaky network
+// stack to hold a health-check goroutine for seconds; a busy port
+// answers in well under 50ms locally, and a dead probe should fail fast.
+const portProbeTimeout = 200 * time.Millisecond
+
+// portInUse reports whether *something* is listening on 127.0.0.1:port.
+// It does NOT bind the port — there is no TOCTOU window. A successful
+// dial means a listener accepted the SYN and responded with SYN-ACK.
+//
+// We deliberately accept any TCP listener, not just HTTP. The caller
+// (the port-conflict check) decides whether the listener is *ours* via
+// a separate signal (engine.ContainerIsRunning) — see CROSS-PLATFORM.md
+// note v2 #1.
+func portInUse(ctx context.Context, port int) bool {
+	if port <= 0 || port > 65535 {
+		return false
+	}
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	d := net.Dialer{Timeout: portProbeTimeout}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/internal/health/runner.go
+++ b/internal/health/runner.go
@@ -1,0 +1,467 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// MetricsSink is the optional observability hook. Default is the no-op
+// sink; a future telemetry subsystem plugs in a real implementation.
+type MetricsSink interface {
+	ObserveCheck(id string, dur time.Duration, findings int, err error)
+	ObserveAction(id string, dur time.Duration, err error)
+}
+
+// noopMetrics is the default sink — does nothing. Avoids nil-checks at
+// every call site.
+type noopMetrics struct{}
+
+func (noopMetrics) ObserveCheck(string, time.Duration, int, error) {}
+func (noopMetrics) ObserveAction(string, time.Duration, error)     {}
+
+// Default tuning. Documented in CROSS-PLATFORM.md § Performance budgets.
+const (
+	defaultMinCadence  = 5 * time.Minute
+	defaultBudget      = 5 * time.Second
+	defaultSemSize     = 8
+	defaultActionPool  = 4
+	suspendBudgetTrips = 3
+)
+
+// Options is the runner constructor parameters. All fields have sensible
+// zero-value defaults so the simplest call site is `health.NewRunner(health.Options{}, checks...)`.
+type Options struct {
+	// MinCadence is the minimum interval between check runs. Each check
+	// runs at max(check.Cadence(), MinCadence). Default 5m.
+	MinCadence time.Duration
+
+	// MaxConcurrentChecks bounds the number of checks running at once.
+	// Default 8.
+	MaxConcurrentChecks int
+
+	// MaxConcurrentActions bounds the number of [Action.Run] calls in
+	// flight. Default 4.
+	MaxConcurrentActions int
+
+	// Logger is the slog logger. Default slog.Default(); typically
+	// callers pass slog.With("subsys", "health").
+	Logger *slog.Logger
+
+	// Metrics is the observability sink. Default no-op.
+	Metrics MetricsSink
+
+	// Now overrides time.Now for tests.
+	Now func() time.Time
+}
+
+// runnerState is the dedup + suspension book-keeping. Guarded by
+// runnerState.mu. Keeping it separate from Runner means the read path
+// (Snapshot()) needs no lock — atomic.Pointer is enough.
+type runnerState struct {
+	mu sync.Mutex
+
+	// Per-finding key (id|severity|dedupKey) → first-seen wall clock.
+	// Drives the "noticed 3m ago" rendering.
+	firstSeen map[string]time.Time
+
+	// Per-check budget-breach counter. Decrements on a successful run
+	// (within budget); reaching suspendBudgetTrips suspends the check
+	// for one cycle.
+	budgetTrips map[string]int
+
+	// Per-check next-allowed-run time. Drives suspension-cooldown.
+	nextRunAt map[string]time.Time
+}
+
+// Runner schedules Checks and publishes the aggregated Snapshot. Construct
+// once via [NewRunner], call [Runner.Start] to begin the periodic loop, and
+// [Runner.Close] at shutdown.
+type Runner struct {
+	opts    Options
+	checks  []Check
+	sem     chan struct{}
+	actions *actionExecutor
+	snap    atomic.Pointer[Snapshot]
+	state   *runnerState
+
+	subscribersMu sync.Mutex
+	subscribers   []func(Snapshot)
+
+	closeOnce sync.Once
+	cancel    context.CancelFunc
+	doneCh    chan struct{}
+}
+
+// NewRunner constructs a runner with the given checks. The returned runner
+// has not yet started ticking — call [Runner.Start] when the caller is
+// ready to begin scheduling.
+func NewRunner(opts Options, checks ...Check) *Runner {
+	if opts.MinCadence <= 0 {
+		opts.MinCadence = defaultMinCadence
+	}
+	if opts.MaxConcurrentChecks <= 0 {
+		opts.MaxConcurrentChecks = defaultSemSize
+	}
+	if opts.MaxConcurrentActions <= 0 {
+		opts.MaxConcurrentActions = defaultActionPool
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	if opts.Metrics == nil {
+		opts.Metrics = noopMetrics{}
+	}
+
+	r := &Runner{
+		opts:   opts,
+		checks: append([]Check(nil), checks...),
+		sem:    make(chan struct{}, opts.MaxConcurrentChecks),
+		state: &runnerState{
+			firstSeen:   map[string]time.Time{},
+			budgetTrips: map[string]int{},
+			nextRunAt:   map[string]time.Time{},
+		},
+		doneCh: make(chan struct{}),
+	}
+	r.actions = newActionExecutor(opts.MaxConcurrentActions, opts.Logger, opts.Metrics)
+	// Publish an empty snapshot so reads before the first batch don't
+	// see a nil pointer.
+	r.snap.Store(&Snapshot{})
+	return r
+}
+
+// Start kicks off the periodic loop. The loop runs until ctx is cancelled
+// or [Runner.Close] is called. Subsequent calls are no-ops.
+//
+// One initial RunNow fires immediately; subsequent runs follow the cadence.
+// This means the UI gets a populated snapshot within seconds of startup,
+// not after waiting for the first 5-minute tick.
+func (r *Runner) Start(ctx context.Context) {
+	if r.cancel != nil {
+		return
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	go r.loop(loopCtx)
+}
+
+// loop is the runner's heartbeat. Cadence is opts.MinCadence; per-check
+// next-run-at is checked at every tick so checks with longer cadences
+// silently skip until their slot.
+func (r *Runner) loop(ctx context.Context) {
+	defer close(r.doneCh)
+
+	// Fire one immediate batch; users opening the app shouldn't wait
+	// 5 minutes to see "Docker is down".
+	r.runBatch(ctx)
+
+	t := time.NewTicker(r.opts.MinCadence)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.runBatch(ctx)
+		}
+	}
+}
+
+// RunNow forces a fresh batch and returns the resulting snapshot. Used by
+// the "Re-check" button in the UI. Safe to call at any time; multiple
+// concurrent callers each see the latest published snapshot but only one
+// batch runs at a time (we serialise via the sem semaphore — a check
+// already running is awaited rather than started twice).
+func (r *Runner) RunNow(ctx context.Context) Snapshot {
+	r.runBatch(ctx)
+	return *r.snap.Load()
+}
+
+// Snapshot returns the most recently published snapshot. Lock-free —
+// dereferences an atomic.Pointer.
+func (r *Runner) Snapshot() Snapshot {
+	return *r.snap.Load()
+}
+
+// DiskFreeBytes returns the most recent host-filesystem free-bytes
+// reading from the disk-low check, or 0 if no DiskLowCheck is registered
+// or it has not produced a reading yet. Used by the UI status-bar
+// segment so it doesn't have to maintain its own polling cadence.
+func (r *Runner) DiskFreeBytes() int64 {
+	for _, c := range r.checks {
+		if dl, ok := c.(*DiskLowCheck); ok {
+			free, _ := dl.LastSnapshot()
+			return free
+		}
+	}
+	return 0
+}
+
+// Subscribe registers a callback that fires after each snapshot
+// publication. The callback runs on the runner goroutine; it should be
+// non-blocking (typical body: copy the snapshot into UI state and call
+// window.Invalidate()).
+//
+// Returned closure detaches the subscription.
+func (r *Runner) Subscribe(fn func(Snapshot)) (unsubscribe func()) {
+	r.subscribersMu.Lock()
+	r.subscribers = append(r.subscribers, fn)
+	idx := len(r.subscribers) - 1
+	r.subscribersMu.Unlock()
+
+	return func() {
+		r.subscribersMu.Lock()
+		defer r.subscribersMu.Unlock()
+		if idx >= len(r.subscribers) {
+			return
+		}
+		r.subscribers[idx] = nil
+	}
+}
+
+// Close stops the loop, drains the action executor, and unblocks any
+// sleeping Start. Idempotent.
+func (r *Runner) Close() error {
+	r.closeOnce.Do(func() {
+		if r.cancel != nil {
+			r.cancel()
+			<-r.doneCh
+		}
+		r.actions.close()
+	})
+	return nil
+}
+
+// SubmitAction enqueues a Finding's Action.Run for execution. Returns
+// ErrAlreadyRunning if the same finding ID is already in flight. The done
+// callback fires on the executor goroutine — UI must Invalidate and not
+// block.
+func (r *Runner) SubmitAction(ctx context.Context, id string, a Action, done func(error)) error {
+	return r.actions.submit(ctx, id, a, done)
+}
+
+// runBatch is the meat of the runner: schedule checks, collect findings,
+// dedup, sort, publish.
+func (r *Runner) runBatch(ctx context.Context) {
+	// Mark "running"; UI disables Re-check.
+	r.publishRunning(true)
+	defer r.publishRunning(false)
+
+	now := r.now()
+	type result struct {
+		check Check
+		out   []Finding
+		err   error
+		dur   time.Duration
+		over  bool
+	}
+	resultsCh := make(chan result, len(r.checks))
+
+	var wg sync.WaitGroup
+	for _, c := range r.checks {
+		c := c
+		// Suspension: skip this check if its next-run-at is in the future.
+		if r.suspendedUntil(c.ID()).After(now) {
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Bound concurrency. ctx is the loop ctx — cancellation
+			// propagates correctly.
+			select {
+			case r.sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-r.sem }()
+
+			budget := c.Budget()
+			if budget <= 0 {
+				budget = defaultBudget
+			}
+			cctx, cancel := context.WithTimeout(ctx, budget)
+			start := r.now()
+			out, err := r.safeRun(cctx, c)
+			cancel()
+			dur := r.now().Sub(start)
+			over := errors.Is(err, context.DeadlineExceeded) || dur > budget
+
+			resultsCh <- result{check: c, out: out, err: err, dur: dur, over: over}
+		}()
+	}
+	wg.Wait()
+	close(resultsCh)
+
+	// Collate results. Errors get translated into a `check-failed:<id>`
+	// warn finding so the user sees something is wrong even on internal
+	// failures.
+	var collected []Finding
+	for res := range resultsCh {
+		r.opts.Metrics.ObserveCheck(res.check.ID(), res.dur, len(res.out), res.err)
+		r.recordBudget(res.check.ID(), res.over)
+
+		if res.err != nil {
+			r.opts.Logger.Error("health: check failed",
+				"check", res.check.ID(),
+				"duration_ms", res.dur.Milliseconds(),
+				"err", res.err.Error(),
+			)
+			collected = append(collected, Finding{
+				ID:          "check-failed",
+				DedupKey:    res.check.ID(),
+				Severity:    SeverityWarn,
+				Title:       fmt.Sprintf("Health check %q failed", res.check.ID()),
+				Detail:      res.err.Error(),
+				Remediation: "Check the application logs and re-run.",
+			})
+			continue
+		}
+		for _, f := range res.out {
+			if res.over {
+				f.Stale = true
+			}
+			collected = append(collected, f)
+		}
+		r.opts.Logger.Debug("health: check ok",
+			"check", res.check.ID(),
+			"duration_ms", res.dur.Milliseconds(),
+			"findings", len(res.out),
+		)
+	}
+
+	r.publish(collected)
+}
+
+// safeRun runs a single check, catching panics so a misbehaving check
+// can't take down the runner goroutine.
+func (r *Runner) safeRun(ctx context.Context, c Check) (out []Finding, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = fmt.Errorf("panic: %v", rec)
+		}
+	}()
+	return c.Run(ctx)
+}
+
+// recordBudget tracks consecutive over-budget runs per check. After
+// suspendBudgetTrips breaches we suspend the check for one MinCadence cycle.
+func (r *Runner) recordBudget(id string, overBudget bool) {
+	r.state.mu.Lock()
+	defer r.state.mu.Unlock()
+	if !overBudget {
+		delete(r.state.budgetTrips, id)
+		return
+	}
+	r.state.budgetTrips[id]++
+	if r.state.budgetTrips[id] >= suspendBudgetTrips {
+		r.state.nextRunAt[id] = r.now().Add(r.opts.MinCadence)
+		r.opts.Logger.Warn("health: check suspended for over-budget breaches",
+			"check", id,
+			"cycles", r.state.budgetTrips[id],
+		)
+		// Reset the counter so we re-evaluate after the cooldown.
+		r.state.budgetTrips[id] = 0
+	}
+}
+
+func (r *Runner) suspendedUntil(id string) time.Time {
+	r.state.mu.Lock()
+	defer r.state.mu.Unlock()
+	return r.state.nextRunAt[id]
+}
+
+// publishRunning toggles the Running flag without rebuilding the rest of
+// the snapshot. Used by runBatch to bracket "I am working" and "I am idle".
+func (r *Runner) publishRunning(running bool) {
+	prev := r.snap.Load()
+	cp := *prev
+	cp.Running = running
+	r.snap.Store(&cp)
+	r.notifySubscribers(cp)
+}
+
+// publish builds the new snapshot from collected findings + state and
+// stores it, increments Generation, fires subscribers.
+func (r *Runner) publish(collected []Finding) {
+	r.state.mu.Lock()
+
+	// Dedup against firstSeen. Build a fresh map of "still present" keys
+	// so we can drop stale firstSeen entries (otherwise it grows
+	// monotonically over a long-running session).
+	stillPresent := make(map[string]struct{}, len(collected))
+	now := r.now()
+	for i := range collected {
+		f := &collected[i]
+		key := findingKey(*f)
+		stillPresent[key] = struct{}{}
+		if first, ok := r.state.firstSeen[key]; ok {
+			f.Detected = first
+		} else {
+			f.Detected = now
+			r.state.firstSeen[key] = now
+		}
+	}
+	for key := range r.state.firstSeen {
+		if _, ok := stillPresent[key]; !ok {
+			delete(r.state.firstSeen, key)
+		}
+	}
+
+	r.state.mu.Unlock()
+
+	// Sort: blocker before warn before info; then ID asc; then DedupKey asc.
+	sort.SliceStable(collected, func(i, j int) bool {
+		a, b := collected[i], collected[j]
+		if a.Severity != b.Severity {
+			return a.Severity > b.Severity
+		}
+		if a.ID != b.ID {
+			return a.ID < b.ID
+		}
+		return a.DedupKey < b.DedupKey
+	})
+
+	prev := r.snap.Load()
+	next := Snapshot{
+		Findings:   collected,
+		LastRun:    now,
+		Running:    false,
+		Generation: prev.Generation + 1,
+	}
+	r.snap.Store(&next)
+	r.notifySubscribers(next)
+}
+
+func (r *Runner) notifySubscribers(s Snapshot) {
+	r.subscribersMu.Lock()
+	subs := make([]func(Snapshot), len(r.subscribers))
+	copy(subs, r.subscribers)
+	r.subscribersMu.Unlock()
+	for _, fn := range subs {
+		if fn == nil {
+			continue
+		}
+		fn(s)
+	}
+}
+
+func (r *Runner) now() time.Time {
+	if r.opts.Now != nil {
+		return r.opts.Now()
+	}
+	return time.Now()
+}
+
+// findingKey is the dedup key used by firstSeen. Two findings sharing an
+// (ID, Severity, DedupKey) triple are the "same observation".
+func findingKey(f Finding) string {
+	// Use a separator unlikely to appear in IDs (which are slug-shaped).
+	return f.ID + "|" + f.Severity.String() + "|" + f.DedupKey
+}

--- a/internal/health/runner_test.go
+++ b/internal/health/runner_test.go
@@ -1,0 +1,282 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeCheck is the minimal Check used by runner tests.
+type fakeCheck struct {
+	id      string
+	cadence time.Duration
+	budget  time.Duration
+	runs    atomic.Int32
+	output  []Finding
+	err     error
+	delay   time.Duration
+}
+
+func (c *fakeCheck) ID() string             { return c.id }
+func (c *fakeCheck) Cadence() time.Duration { return c.cadence }
+func (c *fakeCheck) Budget() time.Duration  { return c.budget }
+func (c *fakeCheck) Run(ctx context.Context) ([]Finding, error) {
+	c.runs.Add(1)
+	if c.delay > 0 {
+		select {
+		case <-time.After(c.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return c.output, c.err
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestRunnerRunNowProducesSnapshot(t *testing.T) {
+	c := &fakeCheck{id: "ok", budget: time.Second, output: []Finding{
+		{ID: "ok", Severity: SeverityInfo, Title: "Hello"},
+	}}
+	r := NewRunner(Options{Logger: quietLogger()}, c)
+	defer r.Close()
+
+	snap := r.RunNow(context.Background())
+	if got := len(snap.Findings); got != 1 {
+		t.Fatalf("expected 1 finding, got %d", got)
+	}
+	if snap.Findings[0].Detected.IsZero() {
+		t.Error("Detected must be populated by the runner")
+	}
+	if snap.Generation == 0 {
+		t.Error("Generation must increment on publish")
+	}
+}
+
+func TestRunnerSortsBySeverity(t *testing.T) {
+	c := &fakeCheck{id: "x", budget: time.Second, output: []Finding{
+		{ID: "warn-a", Severity: SeverityWarn, Title: "warn a"},
+		{ID: "block-z", Severity: SeverityBlocker, Title: "block z"},
+		{ID: "info-m", Severity: SeverityInfo, Title: "info m"},
+	}}
+	r := NewRunner(Options{Logger: quietLogger()}, c)
+	defer r.Close()
+
+	snap := r.RunNow(context.Background())
+	want := []string{"block-z", "warn-a", "info-m"}
+	if len(snap.Findings) != len(want) {
+		t.Fatalf("len mismatch: %d vs %d", len(snap.Findings), len(want))
+	}
+	for i, w := range want {
+		if snap.Findings[i].ID != w {
+			t.Errorf("position %d: got %q want %q", i, snap.Findings[i].ID, w)
+		}
+	}
+}
+
+func TestRunnerPreservesDetectedAcrossRuns(t *testing.T) {
+	first := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	calls := atomic.Int32{}
+	now := func() time.Time {
+		// Run 1 returns first; run 2 returns first+1m. The runner
+		// must NOT re-mint Detected on run 2 because the (ID, Severity,
+		// DedupKey) key is unchanged.
+		if calls.Load() < 1 {
+			return first
+		}
+		return first.Add(time.Minute)
+	}
+	c := &fakeCheck{id: "x", budget: time.Second, output: []Finding{
+		{ID: "stable", Severity: SeverityWarn, Title: "stable"},
+	}}
+	r := NewRunner(Options{Logger: quietLogger(), Now: now}, c)
+	defer r.Close()
+
+	r.RunNow(context.Background())
+	calls.Store(2)
+	snap := r.RunNow(context.Background())
+
+	if got := snap.Findings[0].Detected; !got.Equal(first) {
+		t.Errorf("Detected should be preserved at %v; got %v", first, got)
+	}
+}
+
+func TestRunnerDedupKeyDistinguishesFindings(t *testing.T) {
+	c := &fakeCheck{id: "x", budget: time.Second, output: []Finding{
+		{ID: "wsl-mnt-c", Severity: SeverityWarn, DedupKey: "/mnt/c/a"},
+		{ID: "wsl-mnt-c", Severity: SeverityWarn, DedupKey: "/mnt/c/b"},
+	}}
+	r := NewRunner(Options{Logger: quietLogger()}, c)
+	defer r.Close()
+
+	snap := r.RunNow(context.Background())
+	if len(snap.Findings) != 2 {
+		t.Fatalf("expected 2 distinct findings via DedupKey, got %d", len(snap.Findings))
+	}
+}
+
+func TestRunnerCheckFailedWrapsErrors(t *testing.T) {
+	c := &fakeCheck{id: "boom", budget: time.Second, err: errors.New("kaboom")}
+	r := NewRunner(Options{Logger: quietLogger()}, c)
+	defer r.Close()
+
+	snap := r.RunNow(context.Background())
+	if len(snap.Findings) != 1 {
+		t.Fatalf("expected 1 wrapper finding, got %d", len(snap.Findings))
+	}
+	f := snap.Findings[0]
+	if f.ID != "check-failed" {
+		t.Errorf("expected ID=check-failed, got %q", f.ID)
+	}
+	if f.DedupKey != "boom" {
+		t.Errorf("expected DedupKey=boom, got %q", f.DedupKey)
+	}
+}
+
+func TestRunnerOverBudgetMarksStale(t *testing.T) {
+	c := &fakeCheck{
+		id: "slow", budget: 50 * time.Millisecond, delay: 200 * time.Millisecond,
+		output: []Finding{{ID: "slow", Severity: SeverityWarn, Title: "slow"}},
+	}
+	r := NewRunner(Options{Logger: quietLogger()}, c)
+	defer r.Close()
+
+	snap := r.RunNow(context.Background())
+	// The check returns ctx.Err on timeout — so the wrapper finding is
+	// what we see. Stale on findings makes sense when the check returns
+	// findings *and* takes too long; for context.DeadlineExceeded the
+	// runner emits the check-failed envelope.
+	if len(snap.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(snap.Findings))
+	}
+	if snap.Findings[0].ID != "check-failed" {
+		t.Errorf("expected check-failed envelope from over-budget check; got %q", snap.Findings[0].ID)
+	}
+}
+
+func TestRunnerSubscribeFiresOnPublish(t *testing.T) {
+	c := &fakeCheck{id: "x", budget: time.Second}
+	r := NewRunner(Options{Logger: quietLogger()}, c)
+	defer r.Close()
+
+	var mu sync.Mutex
+	var received []uint64
+	unsubscribe := r.Subscribe(func(s Snapshot) {
+		mu.Lock()
+		received = append(received, s.Generation)
+		mu.Unlock()
+	})
+	defer unsubscribe()
+
+	r.RunNow(context.Background())
+	r.RunNow(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Each RunNow emits two snapshots: Running=true then Running=false.
+	if len(received) < 2 {
+		t.Errorf("expected ≥2 subscriber callbacks, got %d", len(received))
+	}
+}
+
+func TestActionExecutorReentrancyGuard(t *testing.T) {
+	r := NewRunner(Options{Logger: quietLogger()})
+	defer r.Close()
+
+	started := make(chan struct{})
+	finish := make(chan struct{})
+	a := Action{
+		Run: func(ctx context.Context) error {
+			close(started)
+			<-finish
+			return nil
+		},
+		Timeout: time.Second,
+	}
+
+	if err := r.SubmitAction(context.Background(), "x", a, nil); err != nil {
+		t.Fatalf("first submit failed: %v", err)
+	}
+	<-started
+
+	// While in flight, second submit must error with ErrAlreadyRunning.
+	a2 := Action{Run: func(ctx context.Context) error { return nil }}
+	if err := r.SubmitAction(context.Background(), "x", a2, nil); !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("expected ErrAlreadyRunning, got %v", err)
+	}
+
+	close(finish)
+}
+
+func TestRunnerCloseIdempotent(t *testing.T) {
+	r := NewRunner(Options{Logger: quietLogger()})
+	if err := r.Close(); err != nil {
+		t.Errorf("first close: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Errorf("second close: %v", err)
+	}
+}
+
+func TestSnapshotHelpers(t *testing.T) {
+	s := &Snapshot{Findings: []Finding{
+		{ID: "a", Severity: SeverityWarn},
+		{ID: "b", Severity: SeverityInfo},
+		{ID: "c", Severity: SeverityWarn},
+	}}
+	if !s.Has("a") {
+		t.Error("Has(a) should be true")
+	}
+	if s.Has("z") {
+		t.Error("Has(z) should be false")
+	}
+	if got := s.HighestSeverity(); got != SeverityWarn {
+		t.Errorf("HighestSeverity = %v, want Warn", got)
+	}
+	if got := s.CountAt(SeverityWarn); got != 2 {
+		t.Errorf("CountAt(Warn) = %d, want 2", got)
+	}
+	if got := s.CountAt(SeverityBlocker); got != 0 {
+		t.Errorf("CountAt(Blocker) = %d, want 0", got)
+	}
+}
+
+func TestBreakerStateMachine(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	b := &Breaker{MaxFailures: 2, Cooldown: time.Hour, Now: clock}
+
+	if b.State() != "closed" {
+		t.Fatalf("initial state = %q, want closed", b.State())
+	}
+	b.OnFailure()
+	if b.State() != "closed" {
+		t.Errorf("after 1 failure: %q, want closed", b.State())
+	}
+	b.OnFailure()
+	if b.State() != "open" {
+		t.Errorf("after 2 failures: %q, want open", b.State())
+	}
+	if b.Allow() {
+		t.Error("Allow should be false when open")
+	}
+	// Advance past cooldown.
+	now = now.Add(2 * time.Hour)
+	if b.State() != "half-open" {
+		t.Errorf("after cooldown: %q, want half-open", b.State())
+	}
+	if !b.Allow() {
+		t.Error("Allow should be true in half-open")
+	}
+	b.OnSuccess()
+	if b.State() != "closed" {
+		t.Errorf("after success in half-open: %q, want closed", b.State())
+	}
+}

--- a/internal/platform/freespace.go
+++ b/internal/platform/freespace.go
@@ -1,0 +1,24 @@
+package platform
+
+// HostFreeBytes returns the bytes available to the *unprivileged* user at
+// path on the host filesystem. Cheap (single syscall) so callers may
+// invoke it on every health-check cadence without performance impact.
+//
+// On Linux/macOS path may be any directory mounted on the relevant
+// filesystem — typically the user's HomeDir or ~/.locorum. On Windows
+// it's the drive letter (e.g. `C:\`); a directory inside that drive
+// works equivalently because GetDiskFreeSpaceEx looks up the parent
+// volume.
+//
+// Implementation lives in the OS-specific files (freespace_unix.go,
+// freespace_windows.go); this declaration is just the contract.
+//
+// Errors propagate verbatim — they are diagnostic only; the caller
+// should fall back to "unknown" rather than aborting.
+//
+// The returned value can briefly exceed the actual filesystem capacity
+// on copy-on-write filesystems (btrfs, zfs) reporting compressed-block
+// estimates. Treat as "approximate, monotonic enough for thresholding".
+func HostFreeBytes(path string) (int64, error) {
+	return hostFreeBytes(path)
+}

--- a/internal/platform/freespace_unix.go
+++ b/internal/platform/freespace_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package platform
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// hostFreeBytes reads the unprivileged-user-available bytes from statfs(2).
+//
+// We use Bavail (blocks available to non-root) rather than Bfree (blocks
+// available to root) so the number lines up with what the user actually
+// experiences when they try to download a 5GB Docker image into the
+// reserved-for-root region.
+func hostFreeBytes(path string) (int64, error) {
+	if path == "" {
+		return 0, fmt.Errorf("hostFreeBytes: empty path")
+	}
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return 0, fmt.Errorf("statfs %q: %w", path, err)
+	}
+	// Bavail × Bsize. Both are unsigned but the result fits in int64 for
+	// any plausible filesystem size on consumer hardware (max int64 is
+	// 9.2 EB).
+	avail := uint64(st.Bavail) * uint64(st.Bsize)
+	if avail > 1<<62 {
+		// Defensive overflow guard; one petabyte+ on a workstation is
+		// implausible but report a sentinel rather than wrap to negative.
+		return 1 << 62, nil
+	}
+	return int64(avail), nil
+}

--- a/internal/platform/freespace_windows.go
+++ b/internal/platform/freespace_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package platform
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// hostFreeBytes calls GetDiskFreeSpaceExW. The "available" return value is
+// the bytes available to the calling user — accounts for per-user disk
+// quotas if any are in effect.
+func hostFreeBytes(path string) (int64, error) {
+	if path == "" {
+		return 0, fmt.Errorf("hostFreeBytes: empty path")
+	}
+	utf16Path, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("convert path: %w", err)
+	}
+	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes uint64
+	if err := windows.GetDiskFreeSpaceEx(utf16Path, &freeBytesAvailable, &totalNumberOfBytes, &totalNumberOfFreeBytes); err != nil {
+		return 0, fmt.Errorf("GetDiskFreeSpaceEx %q: %w", path, err)
+	}
+	if freeBytesAvailable > 1<<62 {
+		return 1 << 62, nil
+	}
+	return int64(freeBytesAvailable), nil
+}

--- a/internal/platform/paths.go
+++ b/internal/platform/paths.go
@@ -1,0 +1,120 @@
+package platform
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// dockerSeparators is the canonical list of separator characters that must
+// be normalised to '/'. We *cannot* delegate to filepath.ToSlash because on
+// Linux that's a no-op for '\\' (Go's per-OS separator constant) — and the
+// whole point of DockerPath is to translate paths regardless of the build
+// host (e.g. a Linux test runner asserting on a Windows-shaped input).
+const dockerSeparators = "\\"
+
+// WPMaxPluginPathSuffix is the deepest path-suffix we expect under a site's
+// FilesDir for a worst-case WordPress install. Used by IsLongPath to decide
+// whether the fully-qualified path will breach Windows' 260-character
+// MAX_PATH limit.
+//
+// Sourced from a scan of the wordpress.org top-100 plugins for the longest
+// asset path; padded with a safety margin so a future wp-mu-plugin or
+// nested block-asset import doesn't trip it. Length 180 = 158 of measured
+// content + 22 of headroom.
+const WPMaxPluginPathSuffix = 180
+
+// WindowsMaxPath is the legacy MAX_PATH constant from <minwindef.h>. Modern
+// Windows + the LongPathsEnabled registry key allows much longer paths, but
+// many tools (and the user's text editor) still respect the historical
+// limit. Detect-and-warn beats letting the user discover the breakage at
+// composer-update time.
+const WindowsMaxPath = 260
+
+// DockerPath returns p in the slash form Docker's bind-mount API accepts on
+// every supported platform. On Linux/macOS it's a no-op (paths are already
+// slash-separated). On Windows native, it converts `C:\Users\foo\bar` →
+// `/host_mnt/c/Users/foo/bar` style — wait, no, Docker's bind API accepts
+// `C:\Users\foo\bar` natively on Windows; what it *won't* accept is mixed
+// forward/back slashes, so we forward-slash everything via filepath.ToSlash.
+//
+// On WSL hosts pointing at a Windows-side Docker daemon, the caller must
+// either:
+//   - use Linux-side paths (everything under /home/<user>/) and rely on
+//     wsl.exe + Docker Desktop's path-translation, OR
+//   - hand-translate `/mnt/c/...` to `C:/...` first (we don't auto-translate
+//     here because the caller knows whether it's talking to a host- or
+//     Linux-side daemon, and we don't want to corrupt a Linux-side bind).
+//
+// In short: this helper guarantees forward-slash only. Anything more
+// platform-specific is the router/spec-builder's call.
+func DockerPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	// First pass via filepath.ToSlash to handle the build host's own
+	// separator (a Windows build's `\\` for paths Go itself produced).
+	// Second pass replaces any *other* backslashes that survived — e.g.
+	// a Windows-shaped input handed to a Linux build.
+	out := filepath.ToSlash(p)
+	if strings.ContainsAny(out, dockerSeparators) {
+		out = strings.ReplaceAll(out, "\\", "/")
+	}
+	return out
+}
+
+// IsLongPath reports whether the *expected* longest descendant of p
+// (`p + "/" + WPMaxPluginPathSuffix-chars-of-suffix`) would breach Windows'
+// MAX_PATH limit.
+//
+// Returns false on non-Windows hosts — Linux/macOS path limits are far
+// higher and IsLongPath would just produce noise. The check is informational;
+// a true result does NOT block site creation, just adds a yellow note.
+func IsLongPath(p string) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	// Use len() on the original path because Windows paths are typically
+	// drawn from a Windows-codepage (Latin-1-ish) charset where bytes ≈
+	// chars. Even if the user has a CJK home directory, we'd over-count
+	// on non-ASCII — which is the safe direction for a "warn if too long"
+	// check.
+	if p == "" {
+		return false
+	}
+	return len(p)+1+WPMaxPluginPathSuffix > WindowsMaxPath
+}
+
+// IsMntC reports whether p is on Windows-host-mounted DrvFS under WSL2
+// (`/mnt/c/...`, `/mnt/d/...`, etc.). Paths there are 10× slower than
+// native ext4 — sites kept here will *work* but feel sluggish.
+//
+// Returns false on non-WSL hosts, since /mnt/c on a native Linux box is
+// just a regular directory.
+func IsMntC(p string) bool {
+	if !Get().WSL.Active {
+		return false
+	}
+	return isMntDrvFsPath(p)
+}
+
+// isMntDrvFsPath is the path-matching half of IsMntC, factored out so tests
+// don't depend on the package-level WSL state.
+func isMntDrvFsPath(p string) bool {
+	clean := filepath.ToSlash(strings.ToLower(p))
+	if !strings.HasPrefix(clean, "/mnt/") {
+		return false
+	}
+	rest := clean[len("/mnt/"):]
+	// Must have at least a single drive-letter segment: /mnt/c, /mnt/c/...
+	if rest == "" {
+		return false
+	}
+	// First segment is the drive letter. Strict: a single ascii letter.
+	end := strings.IndexByte(rest, '/')
+	letter := rest
+	if end >= 0 {
+		letter = rest[:end]
+	}
+	return len(letter) == 1 && letter[0] >= 'a' && letter[0] <= 'z'
+}

--- a/internal/platform/paths_test.go
+++ b/internal/platform/paths_test.go
@@ -1,0 +1,96 @@
+package platform
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDockerPathSlashesAreNormalised(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"/home/peter/locorum", "/home/peter/locorum"},
+		{`C:\Users\Peter\locorum`, "C:/Users/Peter/locorum"},
+		{`C:\Users\Peter/mixed\separators`, "C:/Users/Peter/mixed/separators"},
+		{"already/slash/form", "already/slash/form"},
+	}
+	for _, c := range cases {
+		got := DockerPath(c.in)
+		if got != c.want {
+			t.Errorf("DockerPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsLongPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// IsLongPath is short-circuited to false on non-Windows. Confirm.
+		if IsLongPath(strings.Repeat("a", 500)) {
+			t.Error("IsLongPath should return false on non-windows hosts")
+		}
+		return
+	}
+	// On Windows, the threshold is WindowsMaxPath - 1 - WPMaxPluginPathSuffix.
+	threshold := WindowsMaxPath - 1 - WPMaxPluginPathSuffix
+	short := strings.Repeat("a", threshold)
+	long := strings.Repeat("a", threshold+1)
+	if IsLongPath(short) {
+		t.Errorf("path of length %d should NOT be flagged long", len(short))
+	}
+	if !IsLongPath(long) {
+		t.Errorf("path of length %d SHOULD be flagged long", len(long))
+	}
+	if IsLongPath("") {
+		t.Error("empty path should not be flagged long")
+	}
+}
+
+func TestIsMntDrvFsPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+		why  string
+	}{
+		{"/mnt/c/Users/foo", true, "drive c"},
+		{"/mnt/d/projects/site", true, "drive d"},
+		{"/mnt/C/Users/foo", true, "uppercase drive letter"},
+		{"/mnt/c", true, "drive root, no trailing slash"},
+		{"/home/peter/locorum", false, "linux home"},
+		{"/mnt/drive/foo", false, "multi-letter pseudo-drive"},
+		{"/mnt/", false, "no drive letter"},
+		{"/mnt", false, "no trailing path at all"},
+		{`C:\Users\Peter`, false, "windows-form path is not a /mnt/ path"},
+		{"", false, "empty"},
+	}
+	for _, c := range cases {
+		got := isMntDrvFsPath(c.in)
+		if got != c.want {
+			t.Errorf("isMntDrvFsPath(%q) = %v, want %v (%s)", c.in, got, c.want, c.why)
+		}
+	}
+}
+
+// TestIsMntCRespectsWSLActive confirms the public IsMntC short-circuits on
+// non-WSL hosts even when the path *would* match. Test installs a fake
+// platform.Info via NewForTest so we don't depend on the build host.
+func TestIsMntCRespectsWSLActive(t *testing.T) {
+	notWSL := &Info{OS: "linux", Arch: "amd64"} // WSL.Active default false
+	restore := NewForTest(notWSL)
+	defer restore()
+
+	if IsMntC("/mnt/c/Users/foo") {
+		t.Error("IsMntC must return false when WSL.Active is false")
+	}
+
+	wsl := &Info{OS: "linux", Arch: "amd64", WSL: WSLInfo{Active: true}}
+	NewForTest(wsl) // this restore is overwritten by the outer defer
+
+	if !IsMntC("/mnt/c/Users/foo") {
+		t.Error("IsMntC must return true on a /mnt/c path with WSL active")
+	}
+	if IsMntC("/home/peter/locorum") {
+		t.Error("IsMntC must return false for non-/mnt path")
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,201 @@
+// Package platform identifies the host Locorum is running on. It centralises
+// every signal we'd otherwise sprinkle across `runtime.GOOS` and ad-hoc
+// `os.LookupEnv("WSL_DISTRO_NAME")` checks: OS, architecture, WSL2 mode,
+// macOS Rosetta, sanitised username, home directory, and host paths.
+//
+// The package has *no* internal dependencies — it is a leaf safe to import
+// from anywhere. The exported [Info] is immutable after [Init] returns; the
+// runtime mutates nothing. Reads do not lock.
+//
+// Concurrency: [Init] is idempotent — multiple goroutines may call it; the
+// first wins. [Get] returns the cached pointer with no synchronisation.
+//
+// Performance: cold [Init] is bounded by the [WSLInfoTimeout] context
+// deadline (500 ms) but only blocks for shell-out when the cheap signals
+// already say "we're in WSL". Native Linux/macOS/Windows paths run
+// entirely in-memory (<10 ms).
+package platform
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+// WSLInfoTimeout caps the `wslinfo --networking-mode` shell-out. On timeout
+// the field stays empty; the caller is informational, not load-bearing.
+const WSLInfoTimeout = 500 * time.Millisecond
+
+// LocorumDataDirName is the subdirectory under HomeDir that stores Locorum's
+// runtime state (settings DB, router config, certs, etc.). Centralised here
+// so tests can override it via NewForTest.
+const LocorumDataDirName = ".locorum"
+
+// Info is an immutable snapshot of host identification produced once at
+// startup. All fields are safe for concurrent reads without locking.
+//
+// A zero-value Info is technically valid but semantically wrong — always go
+// through [Init]/[Get]/[NewForTest].
+type Info struct {
+	// OS mirrors runtime.GOOS at Init time.
+	OS string
+
+	// Arch mirrors runtime.GOARCH at Init time.
+	Arch string
+
+	// WSL is the zero value on non-WSL hosts; .Active is the canonical
+	// "are we running inside WSL?" check.
+	WSL WSLInfo
+
+	// Username is the host login name, NFKC-normalised and stripped of
+	// characters Docker rejects in container-name suffixes. Never empty
+	// — falls back to "locorum" if the OS-reported name is unusable.
+	// Use this anywhere a username flows into a container, label, env
+	// var, or path.
+	Username string
+
+	// UID and GID are os.Getuid() / os.Getgid(); both -1 on Windows.
+	UID, GID int
+
+	// HomeDir is the user's home directory, resolved through
+	// os.UserHomeDir(). On WSL with a Windows-side daemon the value is
+	// the Linux-side path — translate via DockerPath when feeding it to
+	// a host-Windows Docker.
+	HomeDir string
+
+	// UnderRosetta is true on macOS amd64 binaries that the kernel is
+	// translating on an arm64 host. Triggers a hard-fail at startup —
+	// see preflight_darwin.go.
+	UnderRosetta bool
+
+	// Hostname is best-effort; "" if os.Hostname errored.
+	Hostname string
+}
+
+// WSLInfo carries the Windows-Subsystem-for-Linux specifics. Active is the
+// only field code outside this package should branch on; the rest are
+// diagnostic.
+type WSLInfo struct {
+	// Active is true when running inside a WSL2 distro (the default for
+	// any Linux build under WSL). Multiple signals voted on this; see
+	// detectWSL_linux.
+	Active bool
+
+	// Distro is the value of WSL_DISTRO_NAME, "" on non-WSL or when the
+	// env var is missing inside the distro.
+	Distro string
+
+	// NetworkingMode is "nat" / "mirrored" / "virtioproxy" / "" if
+	// `wslinfo --networking-mode` was unavailable or timed out. Only
+	// populated when Active is true.
+	NetworkingMode string
+
+	// KernelRelease mirrors /proc/sys/kernel/osrelease. Diagnostic only.
+	KernelRelease string
+}
+
+// pkgInfo is the package-level cached pointer. Init publishes here; Get
+// reads. atomic.Pointer keeps the read path lock-free.
+var pkgInfo atomic.Pointer[Info]
+
+// Init runs once at process start. Subsequent calls are no-ops returning
+// the cached *Info. Safe to call concurrently — the first goroutine wins
+// and later callers receive the same pointer.
+//
+// The context bounds shell-out steps (today: `wslinfo`). Pass a Background
+// context unless you have a specific deadline to enforce.
+func Init(ctx context.Context) *Info {
+	if cached := pkgInfo.Load(); cached != nil {
+		return cached
+	}
+	info := detect(ctx)
+	if pkgInfo.CompareAndSwap(nil, info) {
+		return info
+	}
+	// Lost the race; the winner's pointer is canonical.
+	return pkgInfo.Load()
+}
+
+// Get returns the previously-initialised *Info. Panics if Init has not
+// been called yet — this is intentional: the rest of the codebase assumes
+// platform was initialised in main, and a missing call is a wiring bug.
+func Get() *Info {
+	v := pkgInfo.Load()
+	if v == nil {
+		panic("platform: Get called before Init")
+	}
+	return v
+}
+
+// IsInitialized reports whether Init has been called. Tests use this to
+// avoid the panic; production code should never need it.
+func IsInitialized() bool {
+	return pkgInfo.Load() != nil
+}
+
+// NewForTest installs the given *Info as the package-level cache,
+// returning a func that restores the previous value. Tests call this
+// in a defer so multiple parallel tests don't leak state to each other.
+//
+// IMPORTANT: this is the *only* way to override the cache after Init.
+// Production code must not call it.
+func NewForTest(t *Info) (restore func()) {
+	prev := pkgInfo.Load()
+	pkgInfo.Store(t)
+	return func() {
+		if prev == nil {
+			pkgInfo.Store(nil)
+			return
+		}
+		pkgInfo.Store(prev)
+	}
+}
+
+// detect builds a fresh Info. Pure function from the host's current state
+// — same machine, same answer.
+func detect(ctx context.Context) *Info {
+	uid, gid := getUIDGID()
+
+	homeDir, _ := os.UserHomeDir()
+
+	rawUser := osLoginName()
+	username := SanitiseUsername(rawUser)
+
+	host, _ := os.Hostname()
+
+	info := &Info{
+		OS:           runtime.GOOS,
+		Arch:         runtime.GOARCH,
+		Username:     username,
+		UID:          uid,
+		GID:          gid,
+		HomeDir:      homeDir,
+		Hostname:     host,
+		UnderRosetta: isUnderRosetta(),
+	}
+
+	info.WSL = detectWSL(ctx)
+
+	return info
+}
+
+// getUIDGID returns os.Getuid()/Getgid() on Unix and -1,-1 on Windows.
+// Wrapped so tests don't need to fork to exercise the Windows path.
+func getUIDGID() (int, int) {
+	uid, gid := os.Getuid(), os.Getgid()
+	return uid, gid
+}
+
+// osLoginName is the best raw signal for the host login name. We try in
+// order: $USER, $USERNAME (Windows convention), $LOGNAME. Empty inputs
+// drop through to SanitiseUsername's fallback.
+func osLoginName() string {
+	for _, key := range []string{"USER", "USERNAME", "LOGNAME"} {
+		if v := os.Getenv(key); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,96 @@
+package platform
+
+import (
+	"context"
+	"runtime"
+	"testing"
+)
+
+// TestInitIdempotent asserts repeated Init calls return the same pointer.
+// The very first call within a test binary may be racing with other tests
+// — guard via NewForTest so we don't pollute global state.
+func TestInitIdempotent(t *testing.T) {
+	restore := NewForTest(nil)
+	defer restore()
+
+	a := Init(context.Background())
+	b := Init(context.Background())
+	if a != b {
+		t.Fatalf("Init must return the same pointer on repeated calls; got %p then %p", a, b)
+	}
+}
+
+// TestGetPanicsBeforeInit verifies the safety net for a wiring bug.
+func TestGetPanicsBeforeInit(t *testing.T) {
+	restore := NewForTest(nil)
+	defer restore()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Get must panic when Init has not been called")
+		}
+	}()
+	_ = Get()
+}
+
+// TestNewForTestRestoresPrevious confirms the test override is reversible
+// so parallel-test files can swap and revert without leaking state.
+func TestNewForTestRestoresPrevious(t *testing.T) {
+	restore := NewForTest(&Info{OS: "fake-original"})
+	defer restore()
+
+	mid := NewForTest(&Info{OS: "fake-replacement"})
+	if Get().OS != "fake-replacement" {
+		t.Fatalf("expected mid-override; got %+v", Get())
+	}
+	mid()
+	if Get().OS != "fake-original" {
+		t.Fatalf("expected restore to original; got %+v", Get())
+	}
+}
+
+// TestDetectFillsMandatoryFields runs detect against the real host. We
+// can't assert specific values, but the contract is "OS/Arch/UID/GID/
+// HomeDir/Username always populated" — it's worth catching a regression
+// where one of those silently goes empty.
+func TestDetectFillsMandatoryFields(t *testing.T) {
+	info := detect(context.Background())
+	if info.OS == "" {
+		t.Error("OS must be populated")
+	}
+	if info.Arch == "" {
+		t.Error("Arch must be populated")
+	}
+	if info.OS != runtime.GOOS {
+		t.Errorf("OS=%q does not match runtime.GOOS=%q", info.OS, runtime.GOOS)
+	}
+	if info.Arch != runtime.GOARCH {
+		t.Errorf("Arch=%q does not match runtime.GOARCH=%q", info.Arch, runtime.GOARCH)
+	}
+	if info.Username == "" {
+		t.Error("Username must be populated (sanitiser fallback should never empty it)")
+	}
+	if info.HomeDir == "" {
+		// HomeDir can legitimately be empty if the test runner has no
+		// HOME env var (rare). Not a test failure — record only.
+		t.Logf("HomeDir empty; runner has no HOME? OS=%s", info.OS)
+	}
+}
+
+// TestNewForTestNilThenInitDetects ensures clearing the cache to nil
+// (the documented restore path) lets a fresh Init populate it again.
+func TestNewForTestNilThenInitDetects(t *testing.T) {
+	restore := NewForTest(nil)
+	defer restore()
+
+	if IsInitialized() {
+		t.Fatal("IsInitialized should be false after NewForTest(nil)")
+	}
+	got := Init(context.Background())
+	if got == nil {
+		t.Fatal("Init returned nil")
+	}
+	if !IsInitialized() {
+		t.Fatal("IsInitialized should be true after Init")
+	}
+}

--- a/internal/platform/rosetta_darwin.go
+++ b/internal/platform/rosetta_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+package platform
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// isUnderRosetta reports whether this binary is being executed under Apple's
+// amd64-on-arm64 translator. Returns false on native arm64 binaries and on
+// arm64 hosts running native arm64 builds.
+//
+// We shell out to `/usr/sbin/sysctl` rather than linking the macOS sys/sysctl
+// header so the package stays cgo-free. The cost is one fork+exec at
+// startup — negligible, and only on darwin.
+//
+// `sysctl.proc_translated` is documented in Apple's sysctl(3): 1 means the
+// running process is a translated x86_64 process under Rosetta; 0 means
+// native; the sysctl is missing entirely on Intel Macs (the binary cannot
+// be Rosetta-translated there).
+func isUnderRosetta() bool {
+	out, err := exec.Command("/usr/sbin/sysctl", "-n", "sysctl.proc_translated").Output()
+	if err != nil {
+		// Intel Macs: the sysctl is missing → sysctl exits non-zero.
+		// Treat as "not Rosetta", which is correct.
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "1"
+}

--- a/internal/platform/rosetta_other.go
+++ b/internal/platform/rosetta_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package platform
+
+// isUnderRosetta is the non-darwin stub. Rosetta is a macOS-only translator;
+// other operating systems are never under it.
+func isUnderRosetta() bool { return false }

--- a/internal/platform/testdata/fuzz/FuzzSanitiseUsername/a05e666c8a205f6f
+++ b/internal/platform/testdata/fuzz/FuzzSanitiseUsername/a05e666c8a205f6f
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("_")

--- a/internal/platform/user.go
+++ b/internal/platform/user.go
@@ -1,0 +1,157 @@
+package platform
+
+import (
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// MaxSanitisedUsernameLen caps the output of [SanitiseUsername]. 32 bytes
+// is enough for any container-name suffix and keeps log lines tidy. Docker
+// label-value limits are far larger, so this is policy, not protocol.
+const MaxSanitisedUsernameLen = 32
+
+// SanitiseUsername returns a deterministic, container-safe form of the
+// host login name. The output:
+//
+//   - matches the regex `^[a-z][a-z0-9._-]*$` after normalisation
+//   - is between 1 and [MaxSanitisedUsernameLen] runes long
+//   - is byte-identical for byte-identical input across Go versions
+//     (locked in by golden tests)
+//
+// Steps (in order):
+//
+//  1. NFKC compatibility composition. Collapses look-alikes that NFD
+//     leaves alone — e.g. "ﬃ" → "ffi", "Ⅳ" → "IV", "①" → "1". Catches
+//     fullwidth/halfwidth quirks common in Asian-locale Windows installs.
+//  2. NFD decomposition + drop combining marks. Strips diacritics:
+//     "André" → "Andre", "Müller" → "Muller". This is the DDEV bug
+//     ("André Kraus" breaks containers) where the fix lives.
+//  3. Replace `\` (Windows DOMAIN\user format), whitespace, and `/` with
+//     `-`. Path separators are dangerous in container paths regardless of
+//     where they end up.
+//  4. Lowercase. Docker container names are case-sensitive but the
+//     ecosystem (Compose, Kubernetes) treats them as lowercase; uniform
+//     output sidesteps "USER vs user" ambiguity.
+//  5. Drop characters outside `[a-z0-9._-]`. Anything that survives this
+//     point is something a shell can mangle.
+//  6. Collapse runs of `-` into one and trim leading/trailing `-`/`.`.
+//  7. Truncate to [MaxSanitisedUsernameLen] (post-step-6, byte length).
+//  8. If the result is empty or starts with a digit, prefix `u-`. If it
+//     is *still* empty (impossible after the prefix, but defensive),
+//     fall through to the literal "locorum".
+//
+// Properties asserted by tests:
+//   - Idempotent: SanitiseUsername(SanitiseUsername(x)) == SanitiseUsername(x).
+//   - Output is in [1, MaxSanitisedUsernameLen] bytes.
+//   - Output regex `^[a-z][a-z0-9._-]*$` always holds.
+func SanitiseUsername(in string) string {
+	// 1. NFKC normalise.
+	s := norm.NFKC.String(in)
+
+	// 2. NFD decompose; drop combining marks; recompose to a flat string.
+	s = stripCombining(s)
+
+	// 3. Replace backslashes, slashes, and whitespace with `-`.
+	var bld strings.Builder
+	bld.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\\', r == '/':
+			bld.WriteByte('-')
+		case unicode.IsSpace(r):
+			bld.WriteByte('-')
+		default:
+			bld.WriteRune(r)
+		}
+	}
+	s = bld.String()
+
+	// 4. Lowercase.
+	s = strings.ToLower(s)
+
+	// 5. Drop characters outside the allowed set.
+	bld.Reset()
+	bld.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			bld.WriteRune(r)
+		case r >= '0' && r <= '9':
+			bld.WriteRune(r)
+		case r == '.' || r == '-' || r == '_':
+			bld.WriteRune(r)
+		}
+	}
+	s = bld.String()
+
+	// 6. Collapse runs of `-`, trim leading/trailing punctuation.
+	s = collapseDashes(s)
+	s = strings.Trim(s, "-.")
+
+	// 7. Truncate.
+	if len(s) > MaxSanitisedUsernameLen {
+		s = s[:MaxSanitisedUsernameLen]
+		// A truncate may now end in a `.` or `-` we've already trimmed
+		// once — re-trim.
+		s = strings.TrimRight(s, "-.")
+	}
+
+	// 8. Empty or doesn't start with [a-z]? Prefix. The regex contract
+	//    is `^[a-z][a-z0-9._-]*$`, so any leading char other than a
+	//    lowercase letter — digit, underscore, etc. — must be moved
+	//    behind the `u-` prefix to keep the first byte alphabetic.
+	if s == "" || !(s[0] >= 'a' && s[0] <= 'z') {
+		s = "u-" + s
+		if len(s) > MaxSanitisedUsernameLen {
+			s = s[:MaxSanitisedUsernameLen]
+			s = strings.TrimRight(s, "-.")
+		}
+	}
+	if s == "" || s == "u-" {
+		return "locorum"
+	}
+	return s
+}
+
+// stripCombining decomposes via NFD and filters out characters in the Mn
+// (Mark, Nonspacing) class — i.e. combining diacritics. The remaining
+// runes are the "base" letters.
+func stripCombining(s string) string {
+	dec := norm.NFD.String(s)
+	var bld strings.Builder
+	bld.Grow(len(dec))
+	for _, r := range dec {
+		if unicode.Is(unicode.Mn, r) {
+			continue
+		}
+		bld.WriteRune(r)
+	}
+	return bld.String()
+}
+
+// collapseDashes replaces runs of `-` with a single `-`. ASCII-only —
+// runs entirely on byte boundaries because `-` is ASCII.
+func collapseDashes(s string) string {
+	if !strings.Contains(s, "--") {
+		return s
+	}
+	var bld strings.Builder
+	bld.Grow(len(s))
+	prevDash := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '-' {
+			if prevDash {
+				continue
+			}
+			prevDash = true
+			bld.WriteByte('-')
+			continue
+		}
+		prevDash = false
+		bld.WriteByte(c)
+	}
+	return bld.String()
+}

--- a/internal/platform/user_test.go
+++ b/internal/platform/user_test.go
@@ -1,0 +1,116 @@
+package platform
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// expectedShape is the post-sanitisation regex; every output string must
+// match. Empty strings would fail this regex which is what we want — the
+// sanitiser guarantees non-empty output.
+var expectedShape = regexp.MustCompile(`^[a-z][a-z0-9._-]*$`)
+
+func TestSanitiseUsernameTable(t *testing.T) {
+	cases := []struct {
+		in, want, why string
+	}{
+		// Latin diacritics — the DDEV "André Kraus" bug.
+		{"André", "andre", "NFD strip combining marks"},
+		{"Müller", "muller", "umlaut decomposes"},
+		{"François", "francois", "cedilla decomposes"},
+		{"Renée", "renee", "acute decomposes"},
+
+		// NFKC-only cases (fullwidth/compat).
+		{"ＡＢＣ", "abc", "fullwidth Latin"},
+		{"ﬃ", "ffi", "ligature decomposes via NFKC"},
+
+		// Whitespace and slashes.
+		{"Andre Kraus", "andre-kraus", "space → dash"},
+		{"DOMAIN\\user", "domain-user", "Windows DOMAIN\\user"},
+		{"a/b/c", "a-b-c", "slashes → dash"},
+		{"  spaces  ", "spaces", "leading/trailing whitespace trimmed"},
+
+		// Mixed case + special chars.
+		{"Foo.Bar_Baz-1", "foo.bar_baz-1", "preserve .,_,-"},
+		{"FOO!BAR@BAZ", "foobarbaz", "drop punctuation"},
+
+		// Edge cases that exercise the prefix and trim rules.
+		{"123abc", "u-123abc", "leading digit gets u- prefix"},
+		{"---x---", "x", "outer dashes trimmed"},
+		{"a---b---c", "a-b-c", "internal dash runs collapsed"},
+		{".dotfile.", "dotfile", "outer dots trimmed"},
+
+		// Empty/garbage → fallback.
+		{"", "locorum", "empty → fallback"},
+		{"   ", "locorum", "whitespace-only → fallback"},
+		{"!!!@@@###", "locorum", "all punctuation → fallback"},
+		{"漢字", "locorum", "non-decomposable CJK → fallback"},
+
+		// Truncation.
+		{strings.Repeat("a", 80), strings.Repeat("a", 32), "truncated to 32"},
+		// Trailing dash after truncate gets re-trimmed.
+		{strings.Repeat("a", 31) + "-extra", "a" + strings.Repeat("a", 30), "truncate doesn't leave trailing dash"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.why, func(t *testing.T) {
+			got := SanitiseUsername(c.in)
+			if got != c.want {
+				t.Errorf("SanitiseUsername(%q) = %q, want %q (%s)", c.in, got, c.want, c.why)
+			}
+			if !expectedShape.MatchString(got) {
+				t.Errorf("output %q failed expectedShape regex", got)
+			}
+		})
+	}
+}
+
+// TestSanitiseUsernameInvariants asserts the contract holds for a small
+// hand-picked corpus regardless of the specific output:
+//
+//   - 1 ≤ len(out) ≤ MaxSanitisedUsernameLen
+//   - regex `^[a-z][a-z0-9._-]*$` matches
+//   - idempotent: f(f(x)) == f(x)
+func TestSanitiseUsernameInvariants(t *testing.T) {
+	corpus := []string{
+		"", "a", "A", "1", " ", "/", "\\", "user@host",
+		"José María", "DOMAIN\\Administrator", "user.name+tag",
+		strings.Repeat("é", 100), strings.Repeat("@", 100),
+	}
+	for _, in := range corpus {
+		out := SanitiseUsername(in)
+		if got := len(out); got < 1 || got > MaxSanitisedUsernameLen {
+			t.Errorf("len out-of-range for %q: got %d", in, got)
+		}
+		if !expectedShape.MatchString(out) {
+			t.Errorf("regex failed for %q → %q", in, out)
+		}
+		if SanitiseUsername(out) != out {
+			t.Errorf("not idempotent: f(%q)=%q but f(f(%q))=%q", in, out, in, SanitiseUsername(out))
+		}
+	}
+}
+
+// FuzzSanitiseUsername hammers the function with arbitrary input and
+// confirms the invariants above. Run on CI nightly via `go test -fuzz`.
+func FuzzSanitiseUsername(f *testing.F) {
+	for _, seed := range []string{
+		"", " ", "a", "A", "1", "/", "\\", "user", "Andre Kraus",
+		"DOMAIN\\user", "ﬃ", "漢字", strings.Repeat("a", 100),
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		out := SanitiseUsername(in)
+		if got := len(out); got < 1 || got > MaxSanitisedUsernameLen {
+			t.Fatalf("len out-of-range for %q: got %d (out=%q)", in, got, out)
+		}
+		if !expectedShape.MatchString(out) {
+			t.Fatalf("regex failed: in=%q out=%q", in, out)
+		}
+		if SanitiseUsername(out) != out {
+			t.Fatalf("not idempotent: in=%q out=%q out2=%q", in, out, SanitiseUsername(out))
+		}
+	})
+}

--- a/internal/platform/wsl_linux.go
+++ b/internal/platform/wsl_linux.go
@@ -1,0 +1,100 @@
+//go:build linux
+
+package platform
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// detectWSL applies the multi-signal detection described in LEARNINGS §6.1.
+// A host is in WSL if any of these are true:
+//
+//   - WSL_INTEROP env var set (the canonical marker; survives sub-shells)
+//   - WSL_DISTRO_NAME env var set (legacy fallback)
+//   - /proc/version contains "microsoft" or "wsl" (case-insensitive)
+//   - /proc/sys/kernel/osrelease ends with "-WSL2" or "-microsoft-standard"
+//
+// Any single signal is sufficient. The function then attempts to populate
+// .NetworkingMode by shelling out to `wslinfo`, bounded by the caller's
+// context (typically WSLInfoTimeout).
+func detectWSL(ctx context.Context) WSLInfo {
+	out := WSLInfo{
+		Distro: os.Getenv("WSL_DISTRO_NAME"),
+	}
+
+	if _, ok := os.LookupEnv("WSL_INTEROP"); ok {
+		out.Active = true
+	}
+	if out.Distro != "" {
+		out.Active = true
+	}
+
+	if data, err := os.ReadFile("/proc/version"); err == nil {
+		lower := bytes.ToLower(data)
+		if bytes.Contains(lower, []byte("microsoft")) || bytes.Contains(lower, []byte("wsl")) {
+			out.Active = true
+		}
+	}
+
+	if release, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
+		out.KernelRelease = strings.TrimSpace(string(release))
+		lower := strings.ToLower(out.KernelRelease)
+		if strings.HasSuffix(lower, "-wsl2") || strings.HasSuffix(lower, "-microsoft-standard") {
+			out.Active = true
+		}
+	}
+
+	if out.Active {
+		out.NetworkingMode = readWSLNetworkingMode(ctx)
+	}
+
+	return out
+}
+
+// readWSLNetworkingMode invokes `wslinfo --networking-mode` with the
+// caller's context as a deadline. The output is one of "nat", "mirrored",
+// or "virtioproxy" depending on the host's WSL config; on older WSL
+// installs `wslinfo` does not exist and we return "".
+//
+// Errors are not surfaced — the value is informational. We do log at
+// debug level so a future oncall can tell why the field is empty.
+func readWSLNetworkingMode(ctx context.Context) string {
+	bin, err := exec.LookPath("wslinfo")
+	if err != nil {
+		// Older WSL releases predate wslinfo. Not an error, just no
+		// data — return silently.
+		return ""
+	}
+	cmd := exec.CommandContext(ctx, bin, "--networking-mode")
+	stdout, err := cmd.Output()
+	if err != nil {
+		// Don't pollute logs on a routine `command not found`-shaped
+		// failure (the CommandContext exec didn't reach the binary).
+		// For real failures (timeout, bad output) record one debug
+		// line so platform-detection problems are diagnosable.
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			slog.Debug("platform: wslinfo failed", "err", err.Error())
+		}
+		return ""
+	}
+	mode := strings.TrimSpace(string(stdout))
+	switch mode {
+	case "nat", "mirrored", "virtioproxy":
+		return mode
+	default:
+		// Some `wslinfo` builds emit additional whitespace/headers.
+		// Take the first non-empty token.
+		fields := strings.Fields(mode)
+		if len(fields) == 0 {
+			return ""
+		}
+		return fields[0]
+	}
+}

--- a/internal/platform/wsl_linux_test.go
+++ b/internal/platform/wsl_linux_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package platform
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDetectWSLEnvSignals exercises the env-var branch. We restore env vars
+// after each subtest so we don't pollute later tests.
+func TestDetectWSLEnvSignals(t *testing.T) {
+	cases := []struct {
+		envKey, envVal string
+		wantActive     bool
+	}{
+		{"WSL_INTEROP", "/run/WSL/something", true},
+		{"WSL_DISTRO_NAME", "Ubuntu-22.04", true},
+	}
+	for _, c := range cases {
+		t.Run(c.envKey, func(t *testing.T) {
+			t.Setenv(c.envKey, c.envVal)
+			info := detectWSL(context.Background())
+			if info.Active != c.wantActive {
+				t.Errorf("Active=%v want %v (env %s=%s)", info.Active, c.wantActive, c.envKey, c.envVal)
+			}
+			if c.envKey == "WSL_DISTRO_NAME" && info.Distro != c.envVal {
+				t.Errorf("Distro=%q want %q", info.Distro, c.envVal)
+			}
+		})
+	}
+}
+
+// TestDetectWSLNoSignalsDefaultsToInactive confirms that on a system with
+// none of the env signals and no /proc/version "microsoft", we return
+// Active=false. We can't fully guarantee /proc/version doesn't say microsoft
+// on the test host (CI may run inside WSL), so skip the assertion if it
+// does. The intent of the test is the *negative* case — we don't want false
+// positives from no signal.
+func TestDetectWSLNoSignalsDefaultsToInactive(t *testing.T) {
+	// Hide the env vars by ensuring they're unset for the duration.
+	t.Setenv("WSL_INTEROP", "")
+	t.Setenv("WSL_DISTRO_NAME", "")
+	os.Unsetenv("WSL_INTEROP")
+	os.Unsetenv("WSL_DISTRO_NAME")
+
+	procVersion, _ := os.ReadFile("/proc/version")
+	osRelease, _ := os.ReadFile("/proc/sys/kernel/osrelease")
+	procSaysWSL := bytesContainsCI(procVersion, "microsoft") ||
+		bytesContainsCI(procVersion, "wsl") ||
+		strings.HasSuffix(strings.ToLower(strings.TrimSpace(string(osRelease))), "-wsl2") ||
+		strings.HasSuffix(strings.ToLower(strings.TrimSpace(string(osRelease))), "-microsoft-standard")
+
+	info := detectWSL(context.Background())
+	if !procSaysWSL && info.Active {
+		t.Errorf("expected Active=false on host with no WSL signals; got %+v", info)
+	}
+}
+
+func bytesContainsCI(haystack []byte, needle string) bool {
+	return strings.Contains(strings.ToLower(string(haystack)), strings.ToLower(needle))
+}

--- a/internal/platform/wsl_other.go
+++ b/internal/platform/wsl_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package platform
+
+import "context"
+
+// detectWSL is the non-Linux stub. The plan-of-record is "WSL only matters
+// when GOOS=linux", so we return the zero value unconditionally. The
+// Windows-side "I can talk to WSL via wsl.exe" check stays in
+// internal/utils.HasWSL — see CROSS-PLATFORM.md note v2 #4.
+func detectWSL(_ context.Context) WSLInfo {
+	return WSLInfo{}
+}

--- a/internal/router/traefik/traefik.go
+++ b/internal/router/traefik/traefik.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/PeterBooker/locorum/internal/docker"
 	"github.com/PeterBooker/locorum/internal/genmark"
+	"github.com/PeterBooker/locorum/internal/platform"
 	"github.com/PeterBooker/locorum/internal/router"
 	tlspkg "github.com/PeterBooker/locorum/internal/tls"
 	"github.com/PeterBooker/locorum/internal/version"
@@ -404,11 +405,14 @@ func (r *Router) createContainer(ctx context.Context) error {
 		},
 	}
 
+	// platform.DockerPath normalises slashes for every supported host;
+	// without it a Windows native build would hand `\` to Docker and the
+	// bind would silently fail with "no such file or directory".
 	hostCfg := &dcontainer.HostConfig{
 		Binds: []string{
-			r.hostStaticPath + ":" + ContainerStaticPath + ":ro",
-			r.hostDynamicDir + ":" + ContainerDynamicDir + ":ro",
-			r.hostCertsDir + ":" + ContainerCertsDir + ":ro",
+			platform.DockerPath(r.hostStaticPath) + ":" + ContainerStaticPath + ":ro",
+			platform.DockerPath(r.hostDynamicDir) + ":" + ContainerDynamicDir + ":ro",
+			platform.DockerPath(r.hostCertsDir) + ":" + ContainerCertsDir + ":ro",
 		},
 		PortBindings: nat.PortMap{
 			"80/tcp":                     {{HostIP: "0.0.0.0", HostPort: strconv.Itoa(r.cfg.HTTPPort)}},

--- a/internal/sites/sites.go
+++ b/internal/sites/sites.go
@@ -115,6 +115,38 @@ func NewSiteManager(st *storage.Storage, cli *client.Client, d *docker.Docker, r
 // always wires through main.New.
 func (sm *SiteManager) Config() *config.Config { return sm.cfg }
 
+// Roots returns the FilesDir of every registered site, deduped and
+// sorted. Implements health.SiteRootLister so the path-shape checks
+// (wsl-mnt-c, windows-longpath) can iterate over real site locations
+// without depending on *sites.SiteManager directly.
+//
+// Errors from the underlying GetSites are swallowed (logged at debug
+// only) — the health check is informational and a transient SQLite
+// hiccup shouldn't trip a "we can't read your sites" finding.
+func (sm *SiteManager) Roots(_ context.Context) []string {
+	if sm == nil || sm.st == nil {
+		return nil
+	}
+	rows, err := sm.st.GetSites()
+	if err != nil {
+		slog.Debug("sites: roots: GetSites failed", "err", err.Error())
+		return nil
+	}
+	seen := make(map[string]struct{}, len(rows))
+	out := make([]string, 0, len(rows))
+	for _, s := range rows {
+		if s.FilesDir == "" {
+			continue
+		}
+		if _, ok := seen[s.FilesDir]; ok {
+			continue
+		}
+		seen[s.FilesDir] = struct{}{}
+		out = append(out, s.FilesDir)
+	}
+	return out
+}
+
 // writeConfigYAML projects the site row + its hooks onto
 // <site.FilesDir>/.locorum/config.yaml. Errors are logged but never
 // propagated — the YAML is a portability convenience, not a load-

--- a/internal/sites/validate.go
+++ b/internal/sites/validate.go
@@ -1,0 +1,65 @@
+package sites
+
+import (
+	"github.com/PeterBooker/locorum/internal/platform"
+)
+
+// PathNote is a single warning produced by [ValidateSitePath]. Severity is
+// always "warn" — the modal allows submission either way; the note exists
+// to set expectations ("this site is going to feel slow" / "Windows MAX_PATH
+// could bite later").
+//
+// We don't reuse health.Finding here because the lifecycle is different:
+// these are surfaced inline next to the path field, not in the System Health
+// panel. Sharing a struct would couple the new-site modal to the runner
+// machinery for no benefit.
+type PathNote struct {
+	// Title is the short heading. ~40 chars.
+	Title string
+
+	// Detail is the single-sentence explanation.
+	Detail string
+
+	// HelpURL is an optional documentation link.
+	HelpURL string
+}
+
+// ValidateSitePath returns 0..n warning notes for path p on a host described
+// by info. Pure: no I/O, no globals, no clock. Safe to call on every
+// keystroke (the caller debounces before re-rendering, but the function
+// itself is microsecond-cheap).
+//
+// Cases checked:
+//
+//   - WSL host with site under /mnt/c (or any /mnt/<letter>/) — DrvFS is
+//     much slower than native ext4 for the WordPress workload.
+//   - Windows host where the path's expected longest descendant exceeds
+//     MAX_PATH — some plugin assets will fail to resolve.
+//
+// Empty path → no notes (the form's "required" check handles emptiness;
+// we don't double up).
+func ValidateSitePath(p string, info *platform.Info) []PathNote {
+	if p == "" || info == nil {
+		return nil
+	}
+
+	var notes []PathNote
+
+	if info.WSL.Active && platform.IsMntC(p) {
+		notes = append(notes, PathNote{
+			Title:   "Slow filesystem",
+			Detail:  "Sites under /mnt/c (or other Windows-mounted drives) run roughly 10× slower than under /home/<user>/.",
+			HelpURL: "https://docs.locorum.dev/wsl-performance",
+		})
+	}
+
+	if info.OS == "windows" && platform.IsLongPath(p) {
+		notes = append(notes, PathNote{
+			Title:   "Path may exceed Windows 260-character limit",
+			Detail:  "Some WordPress plugin assets may fail to resolve. Use a shorter root path, or enable LongPathsEnabled in the registry.",
+			HelpURL: "https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation",
+		})
+	}
+
+	return notes
+}

--- a/internal/sites/validate_test.go
+++ b/internal/sites/validate_test.go
@@ -1,0 +1,53 @@
+package sites
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PeterBooker/locorum/internal/platform"
+)
+
+func TestValidateSitePathEmpty(t *testing.T) {
+	if got := ValidateSitePath("", &platform.Info{OS: "linux"}); len(got) != 0 {
+		t.Errorf("empty path should have no notes, got %v", got)
+	}
+}
+
+func TestValidateSitePathNilInfo(t *testing.T) {
+	if got := ValidateSitePath("/home/peter/sites/foo", nil); len(got) != 0 {
+		t.Errorf("nil info should have no notes, got %v", got)
+	}
+}
+
+func TestValidateSitePathWSLMntC(t *testing.T) {
+	wsl := &platform.Info{OS: "linux", WSL: platform.WSLInfo{Active: true}}
+	restore := platform.NewForTest(wsl)
+	defer restore()
+
+	got := ValidateSitePath("/mnt/c/Users/foo/sites/a", wsl)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 note, got %d", len(got))
+	}
+	if !strings.Contains(strings.ToLower(got[0].Title), "slow") {
+		t.Errorf("expected 'slow' in title, got %q", got[0].Title)
+	}
+}
+
+func TestValidateSitePathWSLNativeIsClean(t *testing.T) {
+	wsl := &platform.Info{OS: "linux", WSL: platform.WSLInfo{Active: true}}
+	restore := platform.NewForTest(wsl)
+	defer restore()
+
+	got := ValidateSitePath("/home/peter/sites/a", wsl)
+	if len(got) != 0 {
+		t.Errorf("native WSL path should produce no notes, got %v", got)
+	}
+}
+
+func TestValidateSitePathLinuxIsAlwaysClean(t *testing.T) {
+	info := &platform.Info{OS: "linux"} // no WSL
+	got := ValidateSitePath(strings.Repeat("a", 500), info)
+	if len(got) != 0 {
+		t.Errorf("linux + long path should produce no notes; long-path is windows-only; got %v", got)
+	}
+}

--- a/internal/ui/healthpanel.go
+++ b/internal/ui/healthpanel.go
@@ -1,0 +1,399 @@
+package ui
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"sync"
+
+	"gioui.org/font"
+	"gioui.org/layout"
+	"gioui.org/op/clip"
+	"gioui.org/op/paint"
+	"gioui.org/unit"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+
+	"github.com/PeterBooker/locorum/internal/health"
+)
+
+// HealthPanel renders the System Health card in the Settings panel. It
+// reads the snapshot from UIState (atomic, lock-free) every frame and
+// renders one row per Finding plus a "Re-check now" button.
+//
+// HealthPanel does NOT own the runner — it only reads. Action invocations
+// route back through the runner via the optional submitAction callback,
+// which the wiring layer (main.go) provides as a closure over
+// runner.SubmitAction.
+type HealthPanel struct {
+	state        *UIState
+	submitAction func(id string, a health.Action) error
+	runNow       func()
+
+	recheckBtn widget.Clickable
+
+	// findingButtons keeps a stable widget.Clickable per finding key
+	// across frames so click-state survives between renders. New keys
+	// are allocated on first Layout pass; no eviction (the set is
+	// bounded by the number of distinct findings, ~10).
+	mu             sync.Mutex
+	findingButtons map[string]*widget.Clickable
+}
+
+// NewHealthPanel constructs the panel. submitAction is the runner's
+// SubmitAction wrapped in a closure; runNow is runner.RunNow + Snapshot
+// publication. Both may be nil for tests.
+func NewHealthPanel(state *UIState, submitAction func(id string, a health.Action) error, runNow func()) *HealthPanel {
+	return &HealthPanel{
+		state:          state,
+		submitAction:   submitAction,
+		runNow:         runNow,
+		findingButtons: make(map[string]*widget.Clickable),
+	}
+}
+
+// HandleUserInteractions reads the re-check button and any per-finding
+// action button. Called by the parent panel each frame.
+func (p *HealthPanel) HandleUserInteractions(gtx layout.Context) {
+	if p.recheckBtn.Clicked(gtx) && p.runNow != nil {
+		go p.runNow()
+	}
+	snap := p.state.HealthSnapshot()
+	for i := range snap.Findings {
+		f := &snap.Findings[i]
+		if f.Action == nil {
+			continue
+		}
+		btn := p.buttonFor(findingButtonKey(*f))
+		if btn.Clicked(gtx) && p.submitAction != nil {
+			act := *f.Action
+			id := f.ID
+			go func() {
+				if err := p.submitAction(id, act); err != nil {
+					p.state.ShowError("Action failed: " + err.Error())
+				}
+			}()
+		}
+	}
+}
+
+// Layout renders the System Health card.
+func (p *HealthPanel) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	snap := p.state.HealthSnapshot()
+	header := func(gtx layout.Context) layout.Dimensions {
+		label := "Re-check now"
+		if snap.Running {
+			label = "Re-checking…"
+		}
+		return th.SmallGated(gtx, &p.recheckBtn, label, !snap.Running && p.runNow != nil)
+	}
+	return panelWithAction(gtx, th, "System Health", header, func(gtx layout.Context) layout.Dimensions {
+		return p.layoutBody(gtx, th, snap)
+	})
+}
+
+func (p *HealthPanel) layoutBody(gtx layout.Context, th *Theme, snap health.Snapshot) layout.Dimensions {
+	if len(snap.Findings) == 0 {
+		lbl := material.Body2(th.Theme, "All systems nominal.")
+		lbl.Color = th.Color.Fg2
+		lbl.TextSize = th.Sizes.Body
+		return lbl.Layout(gtx)
+	}
+	children := make([]layout.FlexChild, 0, len(snap.Findings)+1)
+	for i := range snap.Findings {
+		f := snap.Findings[i]
+		first := i == 0
+		children = append(children, layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			top := th.Spacing.SM
+			if first {
+				top = 0
+			}
+			return layout.Inset{Top: top}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+				return p.layoutFinding(gtx, th, f)
+			})
+		}))
+	}
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx, children...)
+}
+
+func (p *HealthPanel) layoutFinding(gtx layout.Context, th *Theme, f health.Finding) layout.Dimensions {
+	bg, fg := severityColors(th, f.Severity)
+	return RoundedFill(gtx, bg, th.Radii.R2, func(gtx layout.Context) layout.Dimensions {
+		return layout.UniformInset(unit.Dp(12)).Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
+						layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+							return severityDot(gtx, fg)
+						}),
+						layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+							return layout.Inset{Left: unit.Dp(8)}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+								title := f.Title
+								if f.Stale {
+									title = "↻ " + title
+								}
+								lbl := material.Body2(th.Theme, title)
+								lbl.Color = th.Color.Fg
+								lbl.TextSize = th.Sizes.Body
+								lbl.Font.Weight = font.SemiBold
+								return lbl.Layout(gtx)
+							})
+						}),
+					)
+				}),
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					if f.Detail == "" {
+						return layout.Dimensions{}
+					}
+					lbl := material.Body2(th.Theme, f.Detail)
+					lbl.Color = th.Color.Fg2
+					lbl.TextSize = th.Sizes.Body
+					return layout.Inset{Top: unit.Dp(4), Left: unit.Dp(20)}.Layout(gtx, lbl.Layout)
+				}),
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					if f.Remediation == "" {
+						return layout.Dimensions{}
+					}
+					lbl := material.Body2(th.Theme, "→ "+f.Remediation)
+					lbl.Color = th.Color.Fg2
+					lbl.TextSize = th.Sizes.Mono
+					return layout.Inset{Top: unit.Dp(4), Left: unit.Dp(20)}.Layout(gtx, lbl.Layout)
+				}),
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					if f.Action == nil {
+						return layout.Dimensions{}
+					}
+					return layout.Inset{Top: unit.Dp(8), Left: unit.Dp(20)}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+						btn := p.buttonFor(findingButtonKey(f))
+						return th.Small(gtx, btn, f.Action.Label)
+					})
+				}),
+			)
+		})
+	})
+}
+
+func (p *HealthPanel) buttonFor(key string) *widget.Clickable {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if b, ok := p.findingButtons[key]; ok {
+		return b
+	}
+	b := &widget.Clickable{}
+	p.findingButtons[key] = b
+	return b
+}
+
+// severityColors maps a finding severity onto (background, accent).
+func severityColors(th *Theme, sev health.Severity) (color.NRGBA, color.NRGBA) {
+	switch sev {
+	case health.SeverityBlocker:
+		return th.Color.ErrSoft, th.Color.Err
+	case health.SeverityWarn:
+		return th.Color.WarnSoft, th.Color.Warn
+	case health.SeverityInfo:
+		return th.Color.AccentSoft, th.Color.Accent
+	}
+	return th.Color.Bg2, th.Color.Fg3
+}
+
+func severityDot(gtx layout.Context, col color.NRGBA) layout.Dimensions {
+	d := gtx.Dp(unit.Dp(10))
+	r := gtx.Dp(unit.Dp(5))
+	rect := image.Rectangle{Max: image.Point{X: d, Y: d}}
+	defer clip.RRect{Rect: rect, NE: r, NW: r, SE: r, SW: r}.Push(gtx.Ops).Pop()
+	paint.Fill(gtx.Ops, col)
+	return layout.Dimensions{Size: image.Point{X: d, Y: d}}
+}
+
+// findingButtonKey is the stable key for a finding's action button. Action
+// labels can change between runs; only ID + DedupKey are stable enough.
+func findingButtonKey(f health.Finding) string {
+	return f.ID + "|" + f.DedupKey
+}
+
+// HealthBlockerModal renders the full-screen modal that fires when at
+// least one Blocker finding is present. The user has two options:
+// "Re-check" (calls runner.RunNow) and "Quit". There is deliberately no
+// "Ignore" — DDEV's discipline.
+type HealthBlockerModal struct {
+	state   *UIState
+	runNow  func()
+	onQuit  func()
+	recheck widget.Clickable
+	quit    widget.Clickable
+}
+
+// NewHealthBlockerModal builds the modal. quit is invoked when the user
+// clicks Quit; main.go wires it to a graceful shutdown.
+func NewHealthBlockerModal(state *UIState, runNow func(), onQuit func()) *HealthBlockerModal {
+	return &HealthBlockerModal{state: state, runNow: runNow, onQuit: onQuit}
+}
+
+// HasBlocker reports whether the current snapshot contains a blocker.
+func (m *HealthBlockerModal) HasBlocker() bool {
+	snap := m.state.HealthSnapshot()
+	for _, f := range snap.Findings {
+		if f.Severity == health.SeverityBlocker {
+			return true
+		}
+	}
+	return false
+}
+
+// HandleUserInteractions processes button clicks. Called by the root UI
+// before Layout when the modal is visible.
+func (m *HealthBlockerModal) HandleUserInteractions(gtx layout.Context) {
+	if m.recheck.Clicked(gtx) && m.runNow != nil {
+		go m.runNow()
+	}
+	if m.quit.Clicked(gtx) && m.onQuit != nil {
+		m.onQuit()
+	}
+}
+
+// Layout renders the blocker modal as a full-screen overlay.
+func (m *HealthBlockerModal) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	snap := m.state.HealthSnapshot()
+	var blockers []health.Finding
+	for _, f := range snap.Findings {
+		if f.Severity == health.SeverityBlocker {
+			blockers = append(blockers, f)
+		}
+	}
+	if len(blockers) == 0 {
+		return layout.Dimensions{}
+	}
+	return layout.Stack{}.Layout(gtx,
+		layout.Expanded(func(gtx layout.Context) layout.Dimensions {
+			return FillBackground(gtx, th.Color.Overlay, func(gtx layout.Context) layout.Dimensions {
+				return layout.Dimensions{Size: gtx.Constraints.Min}
+			})
+		}),
+		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+			gtx.Constraints.Min = gtx.Constraints.Max
+			return layout.Center.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+				gtx.Constraints.Max.X = gtx.Dp(th.Dims.ModalWidth)
+				return widget.Border{
+					Color: th.Color.Err, Width: unit.Dp(2), CornerRadius: th.Radii.R3,
+				}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+					return RoundedFill(gtx, th.Color.Bg1, th.Radii.R3, func(gtx layout.Context) layout.Dimensions {
+						return layout.UniformInset(unit.Dp(20)).Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+							return m.layoutContent(gtx, th, blockers, snap.Running)
+						})
+					})
+				})
+			})
+		}),
+	)
+}
+
+func (m *HealthBlockerModal) layoutContent(gtx layout.Context, th *Theme, blockers []health.Finding, running bool) layout.Dimensions {
+	children := []layout.FlexChild{
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			lbl := material.Body2(th.Theme, fmt.Sprintf("Locorum can't run (%d issue%s):", len(blockers), pluralS(len(blockers))))
+			lbl.Color = th.Color.Err
+			lbl.TextSize = th.Sizes.H1
+			lbl.Font.Weight = font.SemiBold
+			return layout.Inset{Bottom: th.Spacing.MD}.Layout(gtx, lbl.Layout)
+		}),
+	}
+	for i, f := range blockers {
+		f := f
+		children = append(children, layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			top := th.Spacing.SM
+			if i == 0 {
+				top = 0
+			}
+			return layout.Inset{Top: top}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						lbl := material.Body2(th.Theme, f.Title)
+						lbl.Color = th.Color.Fg
+						lbl.TextSize = th.Sizes.Body
+						lbl.Font.Weight = font.SemiBold
+						return lbl.Layout(gtx)
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						if f.Detail == "" {
+							return layout.Dimensions{}
+						}
+						lbl := material.Body2(th.Theme, f.Detail)
+						lbl.Color = th.Color.Fg2
+						lbl.TextSize = th.Sizes.Body
+						return layout.Inset{Top: unit.Dp(2)}.Layout(gtx, lbl.Layout)
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						if f.Remediation == "" {
+							return layout.Dimensions{}
+						}
+						lbl := material.Body2(th.Theme, "→ "+f.Remediation)
+						lbl.Color = th.Color.Fg2
+						lbl.TextSize = th.Sizes.Mono
+						return layout.Inset{Top: unit.Dp(4)}.Layout(gtx, lbl.Layout)
+					}),
+				)
+			})
+		}))
+	}
+	children = append(children, layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+		return layout.Inset{Top: th.Spacing.LG}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+			return layout.Flex{Axis: layout.Horizontal, Spacing: layout.SpaceStart}.Layout(gtx,
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					return layout.Inset{Right: th.Spacing.SM}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+						return th.SmallGated(gtx, &m.recheck, "Re-check", !running)
+					})
+				}),
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					return DangerButton(gtx, th, &m.quit, "Quit")
+				}),
+			)
+		})
+	}))
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx, children...)
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// HealthBadgeKind is the styling key for the nav-rail badge.
+type HealthBadgeKind int
+
+const (
+	HealthBadgeNone    HealthBadgeKind = iota
+	HealthBadgeInfo                    // hidden in the rail; shown only in the panel
+	HealthBadgeWarn                    // amber
+	HealthBadgeBlocker                 // red
+)
+
+// HealthBadgeFor maps a snapshot onto the rail-badge styling. Returns
+// HealthBadgeNone when the snapshot has no findings or only Info-level
+// ones.
+func HealthBadgeFor(snap health.Snapshot) HealthBadgeKind {
+	hi := snap.HighestSeverity()
+	switch hi {
+	case health.SeverityBlocker:
+		return HealthBadgeBlocker
+	case health.SeverityWarn:
+		return HealthBadgeWarn
+	}
+	return HealthBadgeNone
+}
+
+// LayoutHealthBadge paints a small dot in the given foreground colour.
+// Used by the nav rail to flag the Settings entry. Caller is responsible
+// for positioning.
+func LayoutHealthBadge(gtx layout.Context, kind HealthBadgeKind, th *Theme) layout.Dimensions {
+	if kind == HealthBadgeNone || kind == HealthBadgeInfo {
+		return layout.Dimensions{}
+	}
+	col := th.Color.Warn
+	if kind == HealthBadgeBlocker {
+		col = th.Color.Err
+	}
+	return severityDot(gtx, col)
+}

--- a/internal/ui/navrail.go
+++ b/internal/ui/navrail.go
@@ -7,6 +7,7 @@ import (
 
 	"gioui.org/font"
 	"gioui.org/layout"
+	"gioui.org/op"
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
 	"gioui.org/unit"
@@ -187,6 +188,14 @@ func (n *NavRail) layoutNavItem(
 		textCol = th.Color.Fg
 		weight = font.Medium
 	}
+
+	// Settings entry shows the System Health badge — only it; other
+	// nav items don't carry health meaning.
+	badge := HealthBadgeNone
+	if key == NavViewSettings {
+		badge = HealthBadgeFor(n.state.HealthSnapshot())
+	}
+
 	if collapsed {
 		return layout.Inset{Bottom: unit.Dp(8)}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 			return layout.Center.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
@@ -194,12 +203,23 @@ func (n *NavRail) layoutNavItem(
 					pillSz := gtx.Dp(unit.Dp(48))
 					gtx.Constraints.Min = image.Pt(pillSz, pillSz)
 					gtx.Constraints.Max = image.Pt(pillSz, pillSz)
-					return RoundedFill(gtx, bg, th.Radii.R2, func(gtx layout.Context) layout.Dimensions {
-						gtx.Constraints.Min = image.Pt(pillSz, pillSz)
-						return layout.Center.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
-							return icon(gtx, th, unit.Dp(36), iconCol)
-						})
-					})
+					return layout.Stack{}.Layout(gtx,
+						layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+							return RoundedFill(gtx, bg, th.Radii.R2, func(gtx layout.Context) layout.Dimensions {
+								gtx.Constraints.Min = image.Pt(pillSz, pillSz)
+								return layout.Center.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+									return icon(gtx, th, unit.Dp(36), iconCol)
+								})
+							})
+						}),
+						layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+							if badge == HealthBadgeNone {
+								return layout.Dimensions{Size: image.Pt(pillSz, pillSz)}
+							}
+							gtx.Constraints.Min = image.Pt(pillSz, pillSz)
+							return layoutBadgeOverlay(gtx, badge, th)
+						}),
+					)
 				})
 			})
 		})
@@ -225,11 +245,31 @@ func (n *NavRail) layoutNavItem(
 								return lbl.Layout(gtx)
 							})
 						}),
+						layout.Flexed(1, func(gtx layout.Context) layout.Dimensions {
+							return layout.Dimensions{Size: image.Point{X: gtx.Constraints.Min.X}}
+						}),
+						layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+							return LayoutHealthBadge(gtx, badge, th)
+						}),
 					)
 				})
 			})
 		})
 	})
+}
+
+// layoutBadgeOverlay positions a badge dot in the top-right corner of
+// the surrounding pill (used by the collapsed rail). The pillSz is the
+// outer square's side length in pixels (already passed via Constraints.Min).
+func layoutBadgeOverlay(gtx layout.Context, badge HealthBadgeKind, th *Theme) layout.Dimensions {
+	pillSz := gtx.Constraints.Min.X
+	if pillSz == 0 {
+		pillSz = gtx.Constraints.Max.X
+	}
+	margin := gtx.Dp(unit.Dp(8))
+	off := image.Pt(pillSz-margin-gtx.Dp(unit.Dp(10)), margin-gtx.Dp(unit.Dp(2)))
+	defer op.Offset(off).Push(gtx.Ops).Pop()
+	return LayoutHealthBadge(gtx, badge, th)
 }
 
 // layoutGroups renders the "GROUPS" section header plus the three hardcoded

--- a/internal/ui/newsite.go
+++ b/internal/ui/newsite.go
@@ -1,12 +1,17 @@
 package ui
 
 import (
+	"sync"
+	"time"
+
+	"gioui.org/font"
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
 
 	"github.com/PeterBooker/locorum/internal/dbengine"
+	"github.com/PeterBooker/locorum/internal/platform"
 	"github.com/PeterBooker/locorum/internal/sites"
 	"github.com/PeterBooker/locorum/internal/types"
 )
@@ -61,6 +66,15 @@ type NewSiteModal struct {
 
 	keys *ModalFocus
 	anim *modalShowState
+
+	// Path-validation cache. The Layout pass reads notes; HandleUserInteractions
+	// debounces on the FilesDir value and re-runs ValidateSitePath off
+	// the goroutine started by the debounce timer. The mutex covers both.
+	pathMu      sync.Mutex
+	pathNotes   []sites.PathNote
+	pathTarget  string      // last value we ran validation against
+	pathTimer   *time.Timer // active debounce timer; nil between runs
+	pathPending string      // value to validate when the timer fires
 }
 
 func NewNewSiteModal(state *UIState, sm *sites.SiteManager, toasts *Notifications) *NewSiteModal {
@@ -135,6 +149,11 @@ func indexOfDBEngine(name string, kinds []dbengine.Kind) int {
 // Called by the root UI before Layout when the modal is visible.
 func (m *NewSiteModal) HandleUserInteractions(gtx layout.Context) {
 	keys := ProcessModalKeys(gtx, m.keys.Tag)
+
+	// Debounced path validation. Re-arm the timer whenever the field
+	// value moves; the validator runs at most once per 250 ms regardless
+	// of typing speed.
+	m.scheduleValidation(m.filesDirVal)
 
 	if m.cancelBtn.Clicked(gtx) || m.closeBtn.Clicked(gtx) || keys.Escape {
 		m.state.SetShowNewSiteModal(false)
@@ -232,6 +251,53 @@ func (m *NewSiteModal) HandleUserInteractions(gtx layout.Context) {
 	}
 }
 
+// scheduleValidation arms (or re-arms) the path-debounce timer. Pure-Go
+// validation runs in microseconds, but we still debounce so the UI doesn't
+// feel chatty during a paste. After 250 ms of quiescence the timer fires;
+// the goroutine recomputes notes off the UI loop and stores them, then
+// invalidates so Layout picks up the new content.
+func (m *NewSiteModal) scheduleValidation(target string) {
+	m.pathMu.Lock()
+	defer m.pathMu.Unlock()
+
+	if target == m.pathTarget {
+		return
+	}
+	m.pathPending = target
+	if m.pathTimer != nil {
+		m.pathTimer.Reset(250 * time.Millisecond)
+		return
+	}
+	m.pathTimer = time.AfterFunc(250*time.Millisecond, func() {
+		m.pathMu.Lock()
+		val := m.pathPending
+		m.pathTimer = nil
+		m.pathMu.Unlock()
+
+		var info *platform.Info
+		if platform.IsInitialized() {
+			info = platform.Get()
+		}
+		notes := sites.ValidateSitePath(val, info)
+
+		m.pathMu.Lock()
+		m.pathNotes = notes
+		m.pathTarget = val
+		m.pathMu.Unlock()
+
+		m.state.Invalidate()
+	})
+}
+
+// pathNotesSnapshot returns the current notes for the layout pass.
+func (m *NewSiteModal) pathNotesSnapshot() []sites.PathNote {
+	m.pathMu.Lock()
+	defer m.pathMu.Unlock()
+	out := make([]sites.PathNote, len(m.pathNotes))
+	copy(out, m.pathNotes)
+	return out
+}
+
 func slicesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -283,7 +349,14 @@ func (m *NewSiteModal) layoutForm(gtx layout.Context, th *Theme) layout.Dimensio
 		// Files Dir
 		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 			return layout.Inset{Bottom: th.Spacing.MD}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
-				return m.layoutDirPicker(gtx, th)
+				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return m.layoutDirPicker(gtx, th)
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return m.layoutPathNotes(gtx, th)
+					}),
+				)
 			})
 		}),
 		// Public Dir
@@ -342,6 +415,46 @@ func (m *NewSiteModal) layoutForm(gtx layout.Context, th *Theme) layout.Dimensio
 			)
 		}),
 	)
+}
+
+// layoutPathNotes renders the inline yellow validation notes beneath the
+// directory picker. Empty when there's nothing to warn about.
+func (m *NewSiteModal) layoutPathNotes(gtx layout.Context, th *Theme) layout.Dimensions {
+	notes := m.pathNotesSnapshot()
+	if len(notes) == 0 {
+		return layout.Dimensions{}
+	}
+	children := make([]layout.FlexChild, 0, len(notes))
+	for _, n := range notes {
+		n := n
+		children = append(children, layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			return layout.Inset{Top: th.Spacing.XS}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+				return RoundedFill(gtx, th.Color.WarnSoft, th.Radii.R2, func(gtx layout.Context) layout.Dimensions {
+					return layout.UniformInset(unit.Dp(8)).Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+							layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+								lbl := material.Body2(th.Theme, n.Title)
+								lbl.Color = th.Color.Warn
+								lbl.TextSize = th.Sizes.Body
+								lbl.Font.Weight = font.SemiBold
+								return lbl.Layout(gtx)
+							}),
+							layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+								if n.Detail == "" {
+									return layout.Dimensions{}
+								}
+								lbl := material.Body2(th.Theme, n.Detail)
+								lbl.Color = th.Color.Fg2
+								lbl.TextSize = th.Sizes.Body
+								return layout.Inset{Top: unit.Dp(2)}.Layout(gtx, lbl.Layout)
+							}),
+						)
+					})
+				})
+			})
+		}))
+	}
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx, children...)
 }
 
 func (m *NewSiteModal) layoutDirPicker(gtx layout.Context, th *Theme) layout.Dimensions {

--- a/internal/ui/settingspanel.go
+++ b/internal/ui/settingspanel.go
@@ -16,7 +16,8 @@ import (
 // SettingsPanel takes over columns 2+3 when the nav rail's Settings item
 // is active. Sections (top to bottom):
 //
-//   - Appearance:   theme picker (System / Light / Dark).
+//   - System Health:    runner findings + re-check.
+//   - Appearance:       theme picker (System / Light / Dark).
 //   - New site defaults: pre-fill values for the new-site modal.
 //   - Network & TLS:    router HTTP/HTTPS host ports + mkcert path.
 //
@@ -27,6 +28,7 @@ type SettingsPanel struct {
 	state         *UIState
 	sm            *sites.SiteManager
 	onThemeChange func(ThemeMode)
+	healthPanel   *HealthPanel
 
 	themeEnum widget.Enum
 	syncedTo  string // remembers which value we last seeded from settings
@@ -114,6 +116,11 @@ func NewSettingsPanel(state *UIState, sm *sites.SiteManager, onThemeChange func(
 	return s
 }
 
+// SetHealthPanel attaches the system-health panel renderer. Optional —
+// callers that don't wire a runner (early startup, tests) can leave it
+// nil and the section is omitted from the layout.
+func (s *SettingsPanel) SetHealthPanel(hp *HealthPanel) { s.healthPanel = hp }
+
 // HandleUserInteractions watches the theme picker for selection
 // changes, syncs the engine→version dropdown, and persists any changed
 // defaults.
@@ -128,6 +135,9 @@ func (s *SettingsPanel) HandleUserInteractions(gtx layout.Context) {
 	}
 	s.syncEngineVersionList()
 	s.persistDefaults(gtx)
+	if s.healthPanel != nil {
+		s.healthPanel.HandleUserInteractions(gtx)
+	}
 }
 
 // syncEngineVersionList updates the DB-version dropdown options when
@@ -266,6 +276,12 @@ func (s *SettingsPanel) Layout(gtx layout.Context, th *Theme) layout.Dimensions 
 						lbl.Font.Weight = font.SemiBold
 						return lbl.Layout(gtx)
 					})
+				}),
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					if s.healthPanel == nil {
+						return layout.Dimensions{}
+					}
+					return s.healthPanel.Layout(gtx, th)
 				}),
 				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 					return s.layoutAppearance(gtx, th)

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -2,11 +2,13 @@ package ui
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"gioui.org/app"
 
 	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/health"
 	"github.com/PeterBooker/locorum/internal/hooks"
 	"github.com/PeterBooker/locorum/internal/orch"
 	"github.com/PeterBooker/locorum/internal/storage"
@@ -125,6 +127,27 @@ type UIState struct {
 	// Aggregate health of the global services (router, mail, adminer).
 	// Polled from the main goroutine; written via SetServicesHealth.
 	servicesHealth ServicesHealth
+
+	// healthSnapshot is the latest snapshot from the health.Runner.
+	// Stored via atomic.Pointer so reads are lock-free; the UI Layout
+	// pass reads on every frame without contending with the runner.
+	healthSnapshot atomic.Pointer[health.Snapshot]
+
+	// healthSeen tracks the (per-finding-key) last-seen generation so
+	// we can decide whether to toast a freshly-published finding. Two
+	// concerns: cross-restart persistence (delegated to the config
+	// store via the syncHealthSeen method) and per-frame toast
+	// throttling. Guarded by healthSeenMu.
+	healthSeen      map[string]bool
+	healthSeenMu    sync.Mutex
+	healthFirstFire bool // true until the first snapshot publishes; suppresses
+	// the initial flood of toasts on app start so an upgrade doesn't bury
+	// the user in pre-existing-but-newly-detected findings.
+
+	// diskFreeBytes is the most recent host-filesystem free-byte reading
+	// surfaced by the disk-low check. Zero before the first reading.
+	// Guarded by mu (top-level UIState mutex) — same as servicesHealth.
+	diskFreeBytes int64
 }
 
 // activitySiteCache mirrors a slice of recent activity rows for one site.
@@ -188,13 +211,19 @@ type hookLine struct {
 }
 
 func NewUIState() *UIState {
-	return &UIState{
-		navView:        NavViewSites,
-		siteToggling:   make(map[string]bool),
-		hookState:      make(map[string]*hookSiteState),
-		lifecycleState: make(map[string]*lifecycleSiteState),
-		activityState:  make(map[string]*activitySiteCache),
+	s := &UIState{
+		navView:         NavViewSites,
+		siteToggling:    make(map[string]bool),
+		hookState:       make(map[string]*hookSiteState),
+		lifecycleState:  make(map[string]*lifecycleSiteState),
+		activityState:   make(map[string]*activitySiteCache),
+		healthSeen:      make(map[string]bool),
+		healthFirstFire: true,
 	}
+	// Publish an empty snapshot so the Layout pass never reads nil.
+	empty := health.Snapshot{}
+	s.healthSnapshot.Store(&empty)
+	return s
 }
 
 // ─── Navigation ─────────────────────────────────────────────────────────────
@@ -247,6 +276,102 @@ func (s *UIState) Invalidate() {
 	if w != nil {
 		w.Invalidate()
 	}
+}
+
+// ─── System health ──────────────────────────────────────────────────────────
+
+// SetHealthSnapshot publishes a new snapshot from the runner. Lock-free
+// (atomic.Pointer). Triggers a window invalidation so the Layout pass
+// picks up the new content on the next frame.
+//
+// Toast bookkeeping is delegated to the caller, which knows when first-fire
+// suppression should apply (see UIState.HealthShouldToast).
+func (s *UIState) SetHealthSnapshot(snap health.Snapshot) {
+	cp := snap
+	s.healthSnapshot.Store(&cp)
+	s.Invalidate()
+}
+
+// HealthSnapshot returns the most recently stored snapshot. Never nil
+// because NewUIState publishes an empty snapshot at construction time.
+func (s *UIState) HealthSnapshot() health.Snapshot {
+	v := s.healthSnapshot.Load()
+	if v == nil {
+		return health.Snapshot{}
+	}
+	return *v
+}
+
+// HealthShouldToast reports whether the given finding key has been seen
+// before in this process. The first call for any key returns true (the
+// caller should fire a toast); subsequent calls return false.
+//
+// Returns false during the first-fire window — the runner publishes the
+// initial snapshot but the UI suppresses toasts so a fresh install isn't
+// flooded.
+func (s *UIState) HealthShouldToast(key string) bool {
+	s.healthSeenMu.Lock()
+	defer s.healthSeenMu.Unlock()
+	if s.healthFirstFire {
+		s.healthSeen[key] = true
+		return false
+	}
+	if s.healthSeen[key] {
+		return false
+	}
+	s.healthSeen[key] = true
+	return true
+}
+
+// HealthClearFirstFire ends the first-fire suppression window. Called
+// once after the first snapshot finishes. Subsequent toasts behave normally.
+func (s *UIState) HealthClearFirstFire() {
+	s.healthSeenMu.Lock()
+	s.healthFirstFire = false
+	s.healthSeenMu.Unlock()
+}
+
+// HealthSeenKeys returns a snapshot of the seen-keys set, suitable for
+// JSON serialisation into the persistent settings table.
+func (s *UIState) HealthSeenKeys() []string {
+	s.healthSeenMu.Lock()
+	defer s.healthSeenMu.Unlock()
+	out := make([]string, 0, len(s.healthSeen))
+	for k := range s.healthSeen {
+		out = append(out, k)
+	}
+	return out
+}
+
+// HealthHydrateSeen seeds the seen-keys set from the persisted JSON. Idempotent.
+func (s *UIState) HealthHydrateSeen(keys []string) {
+	s.healthSeenMu.Lock()
+	for _, k := range keys {
+		s.healthSeen[k] = true
+	}
+	s.healthSeenMu.Unlock()
+}
+
+// SetDiskFreeBytes stores the most recent host-filesystem free-byte reading
+// for the top status bar. The runner publishes this via the disk-low check;
+// main.go pulls it out and pushes here on the same cadence the services-
+// health bar polls so the UI updates feel synchronous to the user.
+func (s *UIState) SetDiskFreeBytes(n int64) {
+	s.mu.Lock()
+	changed := s.diskFreeBytes != n
+	s.diskFreeBytes = n
+	s.mu.Unlock()
+	if changed {
+		s.Invalidate()
+	}
+}
+
+// DiskFreeBytes returns the cached host-filesystem free-byte reading.
+// Zero means "unknown" (typical until the first health cycle completes).
+func (s *UIState) DiskFreeBytes() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.diskFreeBytes
 }
 
 // ─── Services health ────────────────────────────────────────────────────────

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"image"
 
 	"gioui.org/font"
@@ -31,9 +32,10 @@ type UI struct {
 	Toasts     *Notifications
 
 	// Modals
-	CloneModal   *CloneModal
-	deleteDialog ConfirmDialog
-	deletePurge  widget.Bool
+	CloneModal    *CloneModal
+	HealthBlocker *HealthBlockerModal
+	deleteDialog  ConfirmDialog
+	deletePurge   widget.Bool
 
 	// Banner action button (e.g. "Set up trusted HTTPS").
 	noticeBtn widget.Clickable
@@ -129,6 +131,9 @@ func (ui *UI) HandleUserInteractions(gtx layout.Context) {
 	if show, _, _ := ui.State.GetCloneModalState(); show {
 		ui.CloneModal.HandleUserInteractions(gtx)
 	}
+	if ui.HealthBlocker != nil && ui.HealthBlocker.HasBlocker() {
+		ui.HealthBlocker.HandleUserInteractions(gtx)
+	}
 }
 
 func (ui *UI) Layout(gtx layout.Context) layout.Dimensions {
@@ -172,6 +177,15 @@ func (ui *UI) Layout(gtx layout.Context) layout.Dimensions {
 				return hp.LayoutModalLayer(gtx, ui.Theme)
 			}
 			return ui.CloneModal.Layout(gtx, ui.Theme)
+		}),
+		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+			// Health blocker overlays everything else when active —
+			// it represents "you can't use the app right now". Render
+			// after the regular modal layer so it sits on top.
+			if ui.HealthBlocker != nil && ui.HealthBlocker.HasBlocker() {
+				return ui.HealthBlocker.Layout(gtx, ui.Theme)
+			}
+			return layout.Dimensions{}
 		}),
 		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
 			return ui.Toasts.Layout(gtx, ui.Theme)
@@ -263,11 +277,13 @@ func (ui *UI) layoutErrorBanner(gtx layout.Context, msg string) layout.Dimension
 }
 
 // layoutTopBar paints the small "frame" bar above the three columns: app
-// name on the left, rolled-up services-health pill on the right.
+// name on the left, optional disk-free segment in the middle, and the
+// rolled-up services-health pill on the right.
 func (ui *UI) layoutTopBar(gtx layout.Context) layout.Dimensions {
 	th := ui.Theme
 	h := ui.State.ServicesHealthSnapshot()
 	statusKey, statusLabel := topBarStatusKeyLabel(h)
+	diskFree := ui.State.DiskFreeBytes()
 
 	return FillBackground(gtx, th.Color.Bg1, func(gtx layout.Context) layout.Dimensions {
 		return layout.Stack{}.Layout(gtx,
@@ -289,6 +305,14 @@ func (ui *UI) layoutTopBar(gtx layout.Context) layout.Dimensions {
 							return layout.Dimensions{Size: image.Point{X: gtx.Constraints.Min.X}}
 						}),
 						layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+							if diskFree <= 0 {
+								return layout.Dimensions{}
+							}
+							return layout.Inset{Right: th.Spacing.MD}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+								return ui.layoutTopBarDisk(gtx, th, diskFree)
+							})
+						}),
+						layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 							return topBarStatus(gtx, th, statusKey, statusLabel)
 						}),
 					)
@@ -299,6 +323,41 @@ func (ui *UI) layoutTopBar(gtx layout.Context) layout.Dimensions {
 			}),
 		)
 	})
+}
+
+// layoutTopBarDisk renders the cached host-filesystem free-bytes reading
+// as a "Disk: 12 GB" mono label. Hidden when no reading is available.
+func (ui *UI) layoutTopBarDisk(gtx layout.Context, th *Theme, free int64) layout.Dimensions {
+	lbl := material.Body2(th.Theme, "Disk: "+formatBytes(free))
+	lbl.Color = th.Color.Fg3
+	lbl.TextSize = th.Sizes.Micro
+	lbl.Font = MonoFont
+	lbl.Font.Weight = font.Medium
+	return lbl.Layout(gtx)
+}
+
+// formatBytes renders byte counts as a short, status-bar-friendly string.
+// Mirrors health.humanBytes. Decimal precision drops once values reach
+// triple digits so the segment width stays roughly stable as numbers grow.
+func formatBytes(n int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+		TB = GB * 1024
+	)
+	switch {
+	case n >= TB:
+		return fmt.Sprintf("%.1f TB", float64(n)/float64(TB))
+	case n >= GB:
+		return fmt.Sprintf("%.0f GB", float64(n)/float64(GB))
+	case n >= MB:
+		return fmt.Sprintf("%.0f MB", float64(n)/float64(MB))
+	case n >= KB:
+		return fmt.Sprintf("%.0f KB", float64(n)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }
 
 // topBarStatusKeyLabel maps the rolled-up health snapshot onto a status

--- a/internal/version/images.go
+++ b/internal/version/images.go
@@ -1,5 +1,10 @@
 package version
 
+import (
+	"strconv"
+	"strings"
+)
+
 // Pinned Docker images used by Locorum. Centralised so upgrades are atomic
 // across the codebase and integration tests pin to the same versions.
 const (
@@ -17,3 +22,80 @@ const (
 	RedisImagePrefix    = "redis:"
 	RedisImageSuffix    = "-alpine"
 )
+
+// MinSupportedDockerServerMajor / MinSupportedDockerServerMinor are the
+// Docker daemon version below which we surface a "Docker too old" warning
+// in the system-health panel. Engine versions ≥ 24.0 carry the BuildKit
+// + healthcheck features Locorum relies on; older daemons still mostly
+// work but ship subtle incompatibilities (esp. with Compose v2 and the
+// modern image SBOM). 24.0 dropped 2023-06; almost three years of slack.
+const (
+	MinSupportedDockerServerMajor = 24
+	MinSupportedDockerServerMinor = 0
+)
+
+// DockerServerVersion is a parsed Major.Minor.Patch view of a daemon's
+// `ServerVersion` string. We hand-roll this rather than pulling in a
+// semver library — the daemon's reported version is always in
+// `<major>.<minor>.<patch>` shape (Docker's own VERSION file enforces it
+// across the moby/docker repo).
+type DockerServerVersion struct {
+	Major, Minor, Patch int
+	Suffix              string // any non-numeric trailer (e.g. "-rc1", "-dev")
+}
+
+// IsZero reports whether v is the unparsed zero value.
+func (v DockerServerVersion) IsZero() bool {
+	return v.Major == 0 && v.Minor == 0 && v.Patch == 0 && v.Suffix == ""
+}
+
+// LessThan reports whether v < (major.minor) (patch is ignored for the
+// minimum-version gate; we never want to warn over a patch-level bump).
+func (v DockerServerVersion) LessThan(major, minor int) bool {
+	if v.Major != major {
+		return v.Major < major
+	}
+	return v.Minor < minor
+}
+
+// ParseDockerServer splits a Docker daemon ServerVersion string into a
+// DockerServerVersion. Returns the zero value plus the original string as
+// .Suffix when parsing fails — callers can use IsZero() to detect that.
+//
+// Accepted shapes (Docker's actual outputs over the years):
+//
+//	"24.0.7"          → 24, 0, 7
+//	"25.0.3-rc1"      → 25, 0, 3, suffix "-rc1"
+//	"20.10.21+azure"  → 20, 10, 21, suffix "+azure"
+//	"dev"             → zero value, suffix "dev"
+func ParseDockerServer(s string) DockerServerVersion {
+	out := DockerServerVersion{}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return out
+	}
+	// Split on the first non-digit-non-dot byte. Everything to the right
+	// is the suffix; everything to the left is the dotted version triple.
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if (c >= '0' && c <= '9') || c == '.' {
+			i++
+			continue
+		}
+		break
+	}
+	num := s[:i]
+	out.Suffix = s[i:]
+	parts := strings.Split(num, ".")
+	if len(parts) >= 1 {
+		out.Major, _ = strconv.Atoi(parts[0])
+	}
+	if len(parts) >= 2 {
+		out.Minor, _ = strconv.Atoi(parts[1])
+	}
+	if len(parts) >= 3 {
+		out.Patch, _ = strconv.Atoi(parts[2])
+	}
+	return out
+}

--- a/internal/version/images_test.go
+++ b/internal/version/images_test.go
@@ -1,0 +1,60 @@
+package version
+
+import "testing"
+
+func TestParseDockerServer(t *testing.T) {
+	cases := []struct {
+		in    string
+		major int
+		minor int
+		patch int
+		suff  string
+	}{
+		{"24.0.7", 24, 0, 7, ""},
+		{"25.0.3-rc1", 25, 0, 3, "-rc1"},
+		{"20.10.21+azure", 20, 10, 21, "+azure"},
+		{"27.3", 27, 3, 0, ""},
+		{"  18.09.6  ", 18, 9, 6, ""},
+		{"", 0, 0, 0, ""},
+		{"dev", 0, 0, 0, "dev"},
+	}
+	for _, c := range cases {
+		got := ParseDockerServer(c.in)
+		if got.Major != c.major || got.Minor != c.minor || got.Patch != c.patch || got.Suffix != c.suff {
+			t.Errorf("ParseDockerServer(%q) = %+v; want major=%d minor=%d patch=%d suffix=%q", c.in, got, c.major, c.minor, c.patch, c.suff)
+		}
+	}
+}
+
+func TestDockerServerVersionLessThan(t *testing.T) {
+	cases := []struct {
+		v      DockerServerVersion
+		mj, mn int
+		want   bool
+	}{
+		{DockerServerVersion{23, 0, 5, ""}, 24, 0, true},
+		{DockerServerVersion{24, 0, 0, ""}, 24, 0, false},
+		{DockerServerVersion{24, 0, 7, ""}, 24, 0, false},
+		{DockerServerVersion{25, 0, 0, ""}, 24, 0, false},
+		{DockerServerVersion{24, 0, 0, ""}, 25, 0, true},
+		{DockerServerVersion{20, 10, 21, ""}, 24, 0, true},
+	}
+	for _, c := range cases {
+		got := c.v.LessThan(c.mj, c.mn)
+		if got != c.want {
+			t.Errorf("(%+v).LessThan(%d, %d) = %v; want %v", c.v, c.mj, c.mn, got, c.want)
+		}
+	}
+}
+
+func TestDockerServerVersionIsZero(t *testing.T) {
+	if !(DockerServerVersion{}).IsZero() {
+		t.Error("zero value should be IsZero")
+	}
+	if (DockerServerVersion{Major: 1}).IsZero() {
+		t.Error("non-zero major should NOT be IsZero")
+	}
+	if (DockerServerVersion{Suffix: "dev"}).IsZero() {
+		t.Error("a parsed but text-only version should NOT be IsZero")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"log"
 	"log/slog"
 	"os"
@@ -17,7 +18,9 @@ import (
 	application "github.com/PeterBooker/locorum/internal/app"
 	settings "github.com/PeterBooker/locorum/internal/config"
 	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/health"
 	"github.com/PeterBooker/locorum/internal/hooks"
+	"github.com/PeterBooker/locorum/internal/platform"
 	"github.com/PeterBooker/locorum/internal/router/traefik"
 	"github.com/PeterBooker/locorum/internal/sites"
 	"github.com/PeterBooker/locorum/internal/storage"
@@ -31,11 +34,21 @@ import (
 var config embed.FS
 
 func main() {
+	// Hard-fail before Gio loads if we're an amd64 binary translated by
+	// Rosetta on Apple Silicon. See preflight_darwin.go.
+	runPreflight()
+
 	slog.Info("starting Locorum", "version", version.Version, "commit", version.Commit, "date", version.Date)
 
+	// Identify the host once. platform.Get() is then safe to call from
+	// any goroutine for the rest of the process lifetime.
+	plat := platform.Init(context.Background())
+
 	// On WSL2, force the X11 backend. WSLg's Wayland compositor does not
-	// fully support window-management actions (minimize/maximize).
-	if _, ok := os.LookupEnv("WSL_DISTRO_NAME"); ok {
+	// fully support window-management actions (minimize/maximize). The
+	// canonical signal lives in platform.Get().WSL.Active — we still
+	// branch on it before Gio touches the display.
+	if plat.WSL.Active {
 		os.Unsetenv("WAYLAND_DISPLAY")
 		os.Setenv("GSETTINGS_BACKEND", "memory")
 		if _, ok := os.LookupEnv("DBUS_SESSION_BUS_ADDRESS"); !ok {
@@ -104,6 +117,61 @@ func main() {
 
 	userInterface := ui.New(sm)
 
+	// Hydrate the toast-suppression set from the persisted JSON so we
+	// don't re-toast findings the user already saw on a previous run.
+	if raw := cfg.HealthLastSeen(); raw != "" {
+		var keys []string
+		if err := json.Unmarshal([]byte(raw), &keys); err == nil {
+			userInterface.State.HealthHydrateSeen(keys)
+		}
+	}
+
+	// System Health runner. Wire it now so the UI can subscribe — the
+	// runner's own loop won't tick until Start, which we defer until
+	// Initialize completes.
+	mkcertInstaller := func(ctx context.Context) error {
+		return mkcert.InstallCA(ctx)
+	}
+	runner := newHealthRunner(plat, d, mkcert, mkcertInstaller, sm, cfg, homeDir)
+	defer runner.Close()
+
+	if cfg.HealthEnabled() {
+		// Subscribe before Start so the very first publication propagates
+		// to the UI. The callback runs on the runner goroutine; it
+		// pushes the snapshot into UIState (atomic) and triggers an
+		// invalidate.
+		runner.Subscribe(func(snap health.Snapshot) {
+			userInterface.State.SetHealthSnapshot(snap)
+			// Toasts: fire one per never-seen-before warning or blocker.
+			// Info-level findings appear in the panel only — toast spam
+			// from the steady-state "your provider is Docker Desktop"
+			// row would burn out the user's attention.
+			for _, f := range snap.Findings {
+				if f.Severity == health.SeverityInfo {
+					continue
+				}
+				key := f.ID + "|" + f.DedupKey
+				if !userInterface.State.HealthShouldToast(key) {
+					continue
+				}
+				userInterface.Toasts.Add(f.Title, toastVariantFor(f.Severity))
+			}
+			// Push the latest disk-free reading into the top-bar
+			// segment. Cheap; runs on every publish.
+			userInterface.State.SetDiskFreeBytes(runner.DiskFreeBytes())
+		})
+		// Wire the System Health panel into Settings and the blocker
+		// modal into the root UI.
+		submit := func(id string, a health.Action) error {
+			return runner.SubmitAction(context.Background(), id, a, nil)
+		}
+		runNow := func() { runner.RunNow(context.Background()) }
+		userInterface.Settings.SetHealthPanel(ui.NewHealthPanel(userInterface.State, submit, runNow))
+		userInterface.HealthBlocker = ui.NewHealthBlockerModal(userInterface.State, runNow, func() {
+			os.Exit(0)
+		})
+	}
+
 	initFunc := func() {
 		d.SetClient(a.GetClient())
 
@@ -133,6 +201,21 @@ func main() {
 		}
 
 		refreshTLSNotice(mkcert, userInterface.State)
+
+		// Start the runner once the docker client is ready. Pre-init
+		// startup would have most checks fail loudly (Ping, ProviderInfo)
+		// and pollute the UI on first frame.
+		if cfg.HealthEnabled() {
+			runner.Start(context.Background())
+			// First-fire window: the runner's initial snapshot is
+			// suppressed for toasts. After it lands, normal toast
+			// behaviour resumes.
+			go func() {
+				time.Sleep(2 * time.Second)
+				userInterface.State.HealthClearFirstFire()
+				persistHealthSeen(cfg, userInterface.State)
+			}()
+		}
 
 		userInterface.State.SetInitDone()
 	}
@@ -169,11 +252,70 @@ func main() {
 		}
 
 		_ = a.Shutdown(context.Background())
+		// Persist the seen-keys set so the next process doesn't re-toast
+		// findings the user already dismissed. Best effort.
+		persistHealthSeen(cfg, userInterface.State)
 		st.Close()
 		os.Exit(0)
 	}()
 
 	app.Main()
+}
+
+// newHealthRunner builds the production runner with the bundled checks.
+// Cadence and thresholds come from the user's config; missing keys fall
+// back to documented defaults.
+func newHealthRunner(plat *platform.Info, d *docker.Docker, mkcert *tlspkg.Mkcert, mkInstaller func(context.Context) error, sm *sites.SiteManager, cfg *settings.Config, homeDir string) *health.Runner {
+	cadence := time.Duration(cfg.HealthCadenceMinutes()) * time.Minute
+	if cadence <= 0 {
+		cadence = 5 * time.Minute
+	}
+	const gb = int64(1024 * 1024 * 1024)
+	checks := health.Bundled(health.BundledOpts{
+		Platform:            plat,
+		Engine:              d,
+		Mkcert:              mkcert,
+		MkcertInstaller:     mkInstaller,
+		Sites:               sm,
+		HostStatfsPath:      homeDir,
+		RouterContainerName: traefik.ContainerName,
+		DiskWarnBytes:       int64(cfg.HealthDiskWarnGB()) * gb,
+		DiskBlockerBytes:    int64(cfg.HealthDiskBlockerGB()) * gb,
+	})
+	return health.NewRunner(health.Options{
+		MinCadence: cadence,
+		Logger:     slog.With("subsys", "health"),
+	}, checks...)
+}
+
+// toastVariantFor maps a finding severity onto the existing notification
+// type. The notifications system has Error / Success / Info; Warn maps to
+// Error so warnings catch the user's eye but don't stick as long as a
+// blocker (the blocker modal handles persistence). Info-level findings
+// don't toast at all (filtered above).
+func toastVariantFor(s health.Severity) ui.NotificationType {
+	switch s {
+	case health.SeverityBlocker, health.SeverityWarn:
+		return ui.NotificationError
+	}
+	return ui.NotificationInfo
+}
+
+// persistHealthSeen writes the current toast-suppression set to the
+// persistent settings table. Idempotent; failures are logged at warn.
+func persistHealthSeen(cfg *settings.Config, state *ui.UIState) {
+	if cfg == nil || state == nil {
+		return
+	}
+	keys := state.HealthSeenKeys()
+	body, err := json.Marshal(keys)
+	if err != nil {
+		slog.Warn("health: marshal last_seen", "err", err.Error())
+		return
+	}
+	if err := cfg.SetHealthLastSeen(string(body)); err != nil {
+		slog.Warn("health: persist last_seen", "err", err.Error())
+	}
 }
 
 // refreshTLSNotice reads the current mkcert status and updates the banner.

--- a/preflight_darwin.go
+++ b/preflight_darwin.go
@@ -1,0 +1,91 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// runPreflight is the very first thing main() does on darwin: it traps the
+// case where someone has installed the amd64 build of Locorum on an Apple
+// Silicon Mac. Rosetta translates the binary, and Docker SDK calls
+// subsequently fail with cryptic messages about platform mismatch.
+//
+// We hard-fail here — the user can't usefully recover from inside a
+// translated process. Showing a native modal (via osascript so we don't
+// have to link AppKit and pull cgo into preflight) gives the user a clear
+// "reinstall the arm64 build" path; falling through to stderr keeps the
+// command-line case usable.
+//
+// Exit code 78 is sysexits(3) EX_CONFIG — a configuration error the user
+// must fix before retrying.
+func runPreflight() {
+	// Only the amd64 binary can be Rosetta-translated. arm64 binaries
+	// always run native; intel Macs report the sysctl as missing.
+	if runtime.GOARCH != "amd64" {
+		return
+	}
+	if !readProcTranslated() {
+		return
+	}
+
+	const exitConfig = 78
+	msg := "Locorum: this is the Intel (amd64) build, but it is being translated by Rosetta on an Apple Silicon Mac.\n" +
+		"Docker performance and container compatibility are unreliable in this configuration.\n\n" +
+		"Please reinstall the arm64 (Apple Silicon) build."
+
+	// stderr always — even if the modal works, the CLI user wants to see why.
+	_, _ = fmt.Fprintln(os.Stderr, msg)
+
+	// Best-effort native modal. Failure (osascript missing, sandbox
+	// blocking, anything) is intentionally swallowed — we already have
+	// a stderr message and we'd rather exit cleanly than panic on a
+	// platform-detection helper.
+	showRosettaModal(msg)
+
+	os.Exit(exitConfig)
+}
+
+// readProcTranslated calls /usr/sbin/sysctl directly so we don't pull in
+// cgo or unsafe SDK constants. The sysctl returns "1" when the running
+// process is Rosetta-translated.
+//
+// Bound by a 1-second context: if sysctl hangs (it shouldn't, but defence
+// in depth) we treat it as "not translated" and proceed. Worse outcome of
+// a false negative: the regular Rosetta health check fires after Gio loads.
+func readProcTranslated() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/usr/sbin/sysctl", "-n", "sysctl.proc_translated")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "1"
+}
+
+// showRosettaModal displays a native macOS alert via osascript. We pin the
+// path to /usr/bin/osascript so a $PATH override can't substitute a
+// malicious binary. The argument is a constant string — user input never
+// reaches it — so AppleScript injection is not a concern.
+//
+// 5-second timeout: the user only needs to see "this won't work"; the
+// process is exiting either way.
+func showRosettaModal(message string) {
+	// AppleScript treats double quotes in the body specially; we don't
+	// inject any user input into the message, so a constant escape pass
+	// is enough.
+	escaped := strings.ReplaceAll(message, `"`, `\"`)
+	script := `display alert "Locorum can't run under Rosetta" message "` + escaped + `" as critical`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/usr/bin/osascript", "-e", script)
+	_ = cmd.Run()
+}

--- a/preflight_other.go
+++ b/preflight_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package main
+
+// runPreflight is the non-darwin stub. Rosetta is macOS-only; other
+// platforms have their own pre-init concerns (the Wayland/X11 switch
+// for WSL) but those are handled inside main() proper.
+func runPreflight() {}


### PR DESCRIPTION
# Cross-platform & system-health foundation

Implements the plan in `CROSS-PLATFORM.md`: honest, performant, secure
behaviour across native Linux, native Windows, WSL2, and macOS (Intel +
Apple Silicon, multiple Docker providers).

## What changes for the user

- **System Health panel** in Settings — every detected issue with title,
  detail, remediation, and (where applicable) a one-click fix. Re-check
  on demand.
- **Nav-rail badge** flags blockers (red) or warnings (amber) at a glance.
- **Blocker modal** intercepts the UI on the very first frame when
  Locorum can't usefully run (Docker down, Rosetta translation, etc.).
- **Top-bar disk segment** shows host filesystem free bytes.
- **New-site modal** warns inline (debounced) about `/mnt/c/...` slow
  paths under WSL and Windows MAX_PATH risk.
- **Rosetta hard-fail** on macOS amd64 builds running under translation
  — native modal + clean exit, before Gio loads.

## What changes under the hood

| New | Purpose |
|---|---|
| `internal/platform/` | Immutable host snapshot: OS/Arch/WSL/Rosetta, sanitised username (NFKC + fuzz-tested), `DockerPath`, `IsLongPath`, `IsMntC`, `HostFreeBytes`. Pure Go, leaf dep. |
| `internal/health/` | Runner with `atomic.Pointer[Snapshot]`, bounded executor, per-ID re-entrancy, circuit breaker, dedup with first-seen preservation. 9 bundled checks. |
| `preflight_{darwin,other}.go` | Apple Silicon Rosetta preflight. |
| `internal/docker/engine_disk.go` | `system df` wrapped in singleflight. |
| `internal/sites/validate.go` | Pure path validator for the new-site modal. |
| `internal/ui/healthpanel.go` | System Health panel + blocker modal + badge. |

| Extended | Why |
|---|---|
| `internal/docker/engine_provider.go` | Adds parsed server version (`ServerVersionP`) and a one-shot warn log on parse failure. |
| `internal/docker/{engine_container,oneshot,engine_chown}.go` | All bind sources route through `platform.DockerPath`; backslashes can no longer leak into Docker on a Linux build host. |
| `internal/router/traefik/traefik.go` | Same DockerPath discipline for the router's binds. |
| `internal/config/` | New `health.*` settings + typed accessors. |
| `internal/ui/state.go` | `health.Snapshot` via `atomic.Pointer`; per-frame lock-free reads. |
| `main.go` | Runner construction + subscribe wiring; replaces the inline `WSL_DISTRO_NAME` Wayland-switch with `platform.Get().WSL.Active`. |

## Concurrency & performance

- `platform.Info` is immutable post-`Init`; reads need no lock.
- `health.Snapshot` is published via `atomic.Pointer`; UI reads are
  lock-free per frame.
- Lock hierarchy is documented and enforced: no goroutine holds two of
  `UIState.mu` / runner mutex / `Docker.pmu` at once.
- Each check has a per-call deadline (`Budget`); 3 over-budget breaches
  suspend the check for one cycle.
- Disk-usage check (slow `system df`) is gated by a circuit breaker (3
  timeouts → open for 1 hour) and singleflight-deduped.
- Action executor: max 4 concurrent, max 1 per finding-ID, 30s default
  timeout.

## Security

- Shell-outs (`wslinfo`, `osascript`, `sysctl`) resolved via
  `exec.LookPath` or pinned absolute paths; no user input ever reaches
  a shell command.
- Username sanitiser: NFKC → strip combining marks → restrict to
  `^[a-z][a-z0-9._-]*$`, length-capped at 32. `\`, `/`, whitespace
  → `-`. Idempotent. Fuzzed (2.5M execs, no failures).
- Port probe is non-binding (`net.DialTimeout`); no TOCTOU.
- Findings only originate from registered in-tree checks; actions are
  bounded.

## Tests

- All 19 packages pass under `go test ./...`.
- `FuzzSanitiseUsername` keeps the contract regex stable across changes.
- `dockerpath_audit_test.go` walks every spec builder + the central
  `buildMounts` and fails on any unwrapped backslash — replacement for
  the manual ToSlash audit.
- Bundled checks have direct table-driven tests using the fake engine.
- Runner tests cover dedup, sort order, over-budget envelope,
  re-entrancy, breaker state machine, subscribe/unsubscribe.

## Migration

- New `health.*` settings rows with documented defaults; no schema
  change.
- First run after upgrade suppresses the toast flood (the very first
  snapshot's findings are recorded as "seen" rather than toasted).
- `health.enabled=false` hides the entire surface (badge, modal,
  toasts, panel) — disable switch is an instant rollback if needed.
- `gofmt -l .` clean, `go vet ./...` clean, `go install .` succeeds.
