### PR TITLE
Implement Agent Support

### DIFF
--- a/daemon_setup.go
+++ b/daemon_setup.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	application "github.com/PeterBooker/locorum/internal/app"
+	"github.com/PeterBooker/locorum/internal/cli"
+	"github.com/PeterBooker/locorum/internal/daemon"
+	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/sites"
+	"github.com/PeterBooker/locorum/internal/version"
+)
+
+// dispatchCLI is called at the top of main(). When the args declare a
+// CLI subcommand (other than `daemon`, which still runs the GUI-less
+// daemon main), we run the CLI dispatcher and exit with its code.
+//
+// Returns true when main() should exit; the caller is responsible for
+// os.Exit so deferred cleanup in main() is allowed to fire (today there
+// is none, but the contract keeps the door open).
+func dispatchCLI() (int, bool) {
+	args := os.Args
+	if len(args) < 2 {
+		return 0, false
+	}
+	if args[1] == "daemon" {
+		// daemon mode is handled by the normal main path; signal to
+		// the caller that we want to keep going but tag ourselves as
+		// "this is a daemon, no GUI."
+		return 0, false
+	}
+	if !cli.IsCLIInvocation(args) {
+		return 0, false
+	}
+	env := cli.NewEnv(args, version.Version)
+	code, _ := cli.Dispatch(args[1:], env)
+	return int(code), true
+}
+
+// isDaemonMode reports whether this process is meant to come up
+// without a GUI window. Two paths get here: the user explicitly typed
+// `locorum daemon`, and the auto-spawn from a CLI client (which sets
+// LOCORUM_DAEMON_MODE=1).
+func isDaemonMode() bool {
+	if daemon.IsDaemonAutoSpawn() {
+		return true
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "daemon" {
+		return true
+	}
+	return false
+}
+
+// startDaemonServices acquires the owner-lock and binds the IPC
+// listener. Returns the lock + server so the caller can defer their
+// shutdown. Errors here are non-fatal in GUI mode (we still want the
+// window to open if the user can't run multiple Locorum at once on a
+// shared machine), but are fatal in daemon mode (no IPC = nothing for
+// the CLI to talk to).
+func startDaemonServices(ctx context.Context, homeDir string, sm *sites.SiteManager) (*daemon.Lock, *daemon.Server, error) {
+	if err := daemon.EnsureStateDir(homeDir); err != nil {
+		return nil, nil, err
+	}
+
+	lock, err := daemon.Acquire(daemon.Path(homeDir), version.Version)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ln, err := daemon.Listen(daemon.SocketPath(homeDir))
+	if err != nil {
+		_ = lock.Release()
+		return nil, nil, err
+	}
+
+	srv := daemon.NewServer(ln, slog.With("subsys", "ipc"))
+	daemon.RegisterMethods(srv, sm)
+
+	go func() {
+		if err := srv.Serve(ctx); err != nil {
+			slog.Warn("ipc server stopped", "err", err.Error())
+		}
+	}()
+
+	slog.Info("daemon ipc bound", "socket", ln.Addr())
+	return lock, srv, nil
+}
+
+// runHeadlessDaemon blocks until SIGTERM/SIGINT or ctx cancel. Used in
+// daemon mode where we have no Gio window event loop to keep the
+// process alive.
+func runHeadlessDaemon(ctx context.Context) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	select {
+	case <-ctx.Done():
+	case sig := <-ch:
+		slog.Info("daemon received signal, shutting down", "signal", sig.String())
+	}
+}
+
+// runDaemonMode is the main loop for `locorum daemon` and the
+// auto-spawn path. It mirrors initFunc / app.Main from the GUI flow
+// without the Gio window: acquire lock, run app.Initialize, bind IPC,
+// block on signal, tear down.
+//
+// Errors during init are fatal here — the daemon has nothing to fall
+// back on, unlike the GUI which still has a usable window if Docker is
+// down.
+func runDaemonMode(homeDir string, sm *sites.SiteManager, a *application.App, d *docker.Docker) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lock, srv, err := startDaemonServices(ctx, homeDir, sm)
+	if err != nil {
+		reportLockError(err)
+		os.Exit(2)
+	}
+	defer func() {
+		srv.Shutdown(2 * time.Second)
+		_ = lock.Release()
+	}()
+
+	d.SetClient(a.GetClient())
+	if err := a.Initialize(ctx); err != nil {
+		slog.Error("daemon initialize failed", "err", err.Error())
+		os.Exit(1)
+	}
+	if err := sm.ReconcileState(); err != nil {
+		slog.Warn("reconcile state failed", "err", err.Error())
+	}
+
+	slog.Info("daemon ready")
+	runHeadlessDaemon(ctx)
+
+	if err := a.Shutdown(context.Background()); err != nil {
+		slog.Warn("daemon shutdown error", "err", err.Error())
+	}
+}
+
+// reportLockError logs whichever specific error a lock acquisition
+// failure produced. The CLI wants the precise daemon owner (pid +
+// start time); GUI mode logs and continues without IPC.
+func reportLockError(err error) {
+	var lockErr *daemon.ErrLocked
+	if errors.As(err, &lockErr) {
+		slog.Warn("another locorum daemon is running",
+			"pid", lockErr.Owner.PID,
+			"started_at", lockErr.Owner.StartedAt,
+			"version", lockErr.Owner.Version)
+		return
+	}
+	slog.Error("failed to acquire daemon lock", "err", err.Error())
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,254 @@
+// Package cli implements Locorum's command-line surface. The same
+// binary that runs the GUI parses os.Args before app.Main() and
+// dispatches a CLI subcommand here when one is recognised. Every
+// mutating command in this package shells JSON-RPC over the IPC socket
+// to the daemon — this package never talks to Docker / SQLite directly.
+//
+// Output rules:
+//   - Tables go to stdout, errors to stderr.
+//   - Exit codes are documented per command (0 = success, 1 = error,
+//     2 = invalid usage, 3 = no daemon).
+//   - --json prints JSON-encoded results, suitable for scripting.
+//   - NO_COLOR and a non-TTY stdout both suppress ANSI sequences.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+	"github.com/PeterBooker/locorum/internal/utils"
+)
+
+// ExitCode classifies the outcome of a CLI invocation. Numeric values
+// are part of the public contract — scripts depend on them.
+type ExitCode int
+
+const (
+	ExitOK         ExitCode = 0
+	ExitError      ExitCode = 1
+	ExitUsage      ExitCode = 2
+	ExitNoDaemon   ExitCode = 3
+	ExitNotFound   ExitCode = 4
+	ExitForbidden  ExitCode = 5
+	ExitConflict   ExitCode = 6
+	ExitNotStarted ExitCode = 7
+)
+
+// errToExit also maps CodeConflict.
+
+// Env carries every dependency a CLI command needs. Constructed once
+// per invocation by main.go; injected into every subcommand so tests
+// can capture stdout/stderr without process-global state.
+type Env struct {
+	Stdout  io.Writer
+	Stderr  io.Writer
+	Args    []string // arguments AFTER the subcommand keyword
+	HomeDir string
+	ExePath string // absolute path to the locorum binary, for auto-spawn
+	Version string
+}
+
+// Command is the runtime contract every subcommand satisfies.
+type Command interface {
+	Name() string
+	Synopsis() string
+	Run(ctx context.Context, env *Env) ExitCode
+}
+
+// commands lists the recognised subcommands in display order. Adding a
+// new one means appending here AND the corresponding switch in
+// Dispatch.
+var commands = []struct {
+	name    string
+	summary string
+}{
+	{"site", "list / describe / start / stop / wp"},
+	{"snapshot", "list / create / restore"},
+	{"hook", "list / run"},
+	{"mcp", "MCP server (stdio) for AI agents"},
+	{"daemon", "run a headless daemon (no GUI)"},
+	{"version", "print build identity"},
+	{"help", "show this help"},
+}
+
+// Dispatch is the entry point called by main.go when os.Args[1] looks
+// like a CLI subcommand. Returns true if the args were consumed (the
+// caller exits with the returned code); false means "no subcommand
+// recognised, continue to GUI."
+func Dispatch(args []string, env *Env) (ExitCode, bool) {
+	if len(args) == 0 {
+		return ExitOK, false
+	}
+	verb := args[0]
+	if !isCLIVerb(verb) {
+		return ExitOK, false
+	}
+
+	ctx, stop := signalContext()
+	defer stop()
+
+	subEnv := *env
+	subEnv.Args = args[1:]
+
+	switch verb {
+	case "site":
+		return runSite(ctx, &subEnv), true
+	case "snapshot":
+		return runSnapshot(ctx, &subEnv), true
+	case "hook":
+		return runHook(ctx, &subEnv), true
+	case "mcp":
+		return runMCP(ctx, &subEnv), true
+	case "daemon":
+		return ExitOK, false // daemon mode is handled in main.go
+	case "version":
+		return runVersion(&subEnv), true
+	case "help", "-h", "--help":
+		printHelp(env.Stdout, env.Version)
+		return ExitOK, true
+	default:
+		fmt.Fprintf(env.Stderr, "locorum: unknown command %q\n", verb)
+		printHelp(env.Stderr, env.Version)
+		return ExitUsage, true
+	}
+}
+
+// isCLIVerb reports whether os.Args[1] looks like a CLI verb. Used by
+// main.go to decide whether to skip Gio bring-up.
+func isCLIVerb(verb string) bool {
+	switch verb {
+	case "site", "snapshot", "hook", "mcp", "daemon", "version", "help",
+		"-h", "--help":
+		return true
+	}
+	return false
+}
+
+// IsCLIInvocation is the public hook main.go uses. Same as isCLIVerb
+// but exported so the package boundary is explicit.
+func IsCLIInvocation(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	return isCLIVerb(args[1])
+}
+
+// IsDaemonVerb reports whether os.Args asks for an explicit daemon
+// boot. Distinct from auto-spawn: the user can run `locorum daemon` to
+// get a headless process for CI.
+func IsDaemonVerb(args []string) bool {
+	return len(args) >= 2 && args[1] == "daemon"
+}
+
+// printHelp renders top-level help.
+func printHelp(w io.Writer, version string) {
+	fmt.Fprintf(w, "Locorum %s — local WordPress dev environments\n\n", version)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  locorum                          Launch the GUI")
+	fmt.Fprintln(w, "  locorum <command> [args...]      Run a CLI command (talks to a running daemon)")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	for _, c := range commands {
+		fmt.Fprintf(w, "  %-10s %s\n", c.name, c.summary)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Run `locorum <command> --help` for command-specific options.")
+}
+
+// signalContext returns a context cancelled by Ctrl-C / SIGTERM. The
+// CLI uses it as the bound on every IPC call so a hung daemon doesn't
+// strand the user.
+func signalContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-ch
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+// dial opens an IPC connection, auto-spawning a daemon if needed. The
+// returned client is closed by the caller on completion.
+//
+// hello.PeerKind defaults to "cli" when empty so all CLI traffic shows
+// up uniformly in the daemon's telemetry.
+func dial(ctx context.Context, env *Env, hello daemon.HelloOptions) (*daemon.Client, error) {
+	if hello.PeerKind == "" {
+		hello.PeerKind = "cli"
+	}
+	cli, err := daemon.EnsureDaemon(ctx, env.HomeDir, env.ExePath, hello)
+	if err != nil {
+		return nil, err
+	}
+	return cli, nil
+}
+
+// errToExit maps an IPC / dial error to a documented exit code so
+// scripts can branch on numeric values without parsing strings.
+func errToExit(err error) ExitCode {
+	if err == nil {
+		return ExitOK
+	}
+	if errors.Is(err, daemon.ErrNoDaemon) {
+		return ExitNoDaemon
+	}
+	var rpcErr *daemon.RPCError
+	if errors.As(err, &rpcErr) {
+		switch rpcErr.Code {
+		case daemon.CodeNotFound:
+			return ExitNotFound
+		case daemon.CodeForbidden:
+			return ExitForbidden
+		case daemon.CodeConflict:
+			return ExitConflict
+		}
+	}
+	return ExitError
+}
+
+// printJSON marshal-prints v with two-space indent.
+func printJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// resolveExePath returns the absolute locorum binary path for spawning
+// the daemon. os.Executable is the canonical answer; we resolve
+// symlinks so a user-installed version (e.g. ~/go/bin/locorum) survives
+// a $PATH update mid-session.
+func resolveExePath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return exe
+	}
+	return resolved
+}
+
+// NewEnv builds a default Env from the running process. CLI entry-point
+// calls NewEnv to keep the wire-up in one place.
+func NewEnv(args []string, version string) *Env {
+	home, _ := utils.GetUserHomeDir()
+	return &Env{
+		Stdout:  os.Stdout,
+		Stderr:  os.Stderr,
+		Args:    args,
+		HomeDir: home,
+		ExePath: resolveExePath(),
+		Version: version,
+	}
+}

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+	"github.com/PeterBooker/locorum/internal/hooks"
+)
+
+// runHook dispatches `locorum hook …`. Limited to non-destructive
+// operations for v1 (list, run); CRUD is GUI-driven and lives in the
+// hooks panel. CLI hooks management is a P5 follow-on.
+func runHook(ctx context.Context, env *Env) ExitCode {
+	if len(env.Args) == 0 {
+		fmt.Fprintln(env.Stderr, "usage: locorum hook <list|run> [args...]")
+		return ExitUsage
+	}
+	verb := env.Args[0]
+	rest := *env
+	rest.Args = env.Args[1:]
+	switch verb {
+	case "list", "ls":
+		return runHookList(ctx, &rest)
+	case "run":
+		return runHookRunCmd(ctx, &rest)
+	case "help", "-h", "--help":
+		fmt.Fprintln(env.Stdout, "hook list <slug>             List hooks attached to a site")
+		fmt.Fprintln(env.Stdout, "hook run <slug> --id <hook>  Run a single hook outside the lifecycle")
+		return ExitOK
+	default:
+		fmt.Fprintf(env.Stderr, "locorum hook: unknown verb %q\n", verb)
+		return ExitUsage
+	}
+}
+
+func runHookList(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("hook list", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	jsonOut := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(env.Stderr, "usage: locorum hook list <slug>")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	var resp struct {
+		Hooks []hooks.Hook `json:"hooks"`
+	}
+	if err := cli.Call(ctx, "hook.list", siteIDParams(target, nil), &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	if *jsonOut {
+		if err := printJSON(env.Stdout, resp.Hooks); err != nil {
+			return ExitError
+		}
+		return ExitOK
+	}
+	tw := tabwriter.NewWriter(env.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tEVENT\tTYPE\tENABLED\tCOMMAND")
+	for _, h := range resp.Hooks {
+		enabled := "off"
+		if h.Enabled {
+			enabled = "on"
+		}
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\n",
+			h.ID, h.Event, h.TaskType, enabled, truncate(h.Command, 60))
+	}
+	if err := tw.Flush(); err != nil {
+		return ExitError
+	}
+	if len(resp.Hooks) == 0 {
+		fmt.Fprintln(env.Stdout, "(no hooks)")
+	}
+	return ExitOK
+}
+
+func runHookRunCmd(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("hook run", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	hookID := fs.Int64("id", 0, "hook id (from `hook list`)")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 || *hookID == 0 {
+		fmt.Fprintln(env.Stderr, "usage: locorum hook run <slug> --id <hook-id>")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	params := siteIDParams(target, map[string]any{"hookId": *hookID})
+	var resp struct {
+		Result hooks.Result `json:"result"`
+	}
+	if err := cli.Call(ctx, "hook.run", params, &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	r := resp.Result
+	fmt.Fprintf(env.Stdout, "exit=%d duration=%s lines=%d\n", r.ExitCode, r.Duration(), r.LinesEmitted)
+	if r.LogPath != "" {
+		fmt.Fprintf(env.Stdout, "log: %s\n", r.LogPath)
+	}
+	if r.Err != nil {
+		fmt.Fprintln(env.Stderr, "hook error:", r.Err)
+	}
+	if r.ExitCode != 0 || r.Err != nil {
+		return ExitError
+	}
+	return ExitOK
+}
+
+// truncate caps s at n runes, appending an ellipsis when shortened.
+// Used for the table view so a multi-line `wp` command doesn't make
+// the output unreadable.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+	"github.com/PeterBooker/locorum/internal/mcp"
+)
+
+// runMCP dispatches `locorum mcp …`. Supports stdio (default; what
+// Claude Code, Cursor, Continue use locally) and HTTP (loopback-only
+// with bearer auth, for remote / multi-agent setups).
+func runMCP(ctx context.Context, env *Env) ExitCode {
+	if len(env.Args) == 0 {
+		fmt.Fprintln(env.Stderr, "usage: locorum mcp <serve|rotate-token> [flags]")
+		return ExitUsage
+	}
+	verb := env.Args[0]
+	rest := *env
+	rest.Args = env.Args[1:]
+	switch verb {
+	case "serve":
+		return runMCPServe(ctx, &rest)
+	case "rotate-token":
+		return runMCPRotateToken(&rest)
+	case "help", "-h", "--help":
+		fmt.Fprintln(env.Stdout, "mcp serve --stdio [--profile full|readonly]")
+		fmt.Fprintln(env.Stdout, "    Run an MCP server on stdin/stdout. Reads LOCORUM_MCP_SCOPE")
+		fmt.Fprintln(env.Stdout, "    from env to scope every tool call to a single site (defence-in-depth).")
+		fmt.Fprintln(env.Stdout, "mcp serve --http 127.0.0.1:2484 [--profile full|readonly]")
+		fmt.Fprintln(env.Stdout, "    Serve MCP over HTTP. Loopback bind only; bearer-token auth")
+		fmt.Fprintln(env.Stdout, "    using the secret in ~/.locorum/state/mcp_token.")
+		fmt.Fprintln(env.Stdout, "mcp rotate-token")
+		fmt.Fprintln(env.Stdout, "    Regenerate the HTTP MCP bearer token.")
+		return ExitOK
+	default:
+		fmt.Fprintf(env.Stderr, "locorum mcp: unknown verb %q\n", verb)
+		return ExitUsage
+	}
+}
+
+// runMCPRotateToken regenerates the bearer token used by HTTP MCP and
+// prints the new value. Existing in-flight HTTP MCP servers continue
+// to use the old value until restarted; the user copies the new token
+// into their MCP client config and runs `locorum mcp serve --http`
+// again.
+func runMCPRotateToken(env *Env) ExitCode {
+	tok, err := mcp.RotateToken(env.HomeDir)
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return ExitError
+	}
+	fmt.Fprintln(env.Stdout, tok)
+	return ExitOK
+}
+
+func runMCPServe(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("mcp serve", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	stdio := fs.Bool("stdio", false, "use stdin/stdout (default when no --http set)")
+	httpBind := fs.String("http", "", "bind HTTP MCP server (e.g. 127.0.0.1:2484)")
+	profile := fs.String("profile", "full", "trust tier: full | readonly")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if !*stdio && *httpBind == "" {
+		// Default to stdio when neither flag is set.
+		*stdio = true
+	}
+	if *stdio && *httpBind != "" {
+		fmt.Fprintln(env.Stderr, "locorum mcp: --stdio and --http are mutually exclusive")
+		return ExitUsage
+	}
+	switch *profile {
+	case daemon.ProfileFull, daemon.ProfileReadOnly:
+	default:
+		fmt.Fprintf(env.Stderr, "locorum mcp: unknown profile %q\n", *profile)
+		return ExitUsage
+	}
+
+	scope := os.Getenv("LOCORUM_MCP_SCOPE")
+
+	// Open the IPC client up front. We pass the profile + scope in
+	// the hello so the daemon enforces both — this server is a thin
+	// shim, the daemon is the security boundary.
+	cli, err := dial(ctx, env, daemon.HelloOptions{
+		PeerKind: "mcp",
+		Profile:  *profile,
+		MCPScope: scope,
+	})
+	if err != nil {
+		// Diagnostics go to stderr — stdout is reserved for MCP frames
+		// and any extra bytes there confuse the connected agent.
+		fmt.Fprintln(env.Stderr, "locorum mcp:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	// MCP logs go to stderr too, never stdout. Replace the default
+	// logger for the lifetime of this command so any package-level
+	// slog.Info call doesn't poison the protocol stream.
+	logger := slog.New(slog.NewJSONHandler(env.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	srv := mcp.NewServer(mcp.Options{
+		In:      os.Stdin,
+		Out:     os.Stdout,
+		Client:  cli,
+		Logger:  logger,
+		Scope:   scope,
+		Profile: *profile,
+		Version: env.Version,
+	})
+
+	if *stdio {
+		if err := srv.Serve(ctx); err != nil {
+			fmt.Fprintln(env.Stderr, "locorum mcp:", err)
+			return ExitError
+		}
+		return ExitOK
+	}
+
+	// HTTP transport. Bring up a loopback listener with bearer auth.
+	token, err := mcp.LoadOrCreateToken(env.HomeDir)
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum mcp:", err)
+		return ExitError
+	}
+	httpSrv, err := mcp.NewHTTPServer(mcp.HTTPOptions{
+		Bind:   *httpBind,
+		Token:  token,
+		Server: srv,
+		Logger: logger,
+	})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum mcp:", err)
+		return ExitUsage
+	}
+	fmt.Fprintf(env.Stderr, "locorum mcp http listening on %s\n", *httpBind)
+	fmt.Fprintf(env.Stderr, "auth token: %s (also at %s)\n", token, mcp.TokenPath(env.HomeDir))
+	if err := httpSrv.Serve(ctx); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum mcp:", err)
+		return ExitError
+	}
+	return ExitOK
+}

--- a/internal/cli/site.go
+++ b/internal/cli/site.go
@@ -1,0 +1,381 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+	"github.com/PeterBooker/locorum/internal/sites"
+)
+
+// runSite is the dispatcher for `locorum site …`. Each verb has its own
+// flag set so adding one doesn't require touching the others.
+func runSite(ctx context.Context, env *Env) ExitCode {
+	if len(env.Args) == 0 {
+		fmt.Fprintln(env.Stderr, "usage: locorum site <list|describe|start|stop|wp|logs> [args...]")
+		return ExitUsage
+	}
+	verb := env.Args[0]
+	rest := *env
+	rest.Args = env.Args[1:]
+	switch verb {
+	case "list", "ls":
+		return runSiteList(ctx, &rest)
+	case "describe", "show":
+		return runSiteDescribe(ctx, &rest)
+	case "start":
+		return runSiteToggle(ctx, &rest, "site.start", "started")
+	case "stop":
+		return runSiteToggle(ctx, &rest, "site.stop", "stopped")
+	case "create":
+		return runSiteCreate(ctx, &rest)
+	case "delete", "rm":
+		return runSiteDelete(ctx, &rest)
+	case "wp":
+		return runSiteWP(ctx, &rest)
+	case "logs":
+		return runSiteLogs(ctx, &rest)
+	case "help", "-h", "--help":
+		fmt.Fprintln(env.Stdout, "site list                                List sites")
+		fmt.Fprintln(env.Stdout, "site describe <slug-or-id>               Print one site's full state")
+		fmt.Fprintln(env.Stdout, "site start <slug-or-id>                  Start a site")
+		fmt.Fprintln(env.Stdout, "site stop <slug-or-id>                   Stop a site")
+		fmt.Fprintln(env.Stdout, "site create --name N --git-remote URL --branch B [--clone-db] [--dry-run]")
+		fmt.Fprintln(env.Stdout, "                                         Create a worktree-bound site")
+		fmt.Fprintln(env.Stdout, "site delete <slug-or-id> [--force] [--purge-volume] [--dry-run]")
+		fmt.Fprintln(env.Stdout, "                                         Delete a site")
+		fmt.Fprintln(env.Stdout, "site wp <slug-or-id> -- <args...>        Run a wp-cli command")
+		fmt.Fprintln(env.Stdout, "site logs <slug-or-id> --service S       Tail container logs")
+		return ExitOK
+	default:
+		fmt.Fprintf(env.Stderr, "locorum site: unknown verb %q\n", verb)
+		return ExitUsage
+	}
+}
+
+// ─── site list ─────────────────────────────────────────────────────────
+
+func runSiteList(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("site list", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	jsonOut := fs.Bool("json", false, "emit JSON instead of a table")
+	includeActivity := fs.Bool("activity", false, "include each site's recent activity")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	var resp []sites.SiteDescription
+	params := map[string]any{"includeActivity": *includeActivity}
+	if err := cli.Call(ctx, "site.list", params, &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+
+	if *jsonOut {
+		if err := printJSON(env.Stdout, resp); err != nil {
+			return ExitError
+		}
+		return ExitOK
+	}
+
+	// Stable ordering for table output: alphabetical by slug. The
+	// daemon already emits in DB-row order, but a list rendered in
+	// "whichever order GetSites returns" is harder to read after the
+	// row count climbs into the dozens.
+	sort.Slice(resp, func(i, j int) bool { return resp[i].Slug < resp[j].Slug })
+
+	tw := tabwriter.NewWriter(env.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "SLUG\tNAME\tSTATUS\tURL\tPHP\tDB")
+	for _, s := range resp {
+		status := "stopped"
+		if s.Started {
+			status = "running"
+		}
+		db := s.Database.Engine
+		if s.Database.Version != "" {
+			db = s.Database.Engine + ":" + s.Database.Version
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.Slug, s.Name, status, s.URL, s.PHP.Version, db)
+	}
+	if err := tw.Flush(); err != nil {
+		return ExitError
+	}
+	if len(resp) == 0 {
+		fmt.Fprintln(env.Stdout, "(no sites yet — create one in the GUI)")
+	}
+	return ExitOK
+}
+
+// ─── site describe ─────────────────────────────────────────────────────
+
+func runSiteDescribe(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("site describe", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	jsonOut := fs.Bool("json", false, "emit JSON instead of a human-readable summary")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(env.Stderr, "usage: locorum site describe <slug-or-id>")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	var desc sites.SiteDescription
+	params := siteIDParams(target, map[string]any{
+		"includeActivity":  true,
+		"activityLimit":    20,
+		"includeSnapshots": true,
+		"includeHostPort":  true,
+	})
+	if err := cli.Call(ctx, "site.describe", params, &desc); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+
+	if *jsonOut {
+		if err := printJSON(env.Stdout, desc); err != nil {
+			return ExitError
+		}
+		return ExitOK
+	}
+
+	printDescribeText(env.Stdout, desc)
+	return ExitOK
+}
+
+// printDescribeText renders a multi-line summary suited to a terminal.
+// Intentionally flat (no nesting) so a one-screen `site describe` shows
+// everything important without scrolling.
+func printDescribeText(w fmtWriter, d sites.SiteDescription) {
+	fmt.Fprintf(w, "Name:      %s\n", d.Name)
+	fmt.Fprintf(w, "Slug:      %s\n", d.Slug)
+	fmt.Fprintf(w, "URL:       %s\n", d.URL)
+	fmt.Fprintf(w, "Status:    %s\n", statusString(d.Started))
+	fmt.Fprintf(w, "Files:     %s\n", d.FilesDir)
+	if d.PublicDir != "" && d.PublicDir != "/" {
+		fmt.Fprintf(w, "Public:    %s\n", d.PublicDir)
+	}
+	fmt.Fprintf(w, "WebServer: %s\n", d.WebServer)
+	if d.Multisite != "" {
+		fmt.Fprintf(w, "Multisite: %s\n", d.Multisite)
+	}
+	fmt.Fprintf(w, "PHP:       %s\n", d.PHP.Version)
+	dbLine := d.Database.Engine + " " + d.Database.Version
+	if d.Database.HostPort > 0 {
+		dbLine += fmt.Sprintf(" (host port %d)", d.Database.HostPort)
+	}
+	fmt.Fprintf(w, "Database:  %s\n", dbLine)
+	fmt.Fprintf(w, "Redis:     %s\n", d.Redis.Version)
+	if d.Hooks.Total > 0 {
+		fmt.Fprintf(w, "Hooks:     %d configured\n", d.Hooks.Total)
+	}
+	if d.SnapshotsCount > 0 {
+		fmt.Fprintf(w, "Snapshots: %d\n", d.SnapshotsCount)
+	}
+	if d.Profiling.Enabled {
+		fmt.Fprintln(w, "Profiling: enabled (SPX)")
+	}
+	if len(d.Activity) > 0 {
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "Recent activity:")
+		for _, a := range d.Activity {
+			fmt.Fprintf(w, "  %s  %-12s  %-10s  %s\n",
+				a.Time.Format("2006-01-02 15:04"),
+				a.Kind, a.Status, a.Message)
+		}
+	}
+}
+
+// statusString renders the bool as a human word — "running" instead of
+// "true" reads better in a terminal.
+func statusString(started bool) string {
+	if started {
+		return "running"
+	}
+	return "stopped"
+}
+
+// ─── site start / stop ─────────────────────────────────────────────────
+
+func runSiteToggle(ctx context.Context, env *Env, method, verb string) ExitCode {
+	fs := flag.NewFlagSet("site "+verb, flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(env.Stderr, "usage: locorum site "+verb+" <slug-or-id>")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	var resp map[string]any
+	if err := cli.Call(ctx, method, siteIDParams(target, nil), &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	fmt.Fprintf(env.Stdout, "%s: %s\n", target, verb)
+	return ExitOK
+}
+
+// ─── site wp -- <args...> ──────────────────────────────────────────────
+
+// runSiteWP parses `locorum site wp <slug> -- arg1 arg2 …`. The `--`
+// separator is required so flag parsing doesn't fight wp-cli's own
+// flags (e.g. `wp option get --orderby=date` — the inner --orderby
+// would otherwise be claimed by our flag set).
+func runSiteWP(ctx context.Context, env *Env) ExitCode {
+	args := env.Args
+	if len(args) < 2 {
+		fmt.Fprintln(env.Stderr, "usage: locorum site wp <slug> -- <wp-cli args...>")
+		return ExitUsage
+	}
+	target := args[0]
+	rest := args[1:]
+	if rest[0] == "--" {
+		rest = rest[1:]
+	}
+	if len(rest) == 0 {
+		fmt.Fprintln(env.Stderr, "locorum: provide at least one wp-cli argument after --")
+		return ExitUsage
+	}
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	params := siteIDParams(target, map[string]any{"args": rest})
+	var resp struct {
+		Output string `json:"output"`
+	}
+	if err := cli.Call(ctx, "site.wp", params, &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	if resp.Output != "" {
+		if !strings.HasSuffix(resp.Output, "\n") {
+			resp.Output += "\n"
+		}
+		fmt.Fprint(env.Stdout, resp.Output)
+	}
+	return ExitOK
+}
+
+// ─── site logs ─────────────────────────────────────────────────────────
+
+func runSiteLogs(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("site logs", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	service := fs.String("service", "php", "container service: web | php | database | redis")
+	lines := fs.Int("lines", 200, "number of trailing lines to fetch")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(env.Stderr, "usage: locorum site logs <slug-or-id> [--service S] [--lines N]")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	params := siteIDParams(target, map[string]any{
+		"service": *service,
+		"lines":   *lines,
+	})
+	var resp struct {
+		Output  string `json:"output"`
+		Service string `json:"service"`
+	}
+	if err := cli.Call(ctx, "site.logs", params, &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	fmt.Fprint(env.Stdout, resp.Output)
+	if !strings.HasSuffix(resp.Output, "\n") {
+		fmt.Fprintln(env.Stdout)
+	}
+	return ExitOK
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────
+
+// fmtWriter is the io.Writer-superset accepted by Fprintf. Aliased so
+// tests can pass a *bytes.Buffer without an extra interface dance.
+type fmtWriter interface {
+	Write(p []byte) (int, error)
+}
+
+// siteIDParams builds the param object every site-scoped method
+// expects. extra is merged in non-destructively. A target that looks
+// like a UUIDv4 is sent as siteId; everything else as slug.
+func siteIDParams(target string, extra map[string]any) map[string]any {
+	params := map[string]any{}
+	if extra != nil {
+		for k, v := range extra {
+			params[k] = v
+		}
+	}
+	if looksLikeUUID(target) {
+		params["siteId"] = target
+	} else {
+		params["slug"] = target
+	}
+	return params
+}
+
+// looksLikeUUID is a cheap check — if the target has dashes and the
+// canonical 8-4-4-4-12 length, treat it as a UUID. Anything else
+// (including slug values that happen to have dashes) goes to slug.
+func looksLikeUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	if s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-' {
+		return false
+	}
+	for i, c := range s {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			continue
+		}
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/site_create.go
+++ b/internal/cli/site_create.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+	"github.com/PeterBooker/locorum/internal/sites"
+)
+
+// runSiteCreate dispatches `locorum site create`. v1 supports the
+// worktree flow (--git-remote required); a future revision will add
+// blank-WP creation matching the GUI's New Site modal. For now,
+// blank-WP is a GUI-only path because it requires file-system pickers
+// the CLI can't reproduce cleanly.
+func runSiteCreate(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("site create", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	name := fs.String("name", "", "human-readable site name (required)")
+	gitRemote := fs.String("git-remote", "", "upstream git URL (required for v1)")
+	branch := fs.String("branch", "", "branch to track (required when --git-remote is set)")
+	parent := fs.String("parent-slug", "", "existing parent site slug (else auto-derived from --git-remote)")
+	cloneDB := fs.Bool("clone-db", false, "copy parent's DB and run search-replace")
+	dryRun := fs.Bool("dry-run", false, "describe the plan without executing")
+	php := fs.String("php", "", "PHP version override")
+	dbEngine := fs.String("db-engine", "", "DB engine override (mysql|mariadb)")
+	dbVersion := fs.String("db-version", "", "DB version override")
+	redis := fs.String("redis", "", "Redis version override")
+	worktreeRoot := fs.String("worktree-root", "", "host path for the worktree directory (defaults to <parent>.worktrees/)")
+	jsonOut := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if strings.TrimSpace(*name) == "" || strings.TrimSpace(*gitRemote) == "" || strings.TrimSpace(*branch) == "" {
+		fmt.Fprintln(env.Stderr, "usage: locorum site create --name N --git-remote URL --branch B [--clone-db] [--dry-run]")
+		return ExitUsage
+	}
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	params := map[string]any{
+		"name":         *name,
+		"gitRemote":    *gitRemote,
+		"branch":       *branch,
+		"parentSlug":   *parent,
+		"cloneDb":      *cloneDB,
+		"dryRun":       *dryRun,
+		"phpVersion":   *php,
+		"dbEngine":     *dbEngine,
+		"dbVersion":    *dbVersion,
+		"redisVersion": *redis,
+		"worktreeRoot": *worktreeRoot,
+	}
+	var resp sites.CreateWorktreeResult
+	if err := cli.Call(ctx, "site.create_worktree", params, &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+
+	if *jsonOut {
+		if err := printJSON(env.Stdout, resp); err != nil {
+			return ExitError
+		}
+		return ExitOK
+	}
+
+	if *dryRun {
+		fmt.Fprint(env.Stdout, resp.DryRunPreview)
+		return ExitOK
+	}
+	fmt.Fprintf(env.Stdout, "Created %s (slug=%s)\n", resp.Site.Name, resp.DerivedSlug)
+	fmt.Fprintf(env.Stdout, "URL: https://%s\n", resp.Site.Domain)
+	if resp.Site.WorktreePath != "" {
+		fmt.Fprintf(env.Stdout, "Worktree: %s\n", resp.Site.WorktreePath)
+	}
+	return ExitOK
+}
+
+// runSiteDelete dispatches `locorum site delete`.
+func runSiteDelete(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("site delete", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	purge := fs.Bool("purge-volume", false, "also remove the database volume (destroys data)")
+	skipSnap := fs.Bool("skip-snapshot", false, "skip the auto-snapshot taken before deletion")
+	force := fs.Bool("force", false, "discard worktree changes without confirmation")
+	dryRun := fs.Bool("dry-run", false, "describe the plan without executing")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(env.Stderr, "usage: locorum site delete <slug-or-id> [--force] [--purge-volume] [--dry-run]")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	params := siteIDParams(target, map[string]any{
+		"purgeVolume":   *purge,
+		"skipSnapshot":  *skipSnap,
+		"forceWorktree": *force,
+		"dryRun":        *dryRun,
+	})
+	var resp map[string]any
+	if err := cli.Call(ctx, "site.delete", params, &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	if *dryRun {
+		fmt.Fprintln(env.Stdout, "Dry run complete — no changes were made (see daemon log for the full plan).")
+	} else {
+		fmt.Fprintf(env.Stdout, "%s: deleted\n", target)
+	}
+	return ExitOK
+}

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+	"github.com/PeterBooker/locorum/internal/sites"
+)
+
+// runSnapshot dispatches `locorum snapshot …`.
+func runSnapshot(ctx context.Context, env *Env) ExitCode {
+	if len(env.Args) == 0 {
+		fmt.Fprintln(env.Stderr, "usage: locorum snapshot <list|create|restore> [args...]")
+		return ExitUsage
+	}
+	verb := env.Args[0]
+	rest := *env
+	rest.Args = env.Args[1:]
+	switch verb {
+	case "list", "ls":
+		return runSnapshotList(ctx, &rest)
+	case "create":
+		return runSnapshotCreate(ctx, &rest)
+	case "restore":
+		return runSnapshotRestore(ctx, &rest)
+	case "help", "-h", "--help":
+		fmt.Fprintln(env.Stdout, "snapshot list <slug>           List snapshots for a site")
+		fmt.Fprintln(env.Stdout, "snapshot create <slug> [--label L]")
+		fmt.Fprintln(env.Stdout, "snapshot restore <slug> --path P [--force]")
+		return ExitOK
+	default:
+		fmt.Fprintf(env.Stderr, "locorum snapshot: unknown verb %q\n", verb)
+		return ExitUsage
+	}
+}
+
+func runSnapshotList(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("snapshot list", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	jsonOut := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(env.Stderr, "usage: locorum snapshot list <slug>")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	var resp struct {
+		Snapshots []sites.SnapshotInfo `json:"snapshots"`
+	}
+	if err := cli.Call(ctx, "snapshot.list", siteIDParams(target, nil), &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	if *jsonOut {
+		if err := printJSON(env.Stdout, resp.Snapshots); err != nil {
+			return ExitError
+		}
+		return ExitOK
+	}
+	tw := tabwriter.NewWriter(env.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "FILENAME\tLABEL\tENGINE\tVERSION\tSIZE\tCREATED")
+	for _, s := range resp.Snapshots {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
+			s.Filename, s.Label, s.Engine, s.Version, s.SizeBytes,
+			s.CreatedAt.Format("2006-01-02 15:04"))
+	}
+	if err := tw.Flush(); err != nil {
+		return ExitError
+	}
+	if len(resp.Snapshots) == 0 {
+		fmt.Fprintln(env.Stdout, "(no snapshots yet)")
+	}
+	return ExitOK
+}
+
+func runSnapshotCreate(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("snapshot create", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	label := fs.String("label", "manual", "short label baked into the filename")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(env.Stderr, "usage: locorum snapshot create <slug> [--label L]")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	var resp struct {
+		Path string `json:"path"`
+	}
+	params := siteIDParams(target, map[string]any{"label": *label})
+	if err := cli.Call(ctx, "snapshot.create", params, &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	fmt.Fprintln(env.Stdout, resp.Path)
+	return ExitOK
+}
+
+func runSnapshotRestore(ctx context.Context, env *Env) ExitCode {
+	fs := flag.NewFlagSet("snapshot restore", flag.ContinueOnError)
+	fs.SetOutput(env.Stderr)
+	path := fs.String("path", "", "absolute path to the snapshot file (required)")
+	force := fs.Bool("force", false, "ignore engine/version mismatch")
+	if err := fs.Parse(env.Args); err != nil {
+		return ExitUsage
+	}
+	if fs.NArg() != 1 || *path == "" {
+		fmt.Fprintln(env.Stderr, "usage: locorum snapshot restore <slug> --path /abs/path.sql.zst [--force]")
+		return ExitUsage
+	}
+	target := fs.Arg(0)
+
+	cli, err := dial(ctx, env, daemon.HelloOptions{})
+	if err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	defer cli.Close()
+
+	params := siteIDParams(target, map[string]any{
+		"path":  *path,
+		"force": *force,
+	})
+	var resp struct{}
+	if err := cli.Call(ctx, "snapshot.restore", params, &resp); err != nil {
+		fmt.Fprintln(env.Stderr, "locorum:", err)
+		return errToExit(err)
+	}
+	fmt.Fprintln(env.Stdout, "snapshot restored")
+	return ExitOK
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,8 @@
+package cli
+
+import "fmt"
+
+func runVersion(env *Env) ExitCode {
+	fmt.Fprintf(env.Stdout, "locorum %s\n", env.Version)
+	return ExitOK
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,6 +215,23 @@ func (c *Config) UpdateCheckEnabled() bool {
 	return parseBool(c.raw(KeyUpdateCheckEnabled), true)
 }
 
+// AutoSnapshotBeforeDestructive reports whether SiteManager should
+// take a safety snapshot before each destructive op (db restore, db
+// import, search-replace, agent-driven root exec). Default true; the
+// setter accepts the explicit "false" string to disable.
+func (c *Config) AutoSnapshotBeforeDestructive() bool {
+	return parseBool(c.raw(KeyAutoSnapshotBeforeDestructive), true)
+}
+
+// SetAutoSnapshotBeforeDestructive persists the toggle.
+func (c *Config) SetAutoSnapshotBeforeDestructive(on bool) error {
+	v := "false"
+	if on {
+		v = "true"
+	}
+	return c.Set(KeyAutoSnapshotBeforeDestructive, v)
+}
+
 // ── Int accessors ───────────────────────────────────────────────────
 
 // RouterHTTPPort returns the host port the global router binds on for

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -66,6 +66,14 @@ const (
 	KeyHealthDiskWarnGB         = "health.disk_warn_gb"    // int, default 5
 	KeyHealthDiskBlockerGB      = "health.disk_blocker_gb" // int, default 1
 	KeyHealthLastSeen           = "health.last_seen"       // json, internal
+
+	// Auto-snapshot wraps for destructive ops (P4 in
+	// AGENTS-SUPPORT.md). When true (the default), Locorum captures a
+	// safety snapshot before each of: snapshot restore, wp db import,
+	// wp search-replace, agent-driven `exec` as root in the database
+	// container. Power users with their own backup discipline can
+	// disable.
+	KeyAutoSnapshotBeforeDestructive = "snapshots.auto_before_destructive"
 )
 
 // Documented default values for every accessor. Centralising these

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -1,0 +1,387 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Client is a goroutine-safe JSON-RPC 2.0 client speaking to a Locorum
+// daemon over the IPC transport. Calls are matched by an integer "id"
+// generated atomically per request; the demuxer goroutine routes each
+// response to its waiting caller via a per-id channel.
+type Client struct {
+	conn net.Conn
+	enc  *json.Encoder
+	dec  *json.Decoder
+
+	nextID atomic.Int64
+
+	mu      sync.Mutex
+	pending map[int64]chan *Response
+	closed  bool
+	closeCh chan struct{}
+}
+
+// HelloOptions configures the client.hello handshake. Most clients
+// declare PeerKind ("cli", "mcp", "gui-test") so the daemon can
+// distinguish traffic in telemetry. Profile / MCPScope are MCP-only.
+type HelloOptions struct {
+	PeerKind string
+	Profile  string
+	MCPScope string
+}
+
+// Dial connects to the daemon socket / pipe and performs the
+// client.hello handshake. ctx bounds the dial + handshake.
+func DialClient(ctx context.Context, socket string, hello HelloOptions) (*Client, error) {
+	conn, err := Dial(ctx, socket)
+	if err != nil {
+		return nil, err
+	}
+	cli := newClient(conn)
+	go cli.readLoop()
+
+	// Even an empty hello succeeds against a Full daemon: it just
+	// stamps the conn with the defaults. We always send one so the
+	// daemon knows where to route activity events for telemetry.
+	helloParams := struct {
+		PeerKind string `json:"peerKind,omitempty"`
+		Profile  string `json:"profile,omitempty"`
+		MCPScope string `json:"mcpScope,omitempty"`
+	}{
+		PeerKind: hello.PeerKind,
+		Profile:  hello.Profile,
+		MCPScope: hello.MCPScope,
+	}
+	var info serverInfo
+	if err := cli.Call(ctx, "client.hello", helloParams, &info); err != nil {
+		_ = cli.Close()
+		return nil, fmt.Errorf("client.hello: %w", err)
+	}
+	return cli, nil
+}
+
+func newClient(conn net.Conn) *Client {
+	return &Client{
+		conn:    conn,
+		enc:     json.NewEncoder(conn),
+		dec:     json.NewDecoder(bufio.NewReaderSize(conn, 64*1024)),
+		pending: make(map[int64]chan *Response),
+		closeCh: make(chan struct{}),
+	}
+}
+
+// Call invokes method with params, blocks until the daemon responds (or
+// ctx is done), and unmarshals the result into out (a pointer to a
+// struct). Pass nil for params or out when neither is needed.
+func (c *Client) Call(ctx context.Context, method string, params, out any) error {
+	id := c.nextID.Add(1)
+	idJSON, err := json.Marshal(id)
+	if err != nil {
+		return fmt.Errorf("encode id: %w", err)
+	}
+
+	var paramsRaw json.RawMessage
+	if params != nil {
+		body, err := json.Marshal(params)
+		if err != nil {
+			return fmt.Errorf("encode params: %w", err)
+		}
+		paramsRaw = body
+	}
+
+	req := Request{
+		JSONRPC: jsonRPCVersion,
+		ID:      idJSON,
+		Method:  method,
+		Params:  paramsRaw,
+	}
+
+	respCh := make(chan *Response, 1)
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return errors.New("client is closed")
+	}
+	c.pending[id] = respCh
+	c.mu.Unlock()
+	// Always remove the pending entry on exit so a cancelled context
+	// doesn't leak a channel forever.
+	defer func() {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+	}()
+
+	if err := c.writeFrame(req); err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closeCh:
+		return errors.New("connection closed")
+	case resp := <-respCh:
+		if resp.Error != nil {
+			return resp.Error
+		}
+		if out != nil && len(resp.Result) > 0 {
+			if err := json.Unmarshal(resp.Result, out); err != nil {
+				return fmt.Errorf("decode result: %w", err)
+			}
+		}
+		return nil
+	}
+}
+
+// writeFrame serialises one request under the client mutex (the encoder
+// shares a buffer with the underlying net.Conn writer).
+func (c *Client) writeFrame(req Request) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return errors.New("client is closed")
+	}
+	return c.enc.Encode(req)
+}
+
+// readLoop reads responses from the conn and routes each to its waiting
+// Call via the pending map. Exits when the connection closes; failure
+// to find a pending entry is logged-but-ignored (the caller may have
+// timed out and dropped its channel).
+func (c *Client) readLoop() {
+	defer c.shutdown(nil)
+	for {
+		var resp Response
+		if err := c.dec.Decode(&resp); err != nil {
+			c.shutdown(err)
+			return
+		}
+		// id is JSON-encoded as a number — unmarshal back to int64.
+		// Defensive: malformed servers might send strings; we drop
+		// them rather than panic.
+		var id int64
+		if len(resp.ID) > 0 {
+			if err := json.Unmarshal(resp.ID, &id); err != nil {
+				continue
+			}
+		}
+		c.mu.Lock()
+		ch, ok := c.pending[id]
+		c.mu.Unlock()
+		if !ok {
+			continue
+		}
+		// respCh is buffered size-1 from Call; non-blocking send.
+		select {
+		case ch <- &resp:
+		default:
+		}
+	}
+}
+
+// shutdown drains pending channels and marks the client closed.
+// Idempotent. _err is recorded for diagnostics but otherwise unused —
+// callers see a generic "connection closed" error from Call.
+func (c *Client) shutdown(_ error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	close(c.closeCh)
+	pending := c.pending
+	c.pending = nil
+	c.mu.Unlock()
+	for _, ch := range pending {
+		close(ch)
+	}
+	_ = c.conn.Close()
+}
+
+// Close terminates the client connection. Safe to call multiple times;
+// pending Calls return "connection closed".
+func (c *Client) Close() error {
+	c.shutdown(nil)
+	return nil
+}
+
+// EnsureDaemon returns a connected client to the daemon, auto-spawning
+// a headless daemon process if none is running. The auto-spawn path is
+// the foundation of the "CLI just works" UX: a user types
+// `locorum site list` on a fresh box and we transparently bring up the
+// backend, run their query, and leave it running for next time.
+//
+// On Windows the auto-spawn uses Cmd.Process.Release so the parent CLI
+// can exit without taking the daemon with it; on POSIX we set Setsid
+// so the daemon survives the controlling terminal closing.
+//
+// homeDir, lockPath, socketPath: the canonical state-dir paths. Pass
+// the same values the daemon process would compute.
+//
+// exePath: the absolute path to the locorum binary. Pass os.Executable
+// in production; tests override with a mock binary that signals readiness
+// the same way (binds the socket, holds it open).
+//
+// hello: handshake metadata, recorded in conn metadata.
+//
+// Auto-spawn is idempotent against races: two CLIs starting at once
+// will both try to spawn; one Acquire wins the lock and the other dials
+// in normally.
+func EnsureDaemon(ctx context.Context, homeDir, exePath string, hello HelloOptions) (*Client, error) {
+	socket := SocketPath(homeDir)
+
+	// Fast path: a daemon is already up.
+	if cli, err := DialClient(ctx, socket, hello); err == nil {
+		return cli, nil
+	} else if !errors.Is(err, ErrNoDaemon) {
+		// A real error (perm denied, crashed daemon mid-handshake) —
+		// bubble it up. Auto-spawn would just race with whatever's
+		// holding the lock.
+		return nil, err
+	}
+
+	if exePath == "" {
+		// Without a binary path we can't spawn. Caller should have
+		// resolved os.Executable at startup.
+		return nil, ErrNoDaemon
+	}
+
+	if err := spawnDaemon(exePath, homeDir); err != nil {
+		return nil, fmt.Errorf("spawn daemon: %w", err)
+	}
+
+	// Poll until the socket appears or ctx times out. The daemon
+	// finishes binding the socket before app.Initialize touches
+	// Docker, so this typically takes <100ms; we keep a 5s upper
+	// bound for slow init.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+		cli, err := DialClient(dialCtx, socket, hello)
+		cancel()
+		if err == nil {
+			return cli, nil
+		}
+		if !errors.Is(err, ErrNoDaemon) && !isConnRefused(err) {
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("daemon did not bind socket within timeout: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// isConnRefused is the cross-platform "no listener on socket" check.
+// Returned by Dial when the socket file exists but isn't accepting
+// (race window during daemon startup).
+func isConnRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	// We don't import syscall.ECONNREFUSED here to keep this file
+	// platform-portable; the string match is good enough for our
+	// "wait for daemon to bind" loop.
+	msg := err.Error()
+	for _, needle := range []string{"connection refused", "no such file", "cannot find the file"} {
+		if containsFold(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(s, sub string) bool {
+	if len(sub) > len(s) {
+		return false
+	}
+	// ASCII-only fold is sufficient for the error strings we match.
+	for i := 0; i+len(sub) <= len(s); i++ {
+		match := true
+		for j := 0; j < len(sub); j++ {
+			a, b := s[i+j], sub[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// daemonReadyEnv is the env var the auto-spawned daemon sees that tells
+// it to come up headless (no Gio window). main.go reads this and skips
+// the GUI bring-up.
+const daemonReadyEnv = "LOCORUM_DAEMON_MODE"
+
+// daemonReadyValue is the magic value of LOCORUM_DAEMON_MODE that
+// signals "yes, you are an auto-spawned daemon."
+const daemonReadyValue = "1"
+
+// spawnDaemon execs the locorum binary with the daemon-mode env var
+// set. The child detaches from the parent's stdout/stdin so a CLI exit
+// doesn't kill the daemon. Logs route to ~/.locorum/state/daemon.log
+// so the auto-spawn case is debuggable post-mortem.
+func spawnDaemon(exePath, homeDir string) error {
+	logPath := SocketPath(homeDir) + ".log" // sits next to socket; same 0600 perm scope
+	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		// Log file is optional. A locked filesystem shouldn't block
+		// auto-spawn — fall back to /dev/null on POSIX.
+		logFile = nullDevice()
+	}
+	cmd := exec.Command(exePath, "daemon", "--from-spawn")
+	cmd.Env = append(os.Environ(), daemonReadyEnv+"="+daemonReadyValue)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.Stdin = nil
+	configureDetached(cmd)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// Don't Wait — the daemon outlives the CLI. Release so Go's
+	// runtime cleans up the spawn-side state.
+	return cmd.Process.Release()
+}
+
+// IsDaemonAutoSpawn returns true when the current process was started
+// via spawnDaemon. main.go branches on this to skip Gio.
+func IsDaemonAutoSpawn() bool {
+	return os.Getenv(daemonReadyEnv) == daemonReadyValue
+}
+
+// FormatLockOwner returns a human-readable description of the current
+// lock holder. Intended for CLI diagnostics ("daemon is already
+// running, pid=12345 since 2026-05-06T12:00:00Z").
+func FormatLockOwner(o Owner) string {
+	if o.PID == 0 {
+		return "unknown"
+	}
+	return "pid=" + strconv.Itoa(o.PID) + " started=" + o.StartedAt.Format(time.RFC3339)
+}

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -1,0 +1,299 @@
+// Package daemon owns the process-coordination machinery for Locorum:
+// the owner.lock that arbitrates which process owns Docker lifecycle,
+// the local IPC transport (Unix domain socket on POSIX, named pipe on
+// Windows), the JSON-RPC server bound to a SiteManager, and the matching
+// client that CLI / MCP processes shell over.
+//
+// The split exists because Locorum's GUI and CLI are the same binary.
+// Two processes both calling app.Initialize would race-delete each
+// other's Docker resources (they share the io.locorum.platform=locorum
+// label). Instead, exactly one process holds the lock and runs the
+// daemon goroutines; every other invocation is an IPC client.
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// LockFilename is the basename of the owner-lock under
+// ~/.locorum/state/. The full path is built by Path().
+const LockFilename = "owner.lock"
+
+// SocketFilename is the basename of the IPC socket on POSIX. Windows
+// uses a named pipe and ignores this value (see transport_windows.go).
+const SocketFilename = "locorum.sock"
+
+// stateDir is the relative path under the home dir where daemon state
+// files live. Mirrors the pre-existing convention used by the health
+// runner ("state/").
+const stateDir = ".locorum/state"
+
+// Path returns the absolute owner-lock path under homeDir. Callers are
+// responsible for ensuring the directory exists; Acquire will create it
+// if missing.
+func Path(homeDir string) string {
+	return filepath.Join(homeDir, stateDir, LockFilename)
+}
+
+// SocketPath returns the absolute IPC-socket path under homeDir. Same
+// directory as the lock so a single chmod 0700 protects both.
+func SocketPath(homeDir string) string {
+	return filepath.Join(homeDir, stateDir, SocketFilename)
+}
+
+// StateDir returns the absolute parent directory holding the lock and
+// socket. EnsureStateDir creates it with 0700 perms so other users on
+// the host cannot connect to or steal the lock.
+func StateDir(homeDir string) string {
+	return filepath.Join(homeDir, stateDir)
+}
+
+// EnsureStateDir creates ~/.locorum/state with 0700 perms (owner-only
+// rwx). Idempotent. Tightening perms on an existing dir is best-effort
+// because a directory created by an earlier release with 0755 should
+// still work for the lock; callers may log a warning if the OS-reported
+// mode is wider than 0700.
+func EnsureStateDir(homeDir string) error {
+	dir := StateDir(homeDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	// Best-effort tighten. Failures (e.g. read-only filesystem in a
+	// hardened sandbox) are logged by the caller, not surfaced here —
+	// the dir exists, which is the only invariant this function
+	// promises.
+	_ = os.Chmod(dir, 0o700)
+	return nil
+}
+
+// Owner is the JSON payload written into the lock file. PID + StartedAt
+// together identify a specific process even after PID rollover, which
+// matters on long-running hosts that recycle the daemon weekly.
+type Owner struct {
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"startedAt"`
+	Version   string    `json:"version,omitempty"`
+}
+
+// Lock is an acquired owner.lock. Release exactly once on shutdown to
+// remove the file and release the OS-level advisory lock.
+//
+// Lock is not safe for concurrent use; callers should hold one Lock per
+// process. flock() releases automatically when the process exits, so a
+// crash leaks at most a stale file (handled by stale-detection in
+// Acquire).
+type Lock struct {
+	path string
+	f    *os.File
+	// owner is the payload we wrote on acquire. Surfaced via Owner()
+	// so tests and the CLI's "daemon is already running" diagnostic
+	// can read what we promised without a second file read.
+	owner Owner
+}
+
+// ErrLocked indicates that a live Locorum daemon already owns the lock.
+// Wraps the on-disk Owner so the CLI can print a useful diagnostic.
+type ErrLocked struct {
+	Path  string
+	Owner Owner
+}
+
+func (e *ErrLocked) Error() string {
+	if e == nil {
+		return "lock held"
+	}
+	return fmt.Sprintf("locorum daemon already running (pid=%d, since %s)",
+		e.Owner.PID, e.Owner.StartedAt.Format(time.RFC3339))
+}
+
+// Acquire takes the owner-lock at path with stale-detection. Three
+// possible outcomes:
+//
+//   - Success: returns a *Lock holding the OS-level exclusive lock plus
+//     a freshly-written Owner record on disk. Caller releases via
+//     Lock.Release.
+//   - Held by a live process: returns *ErrLocked. CLI clients translate
+//     this into "talk to that pid over IPC instead."
+//   - Held but stale (pid gone, or pid recycled to a different process):
+//     takes over. The takeover is OS-atomic via flock(LOCK_EX|LOCK_NB),
+//     so two simultaneous takeovers can't both succeed.
+//
+// version is stamped into the lock payload so the CLI can warn when an
+// older daemon version is holding the lock (useful after a binary
+// upgrade where the user forgot to restart the GUI).
+func Acquire(path, version string) (*Lock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create lock dir: %w", err)
+	}
+
+	// O_RDWR|O_CREATE so the same fd works for read-existing-PID,
+	// truncate-and-rewrite, and the OS-level advisory lock applied
+	// next. 0600 guards against world-readable PIDs leaking process
+	// identity to other local users.
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock: %w", err)
+	}
+
+	// Try the OS-level exclusive non-blocking lock. On unix this is
+	// flock(LOCK_EX|LOCK_NB); on windows LockFileEx with
+	// LOCKFILE_EXCLUSIVE_LOCK|LOCKFILE_FAIL_IMMEDIATELY.
+	if err := platformLock(f); err != nil {
+		// We didn't get the OS lock — read the existing payload to
+		// decide whether the holder is actually alive (live → return
+		// ErrLocked, dead → re-attempt after taking over).
+		owner, _ := readOwnerFromFile(f)
+		_ = f.Close()
+		if processAlive(owner.PID) {
+			return nil, &ErrLocked{Path: path, Owner: owner}
+		}
+		// Stale. Removing the file then trying again gives any
+		// concurrent takeover candidate exactly one chance — flock
+		// will then arbitrate. We deliberately do NOT recurse forever:
+		// one retry is enough; persistent failure means something
+		// bigger is broken and the caller should see it.
+		_ = os.Remove(path)
+		return acquireOnce(path, version)
+	}
+
+	return finishAcquire(f, path, version)
+}
+
+// acquireOnce is the post-stale-removal retry path. Same body as
+// Acquire's happy path but without the recursion guard.
+func acquireOnce(path, version string) (*Lock, error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock (retry): %w", err)
+	}
+	if err := platformLock(f); err != nil {
+		owner, _ := readOwnerFromFile(f)
+		_ = f.Close()
+		// A second contender beat us to it after we removed the stale
+		// file. Treat their claim as authoritative.
+		return nil, &ErrLocked{Path: path, Owner: owner}
+	}
+	return finishAcquire(f, path, version)
+}
+
+// finishAcquire writes our Owner payload and returns the held Lock.
+// Truncates whatever stale bytes survived the previous holder's crash.
+func finishAcquire(f *os.File, path, version string) (*Lock, error) {
+	owner := Owner{
+		PID:       os.Getpid(),
+		StartedAt: time.Now().UTC(),
+		Version:   version,
+	}
+	body, err := json.Marshal(owner)
+	if err != nil {
+		_ = platformUnlock(f)
+		_ = f.Close()
+		return nil, fmt.Errorf("marshal lock owner: %w", err)
+	}
+	if err := f.Truncate(0); err != nil {
+		_ = platformUnlock(f)
+		_ = f.Close()
+		return nil, fmt.Errorf("truncate lock: %w", err)
+	}
+	if _, err := f.WriteAt(body, 0); err != nil {
+		_ = platformUnlock(f)
+		_ = f.Close()
+		return nil, fmt.Errorf("write lock: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		// Sync failure is informational — the OS lock and in-memory
+		// payload are still correct. A reader that sees an empty file
+		// here would briefly miss our Owner, but processAlive() will
+		// still return true because we hold the flock.
+		_ = err
+	}
+	return &Lock{path: path, f: f, owner: owner}, nil
+}
+
+// Owner returns the payload we wrote on acquire. Stable across the
+// lifetime of the Lock; never touches the file again.
+func (l *Lock) Owner() Owner { return l.owner }
+
+// Release drops the OS-level lock and removes the file. Idempotent: a
+// second Release after the first is a no-op. Always returns nil so
+// `defer lock.Release()` can be used without an error trail at every
+// call site; serious releases also fall through process-exit cleanup of
+// flock.
+func (l *Lock) Release() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	// Order matters: remove the file BEFORE unlock so a concurrent
+	// Acquire+takeover doesn't grab a fresh lock on the file we then
+	// remove out from under them.
+	_ = os.Remove(l.path)
+	_ = platformUnlock(l.f)
+	_ = l.f.Close()
+	l.f = nil
+	return nil
+}
+
+// ReadOwner reads the lock payload at path without taking the OS lock.
+// Used by the CLI to print a "daemon is running, pid=X" message before
+// it dials the socket. Returns a zero Owner and nil error when the file
+// does not exist (i.e. no daemon has ever started).
+func ReadOwner(path string) (Owner, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Owner{}, nil
+		}
+		return Owner{}, fmt.Errorf("read lock: %w", err)
+	}
+	body = []byte(strings.TrimSpace(string(body)))
+	if len(body) == 0 {
+		return Owner{}, nil
+	}
+	var owner Owner
+	if err := json.Unmarshal(body, &owner); err != nil {
+		// Tolerate a legacy "pid only" file (single decimal int) so
+		// upgrades from a future where someone wrote bare PIDs don't
+		// hard-fail at startup.
+		if pid, perr := strconv.Atoi(string(body)); perr == nil {
+			return Owner{PID: pid}, nil
+		}
+		return Owner{}, fmt.Errorf("parse lock: %w", err)
+	}
+	return owner, nil
+}
+
+// readOwnerFromFile is the same as ReadOwner but reuses an open file.
+// Returns the zero Owner on any error; callers handle "the holder may
+// be dead" via processAlive(0) → false.
+func readOwnerFromFile(f *os.File) (Owner, error) {
+	if _, err := f.Seek(0, 0); err != nil {
+		return Owner{}, err
+	}
+	stat, err := f.Stat()
+	if err != nil || stat.Size() == 0 {
+		return Owner{}, err
+	}
+	body := make([]byte, stat.Size())
+	if _, err := f.ReadAt(body, 0); err != nil {
+		return Owner{}, err
+	}
+	body = []byte(strings.TrimSpace(string(body)))
+	if len(body) == 0 {
+		return Owner{}, nil
+	}
+	var owner Owner
+	if err := json.Unmarshal(body, &owner); err != nil {
+		if pid, perr := strconv.Atoi(string(body)); perr == nil {
+			return Owner{PID: pid}, nil
+		}
+		return Owner{}, err
+	}
+	return owner, nil
+}

--- a/internal/daemon/lock_test.go
+++ b/internal/daemon/lock_test.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquire_FreshLock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owner.lock")
+
+	lock, err := Acquire(path, "test")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer lock.Release()
+
+	got := lock.Owner()
+	if got.PID == 0 {
+		t.Fatalf("owner pid not stamped")
+	}
+	if got.Version != "test" {
+		t.Fatalf("version: got %q want %q", got.Version, "test")
+	}
+}
+
+func TestAcquire_SecondCallerIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owner.lock")
+
+	lock, err := Acquire(path, "first")
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	defer lock.Release()
+
+	_, err = Acquire(path, "second")
+	if err == nil {
+		t.Fatalf("expected ErrLocked, got nil")
+	}
+	var locked *ErrLocked
+	if !errors.As(err, &locked) {
+		t.Fatalf("expected *ErrLocked, got %T: %v", err, err)
+	}
+	if locked.Owner.PID == 0 {
+		t.Fatalf("ErrLocked: owner pid not populated")
+	}
+}
+
+func TestAcquire_AfterReleaseSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owner.lock")
+
+	first, err := Acquire(path, "first")
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	if err := first.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	second, err := Acquire(path, "second")
+	if err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	defer second.Release()
+	if second.Owner().Version != "second" {
+		t.Fatalf("second owner.version: got %q", second.Owner().Version)
+	}
+}
+
+func TestReadOwner_MissingReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owner.lock")
+
+	got, err := ReadOwner(path)
+	if err != nil {
+		t.Fatalf("ReadOwner: %v", err)
+	}
+	if got.PID != 0 {
+		t.Fatalf("expected zero owner, got %+v", got)
+	}
+}
+
+func TestReleaseIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owner.lock")
+	lock, err := Acquire(path, "test")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatalf("second Release should be no-op: %v", err)
+	}
+}

--- a/internal/daemon/lock_unix.go
+++ b/internal/daemon/lock_unix.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// platformLock takes an exclusive non-blocking advisory lock on f.
+// Returns an error matching unix.EWOULDBLOCK when another process holds
+// the lock. The lock is automatically released by the kernel if the
+// process exits, so a daemon crash never leaks a permanent block.
+func platformLock(f *os.File) error {
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		return err
+	}
+	return nil
+}
+
+// platformUnlock releases an advisory lock previously taken by
+// platformLock. Errors are returned for completeness but the caller
+// generally ignores them: f.Close() also releases the lock, and the
+// kernel cleans up after process exit.
+func platformUnlock(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}
+
+// processAlive reports whether the given PID currently exists. Returns
+// false for pid <= 0 (zero from a legacy lock file, negative from a
+// malformed payload). On unix this uses kill(pid, 0): the kernel
+// returns EPERM if the process exists but isn't owned by us (which still
+// counts as "alive") and ESRCH if it's gone.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	// EPERM means the process exists but we don't own it — still
+	// "alive" for the purposes of stale-lock detection. ESRCH means
+	// gone.
+	return errors.Is(err, syscall.EPERM)
+}

--- a/internal/daemon/lock_windows.go
+++ b/internal/daemon/lock_windows.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// platformLock takes an exclusive non-overlapping byte-range lock on f.
+// LockFileEx with LOCKFILE_EXCLUSIVE_LOCK|LOCKFILE_FAIL_IMMEDIATELY is
+// the Windows analogue of flock(LOCK_EX|LOCK_NB). The lock spans the
+// maximum file size (0xFFFFFFFF on each end of the range) so concurrent
+// growth of the file does not leave a writable gap.
+func platformLock(f *os.File) error {
+	overlapped := &windows.Overlapped{}
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		0xFFFFFFFF, 0xFFFFFFFF,
+		overlapped,
+	)
+}
+
+// platformUnlock releases the byte-range lock. UnlockFileEx requires
+// the same range we passed to LockFileEx.
+func platformUnlock(f *os.File) error {
+	overlapped := &windows.Overlapped{}
+	return windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0,
+		0xFFFFFFFF, 0xFFFFFFFF,
+		overlapped,
+	)
+}
+
+// processAlive reports whether the given PID currently exists.
+// OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION) succeeds for any
+// running PID we have permission to inspect, including those owned by
+// other users on the same logon session. A process in the "zombie"
+// state (signaled but not yet reaped) returns its exit code via
+// GetExitCodeProcess; we filter that out to avoid treating a freshly-
+// dead daemon as "alive."
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	const flags = windows.PROCESS_QUERY_LIMITED_INFORMATION
+	h, err := windows.OpenProcess(flags, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h)
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		// We have a handle but can't read state — be conservative
+		// and treat as alive so we don't accidentally seize a
+		// running daemon's lock.
+		return true
+	}
+	const stillActive = 259 // STILL_ACTIVE
+	return code == stillActive
+}

--- a/internal/daemon/methods.go
+++ b/internal/daemon/methods.go
@@ -1,0 +1,586 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/PeterBooker/locorum/internal/hooks"
+	"github.com/PeterBooker/locorum/internal/sites"
+	"github.com/PeterBooker/locorum/internal/storage"
+	"github.com/PeterBooker/locorum/internal/types"
+)
+
+// SiteService is the subset of *sites.SiteManager the daemon dispatches
+// to. Defined as an interface so daemon tests can stub it without
+// pulling Docker / SQLite into a unit test.
+//
+// The concrete *sites.SiteManager satisfies this interface today; new
+// methods land here when they're ready to be reachable from CLI/MCP.
+type SiteService interface {
+	DescribeAll(ctx context.Context, opts sites.DescribeOptions) ([]sites.SiteDescription, error)
+	Describe(ctx context.Context, siteID string, opts sites.DescribeOptions) (*sites.SiteDescription, error)
+
+	StartSite(ctx context.Context, siteID string) error
+	StopSite(ctx context.Context, siteID string) error
+
+	CreateWorktreeSite(ctx context.Context, opts sites.CreateWorktreeOptions) (*sites.CreateWorktreeResult, error)
+	DeleteSiteWithOptions(ctx context.Context, siteID string, opts sites.DeleteOptions) error
+
+	RecentActivity(siteID string) ([]storage.ActivityEvent, error)
+	GetActivity(siteID string, limit int) ([]storage.ActivityEvent, error)
+
+	GetContainerLogs(ctx context.Context, siteID, service string, lines int) (string, error)
+	ExecWPCLI(ctx context.Context, siteID string, args []string) (string, error)
+
+	Snapshot(ctx context.Context, siteID, label string) (string, error)
+	ListSnapshots(slug string) ([]sites.SnapshotInfo, error)
+	RestoreSnapshot(ctx context.Context, siteID, snapshotPath string, opts sites.RestoreSnapshotOptions) error
+
+	RunHookNow(ctx context.Context, h hooks.Hook) (hooks.Result, error)
+	ListSiteHooks(siteID string) ([]hooks.Hook, error)
+
+	// Used to resolve slug → site for slug-addressed methods so MCP
+	// tools can pass a slug without first asking for an id.
+	GetSites() ([]types.Site, error)
+}
+
+// RegisterMethods wires SiteService onto the Server. Methods are split
+// by side-effect class so the readonly profile only sees harmless ones.
+//
+// Site-scoped MCP enforcement applies to every method whose Params have
+// a "siteId" or "slug" field — see SiteScoped() option in server.go.
+func RegisterMethods(s *Server, svc SiteService) {
+	// ─── Read-only methods ──────────────────────────────────────────
+	s.Register("site.list", makeSiteList(svc), ReadOnly())
+	s.Register("site.describe", makeSiteDescribe(svc), ReadOnly(), SiteScoped())
+	s.Register("site.recentActivity", makeRecentActivity(svc), ReadOnly(), SiteScoped())
+	s.Register("site.activity", makeGetActivity(svc), ReadOnly(), SiteScoped())
+	s.Register("site.logs", makeContainerLogs(svc), ReadOnly(), SiteScoped())
+	s.Register("snapshot.list", makeSnapshotList(svc), ReadOnly(), SiteScoped())
+	s.Register("hook.list", makeHookList(svc), ReadOnly(), SiteScoped())
+
+	// ─── Mutating methods (Full only) ───────────────────────────────
+	s.Register("site.start", makeSiteStart(svc), SiteScoped())
+	s.Register("site.stop", makeSiteStop(svc), SiteScoped())
+	s.Register("site.wp", makeWPCLI(svc), SiteScoped())
+	s.Register("site.delete", makeSiteDelete(svc), SiteScoped())
+	s.Register("site.create_worktree", makeWorktreeCreate(svc))
+	s.Register("snapshot.create", makeSnapshotCreate(svc), SiteScoped())
+	s.Register("snapshot.restore", makeSnapshotRestore(svc), SiteScoped())
+	s.Register("hook.run", makeHookRun(svc), SiteScoped())
+}
+
+// ─── Param shapes ──────────────────────────────────────────────────────
+
+// siteRef identifies a site by either UUID or slug. Methods accept
+// whichever the caller has handy and resolve to the canonical id
+// internally. resolveSite returns NotFound on unknown values so both
+// shapes get the same error.
+type siteRef struct {
+	SiteID string `json:"siteId,omitempty"`
+	Slug   string `json:"slug,omitempty"`
+}
+
+// resolveSite converts a siteRef to a canonical site id by consulting
+// the SiteService. Empty values return CodeInvalidParams.
+func resolveSite(svc SiteService, ref siteRef) (string, error) {
+	if ref.SiteID != "" {
+		return ref.SiteID, nil
+	}
+	if ref.Slug == "" {
+		return "", NewMethodError(codeInvalidParams, "params must include siteId or slug", nil)
+	}
+	rows, err := svc.GetSites()
+	if err != nil {
+		return "", err
+	}
+	for _, s := range rows {
+		if s.Slug == ref.Slug {
+			return s.ID, nil
+		}
+	}
+	return "", NotFound("site")
+}
+
+// listOptions toggles the optional sections on site.list. The defaults
+// are cheap (no Docker / disk lookups). Clients pass true on the
+// fields they want.
+type listOptions struct {
+	IncludeActivity  bool `json:"includeActivity,omitempty"`
+	ActivityLimit    int  `json:"activityLimit,omitempty"`
+	IncludeSnapshots bool `json:"includeSnapshots,omitempty"`
+	IncludeHostPort  bool `json:"includeHostPort,omitempty"`
+}
+
+func (o listOptions) toDescribe() sites.DescribeOptions {
+	return sites.DescribeOptions{
+		IncludeActivity:  o.IncludeActivity,
+		ActivityLimit:    o.ActivityLimit,
+		IncludeSnapshots: o.IncludeSnapshots,
+		IncludeHostPort:  o.IncludeHostPort,
+	}
+}
+
+// ─── site.list ─────────────────────────────────────────────────────────
+
+func makeSiteList(svc SiteService) Handler {
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var p listOptions
+		if err := unmarshalParams(params, &p); err != nil {
+			return nil, err
+		}
+		return svc.DescribeAll(ctx, p.toDescribe())
+	}
+}
+
+// ─── site.describe ─────────────────────────────────────────────────────
+
+func makeSiteDescribe(svc SiteService) Handler {
+	type describeParams struct {
+		siteRef
+		listOptions
+	}
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var p describeParams
+		if err := unmarshalParams(params, &p); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, p.siteRef)
+		if err != nil {
+			return nil, err
+		}
+		desc, err := svc.Describe(ctx, id, p.listOptions.toDescribe())
+		if err != nil {
+			return nil, err
+		}
+		if desc == nil {
+			return nil, NotFound("site")
+		}
+		return desc, nil
+	}
+}
+
+// ─── site.start / site.stop ────────────────────────────────────────────
+
+func makeSiteStart(svc SiteService) Handler {
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var ref siteRef
+		if err := unmarshalParams(params, &ref); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, ref)
+		if err != nil {
+			return nil, err
+		}
+		if err := svc.StartSite(ctx, id); err != nil {
+			return nil, mapNotFoundError(err)
+		}
+		return map[string]any{"started": true, "siteId": id}, nil
+	}
+}
+
+func makeSiteStop(svc SiteService) Handler {
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var ref siteRef
+		if err := unmarshalParams(params, &ref); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, ref)
+		if err != nil {
+			return nil, err
+		}
+		if err := svc.StopSite(ctx, id); err != nil {
+			return nil, mapNotFoundError(err)
+		}
+		return map[string]any{"stopped": true, "siteId": id}, nil
+	}
+}
+
+// ─── site.recentActivity / site.activity ──────────────────────────────
+
+func makeRecentActivity(svc SiteService) Handler {
+	return func(_ context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var ref siteRef
+		if err := unmarshalParams(params, &ref); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, ref)
+		if err != nil {
+			return nil, err
+		}
+		rows, err := svc.RecentActivity(id)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"events": activityToWire(rows)}, nil
+	}
+}
+
+func makeGetActivity(svc SiteService) Handler {
+	type p struct {
+		siteRef
+		Limit int `json:"limit,omitempty"`
+	}
+	return func(_ context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var args p
+		if err := unmarshalParams(params, &args); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, args.siteRef)
+		if err != nil {
+			return nil, err
+		}
+		limit := args.Limit
+		if limit <= 0 {
+			limit = 50
+		}
+		rows, err := svc.GetActivity(id, limit)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"events": activityToWire(rows)}, nil
+	}
+}
+
+func activityToWire(rows []storage.ActivityEvent) []sites.ActivityEntry {
+	out := make([]sites.ActivityEntry, len(rows))
+	for i, r := range rows {
+		out[i] = sites.ActivityEntry{
+			ID:         r.ID,
+			Time:       r.Time,
+			Plan:       r.Plan,
+			Kind:       string(r.Kind),
+			Status:     string(r.Status),
+			DurationMS: r.DurationMS,
+			Message:    r.Message,
+		}
+	}
+	return out
+}
+
+// ─── site.logs ─────────────────────────────────────────────────────────
+
+func makeContainerLogs(svc SiteService) Handler {
+	type p struct {
+		siteRef
+		Service string `json:"service"`
+		Lines   int    `json:"lines,omitempty"`
+	}
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var args p
+		if err := unmarshalParams(params, &args); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, args.siteRef)
+		if err != nil {
+			return nil, err
+		}
+		if args.Service == "" {
+			return nil, NewMethodError(codeInvalidParams, "service is required", nil)
+		}
+		switch args.Service {
+		case "web", "php", "database", "redis":
+		default:
+			return nil, NewMethodError(codeInvalidParams, "unknown service: "+args.Service, nil)
+		}
+		lines := args.Lines
+		if lines <= 0 {
+			lines = 200
+		}
+		body, err := svc.GetContainerLogs(ctx, id, args.Service, lines)
+		if err != nil {
+			return nil, mapNotFoundError(err)
+		}
+		return map[string]any{"output": body, "service": args.Service, "lines": lines}, nil
+	}
+}
+
+// ─── site.wp (wp-cli) ──────────────────────────────────────────────────
+
+func makeWPCLI(svc SiteService) Handler {
+	type p struct {
+		siteRef
+		Args []string `json:"args"`
+	}
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var args p
+		if err := unmarshalParams(params, &args); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, args.siteRef)
+		if err != nil {
+			return nil, err
+		}
+		if len(args.Args) == 0 {
+			return nil, NewMethodError(codeInvalidParams, "args must contain at least one wp-cli argument", nil)
+		}
+		// Defence in depth: forbid raw shell metacharacters in args.
+		// ExecInContainer passes argv directly, so this is informational
+		// only — but better to reject early than ship the surprise to
+		// the user.
+		for _, a := range args.Args {
+			if strings.ContainsAny(a, "\x00") {
+				return nil, NewMethodError(codeInvalidParams, "wp-cli args must not contain NUL bytes", nil)
+			}
+		}
+		out, err := svc.ExecWPCLI(ctx, id, args.Args)
+		if err != nil {
+			return nil, mapNotFoundError(err)
+		}
+		return map[string]any{"output": out}, nil
+	}
+}
+
+// ─── snapshot.{create,list,restore} ────────────────────────────────────
+
+func makeSnapshotCreate(svc SiteService) Handler {
+	type p struct {
+		siteRef
+		Label string `json:"label,omitempty"`
+	}
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var args p
+		if err := unmarshalParams(params, &args); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, args.siteRef)
+		if err != nil {
+			return nil, err
+		}
+		path, err := svc.Snapshot(ctx, id, args.Label)
+		if err != nil {
+			return nil, mapNotFoundError(err)
+		}
+		return map[string]any{"path": path}, nil
+	}
+}
+
+func makeSnapshotList(svc SiteService) Handler {
+	return func(_ context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var ref siteRef
+		if err := unmarshalParams(params, &ref); err != nil {
+			return nil, err
+		}
+		// snapshot.list is keyed by slug on disk, not site id, so we
+		// need to resolve to a slug specifically. Look up the row.
+		rows, err := svc.GetSites()
+		if err != nil {
+			return nil, err
+		}
+		var slug string
+		for _, s := range rows {
+			if (ref.SiteID != "" && s.ID == ref.SiteID) || (ref.Slug != "" && s.Slug == ref.Slug) {
+				slug = s.Slug
+				break
+			}
+		}
+		if slug == "" {
+			return nil, NotFound("site")
+		}
+		snaps, err := svc.ListSnapshots(slug)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"snapshots": snaps}, nil
+	}
+}
+
+func makeSnapshotRestore(svc SiteService) Handler {
+	type p struct {
+		siteRef
+		Path     string `json:"path"`
+		Force    bool   `json:"force,omitempty"`
+		SkipHook bool   `json:"skipHook,omitempty"`
+	}
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var args p
+		if err := unmarshalParams(params, &args); err != nil {
+			return nil, err
+		}
+		if args.Path == "" {
+			return nil, NewMethodError(codeInvalidParams, "snapshot path is required", nil)
+		}
+		id, err := resolveSite(svc, args.siteRef)
+		if err != nil {
+			return nil, err
+		}
+		opts := sites.RestoreSnapshotOptions{
+			AllowEngineMismatch: args.Force,
+		}
+		if err := svc.RestoreSnapshot(ctx, id, args.Path, opts); err != nil {
+			return nil, mapNotFoundError(err)
+		}
+		return map[string]any{"restored": true}, nil
+	}
+}
+
+// ─── hook.list / hook.run ──────────────────────────────────────────────
+
+func makeHookList(svc SiteService) Handler {
+	return func(_ context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var ref siteRef
+		if err := unmarshalParams(params, &ref); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, ref)
+		if err != nil {
+			return nil, err
+		}
+		rows, err := svc.ListSiteHooks(id)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"hooks": rows}, nil
+	}
+}
+
+func makeHookRun(svc SiteService) Handler {
+	type p struct {
+		siteRef
+		HookID int64 `json:"hookId"`
+	}
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var args p
+		if err := unmarshalParams(params, &args); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, args.siteRef)
+		if err != nil {
+			return nil, err
+		}
+		// Find the hook by id within this site so the caller can't
+		// run a hook that belongs to a different site.
+		hookList, err := svc.ListSiteHooks(id)
+		if err != nil {
+			return nil, err
+		}
+		var target *hooks.Hook
+		for i := range hookList {
+			if hookList[i].ID == args.HookID {
+				target = &hookList[i]
+				break
+			}
+		}
+		if target == nil {
+			return nil, NotFound("hook")
+		}
+		res, err := svc.RunHookNow(ctx, *target)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"result": res}, nil
+	}
+}
+
+// ─── site.create_worktree ──────────────────────────────────────────────
+
+func makeWorktreeCreate(svc SiteService) Handler {
+	type p struct {
+		Name         string `json:"name"`
+		GitRemote    string `json:"gitRemote"`
+		Branch       string `json:"branch"`
+		ParentSlug   string `json:"parentSlug,omitempty"`
+		CloneDB      bool   `json:"cloneDb,omitempty"`
+		PHPVersion   string `json:"phpVersion,omitempty"`
+		DBEngine     string `json:"dbEngine,omitempty"`
+		DBVersion    string `json:"dbVersion,omitempty"`
+		RedisVersion string `json:"redisVersion,omitempty"`
+		WorktreeRoot string `json:"worktreeRoot,omitempty"`
+		DryRun       bool   `json:"dryRun,omitempty"`
+	}
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var args p
+		if err := unmarshalParams(params, &args); err != nil {
+			return nil, err
+		}
+		opts := sites.CreateWorktreeOptions{
+			Name:         args.Name,
+			GitRemote:    args.GitRemote,
+			Branch:       args.Branch,
+			ParentSlug:   args.ParentSlug,
+			CloneDB:      args.CloneDB,
+			PHPVersion:   args.PHPVersion,
+			DBEngine:     args.DBEngine,
+			DBVersion:    args.DBVersion,
+			RedisVersion: args.RedisVersion,
+			WorktreeRoot: args.WorktreeRoot,
+			DryRun:       args.DryRun,
+		}
+		res, err := svc.CreateWorktreeSite(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+}
+
+// ─── site.delete ───────────────────────────────────────────────────────
+
+func makeSiteDelete(svc SiteService) Handler {
+	type p struct {
+		siteRef
+		PurgeVolume   bool `json:"purgeVolume,omitempty"`
+		SkipSnapshot  bool `json:"skipSnapshot,omitempty"`
+		ForceWorktree bool `json:"forceWorktree,omitempty"`
+		DryRun        bool `json:"dryRun,omitempty"`
+	}
+	return func(ctx context.Context, _ *Conn, params json.RawMessage) (any, error) {
+		var args p
+		if err := unmarshalParams(params, &args); err != nil {
+			return nil, err
+		}
+		id, err := resolveSite(svc, args.siteRef)
+		if err != nil {
+			return nil, err
+		}
+		opts := sites.DeleteOptions{
+			PurgeVolume:   args.PurgeVolume,
+			SkipSnapshot:  args.SkipSnapshot,
+			ForceWorktree: args.ForceWorktree,
+			DryRun:        args.DryRun,
+		}
+		if err := svc.DeleteSiteWithOptions(ctx, id, opts); err != nil {
+			// Map worktree-dirty into a typed code so the CLI can
+			// prompt for --force without parsing strings.
+			if errors.Is(err, sites.ErrWorktreeDirty) {
+				return nil, NewMethodError(CodeConflict, err.Error(), err)
+			}
+			return nil, mapNotFoundError(err)
+		}
+		return map[string]any{"deleted": !args.DryRun, "siteId": id, "dryRun": args.DryRun}, nil
+	}
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────
+
+// unmarshalParams decodes params into v. Empty params is fine (v keeps
+// its zero values); malformed JSON is mapped to CodeInvalidParams.
+func unmarshalParams(params json.RawMessage, v any) error {
+	if len(params) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(params, v); err != nil {
+		return NewMethodError(codeInvalidParams, "invalid params: "+err.Error(), nil)
+	}
+	return nil
+}
+
+// mapNotFoundError translates well-known SiteManager error strings into
+// CodeNotFound. SiteManager returns plain fmt.Errorf("site %q not
+// found") values; the wire format prefers a typed code so MCP clients
+// don't string-match.
+func mapNotFoundError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var me *MethodError
+	if errors.As(err, &me) {
+		return err
+	}
+	if strings.Contains(err.Error(), "not found") {
+		return NewMethodError(CodeNotFound, err.Error(), err)
+	}
+	return err
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -1,0 +1,127 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// Wire-format constants. Locorum's IPC speaks JSON-RPC 2.0 framed by
+// newlines (no Content-Length headers — that's an LSP convention, not
+// a JSON-RPC requirement). One request per line, one response per line.
+// Notifications (method calls without "id") are not used today; the
+// dispatcher accepts them silently for forward-compat.
+const (
+	jsonRPCVersion = "2.0"
+
+	// MaxMessageBytes caps an inbound frame at 8 MiB. Generous enough
+	// for any realistic Locorum payload (a 5 MiB log tail is on the
+	// upper bound of what we render in the GUI), and small enough that
+	// a hostile or buggy client can't exhaust the daemon's heap with
+	// unbounded JSON.
+	MaxMessageBytes = 8 * 1024 * 1024
+)
+
+// JSON-RPC error codes. Values < -32000 are reserved by the spec for
+// transport-layer errors; method-specific errors live in the
+// implementation-defined range -32000..-32099.
+const (
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+
+	// CodeNotFound is returned when a method's target (site, snapshot,
+	// container) does not exist. Mapped from generic "not found"
+	// errors at the dispatcher boundary so clients can branch on it.
+	CodeNotFound = -32001
+
+	// CodeForbidden is returned when the caller's profile / scope does
+	// not permit the requested method. Distinguishes a security refusal
+	// from a buggy client.
+	CodeForbidden = -32002
+
+	// CodeAborted indicates the daemon was shutting down or otherwise
+	// could not service the request right now. Clients may retry.
+	CodeAborted = -32003
+
+	// CodeConflict reports that the request collides with current
+	// state — e.g. deleting a worktree with uncommitted changes
+	// without --force. The error message includes the actionable
+	// remediation; clients usually surface it directly.
+	CodeConflict = -32004
+)
+
+// Request is the inbound JSON-RPC frame.
+//
+// Params is left as raw bytes so per-method handlers can unmarshal into
+// their own typed struct without paying a re-marshal at the dispatcher.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is the outbound JSON-RPC frame. Exactly one of Result or
+// Error is set.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError matches the JSON-RPC 2.0 error object.
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+// ErrNoDaemon is returned by Dial when no daemon is running. CLI clients
+// catch this to decide whether to auto-spawn.
+var ErrNoDaemon = errors.New("no locorum daemon running")
+
+// MethodError builds a typed RPCError for handler returns. The
+// dispatcher unwraps these into the response's Error field and leaves
+// untyped errors to map to CodeInternalError.
+type MethodError struct {
+	Code    int
+	Message string
+	Cause   error
+}
+
+func (e *MethodError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Cause != nil {
+		return e.Message + ": " + e.Cause.Error()
+	}
+	return e.Message
+}
+
+func (e *MethodError) Unwrap() error { return e.Cause }
+
+// NewMethodError constructs a MethodError with a typed code.
+func NewMethodError(code int, msg string, cause error) *MethodError {
+	return &MethodError{Code: code, Message: msg, Cause: cause}
+}
+
+// NotFound is a sugar constructor for the common case.
+func NotFound(what string) *MethodError {
+	return &MethodError{Code: CodeNotFound, Message: what + " not found"}
+}
+
+// Forbidden is the profile-rejection sugar constructor.
+func Forbidden(method string) *MethodError {
+	return &MethodError{Code: CodeForbidden, Message: "method not permitted: " + method}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1,0 +1,454 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Handler is the per-method implementation. Receives the connection
+// context (already wired with cancellation), the unparsed params
+// (json.RawMessage), and returns either a result that will be JSON-
+// encoded as the response, or a *MethodError for typed errors.
+//
+// Handlers may return any error type; non-MethodError values map to
+// codeInternalError with the error string as the message. Sensitive
+// data (file paths the user might prefer hidden, plaintext credentials)
+// must NOT be embedded in handler errors — clients log them.
+type Handler func(ctx context.Context, conn *Conn, params json.RawMessage) (any, error)
+
+// Conn is the per-connection metadata exposed to handlers. PeerKind is
+// the self-declared client identity (cli, mcp, gui) — useful for
+// telemetry and "agent ran 17 mutations in the last hour" counters.
+// MCPScope, when non-empty, restricts every handler call to a specific
+// site slug; the dispatcher enforces this for site-scoped methods so
+// rogue MCP tool calls cannot pivot to a sibling worktree (D6 in the
+// AGENTS-SUPPORT plan).
+type Conn struct {
+	PeerKind string
+	MCPScope string
+	// Profile names the trust tier the client has selected. "full" is
+	// the default; "readonly" restricts to a curated method allowlist.
+	// Sandbox is reserved for a future tier (Part 6).
+	Profile string
+
+	// remote is the underlying connection. Handlers don't read or
+	// write it directly; the server owns the framing.
+	remote net.Conn
+}
+
+// Server is the JSON-RPC server side of the daemon. Constructed once
+// per process, mounted on a Listener, owns goroutine lifecycle for
+// every accepted connection.
+type Server struct {
+	ln       Listener
+	handlers map[string]methodEntry
+	logger   *slog.Logger
+
+	// activeConns counts in-flight connections so Shutdown can wait
+	// for them to drain. atomic to avoid a mutex on every Accept.
+	activeConns int64
+
+	// wg tracks every accept-loop and per-conn goroutine so Shutdown
+	// can return only after all of them exit.
+	wg sync.WaitGroup
+
+	// shutdownOnce guards against a double-close: a defer-Shutdown in
+	// the top-level call site combined with an explicit Shutdown in a
+	// signal handler is realistic.
+	shutdownOnce sync.Once
+	shutdownCh   chan struct{}
+}
+
+// methodEntry pairs a handler with its profile gating metadata. ReadOnly
+// methods are reachable from the readonly profile; everything else is
+// full-only. SiteScoped methods carry a "siteId" or "slug" string field
+// in their Params; the dispatcher pulls that field and rejects the call
+// if it doesn't match Conn.MCPScope (when scope is set).
+type methodEntry struct {
+	handler    Handler
+	readOnly   bool
+	siteScoped bool
+}
+
+// NewServer constructs a Server bound to ln. Methods are registered via
+// Register; the caller does that before Serve.
+func NewServer(ln Listener, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Server{
+		ln:         ln,
+		handlers:   make(map[string]methodEntry),
+		logger:     logger.With("subsys", "ipc"),
+		shutdownCh: make(chan struct{}),
+	}
+}
+
+// Register installs a handler for a method name. ReadOnly methods are
+// reachable from the readonly profile. SiteScoped methods accept Params
+// containing either a "siteId" or "slug" string; when MCP-scoped, the
+// dispatcher rejects calls whose value differs from the conn scope.
+func (s *Server) Register(method string, h Handler, opts ...MethodOption) {
+	entry := methodEntry{handler: h}
+	for _, opt := range opts {
+		opt(&entry)
+	}
+	s.handlers[method] = entry
+}
+
+// MethodOption mutates a methodEntry at registration time.
+type MethodOption func(*methodEntry)
+
+// ReadOnly marks a method as available in the readonly profile.
+func ReadOnly() MethodOption { return func(m *methodEntry) { m.readOnly = true } }
+
+// SiteScoped marks a method as enforcing scope checks against
+// Conn.MCPScope. Params must be a JSON object with a "siteId" or
+// "slug" string field; missing or mismatched values reject the call
+// with CodeForbidden.
+func SiteScoped() MethodOption { return func(m *methodEntry) { m.siteScoped = true } }
+
+// Serve runs the accept loop until the listener is closed or Shutdown
+// is called. Blocks; callers run it in a goroutine.
+func (s *Server) Serve(ctx context.Context) error {
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	// Cancel-on-shutdown ctx so per-conn handlers see the signal even
+	// before their underlying connection is closed.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		<-s.shutdownCh
+		cancel()
+	}()
+
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) || isShutdown(s.shutdownCh) {
+				return nil
+			}
+			// Transient accept errors (e.g. EMFILE) shouldn't kill
+			// the daemon; log and back off briefly.
+			s.logger.Warn("accept failed", "err", err.Error())
+			select {
+			case <-time.After(100 * time.Millisecond):
+			case <-s.shutdownCh:
+				return nil
+			}
+			continue
+		}
+		atomic.AddInt64(&s.activeConns, 1)
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			defer atomic.AddInt64(&s.activeConns, -1)
+			s.handleConn(ctx, conn)
+		}()
+	}
+}
+
+// Shutdown closes the listener, signals every in-flight connection,
+// and waits for handlers to drain (or up to timeout). Idempotent.
+//
+// Shutdown does NOT cancel handlers mid-RPC by force-closing the
+// connection — handlers see ctx.Done() and may complete or abort
+// gracefully. After the timeout, remaining connections are closed.
+func (s *Server) Shutdown(timeout time.Duration) {
+	s.shutdownOnce.Do(func() {
+		close(s.shutdownCh)
+		_ = s.ln.Close()
+	})
+	if timeout <= 0 {
+		s.wg.Wait()
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		s.logger.Warn("shutdown timed out with active connections",
+			"active", atomic.LoadInt64(&s.activeConns))
+	}
+}
+
+// handleConn reads newline-delimited JSON-RPC frames from conn and
+// dispatches each through the registered handler. One inbound message
+// produces exactly one outbound message; pipelining is supported (the
+// server reads the next frame as soon as the response is written).
+func (s *Server) handleConn(ctx context.Context, raw net.Conn) {
+	defer raw.Close()
+
+	conn := &Conn{
+		Profile: ProfileFull,
+		remote:  raw,
+	}
+
+	// One reader per conn. bufio.Scanner is bounded by MaxMessageBytes
+	// to keep a single hostile client from claiming all the daemon's
+	// memory by sending a multi-gigabyte never-newlined frame.
+	scanner := bufio.NewScanner(raw)
+	scanner.Buffer(make([]byte, 64*1024), MaxMessageBytes)
+	// Custom split: standard ScanLines is fine, but we want to trim CR
+	// proactively for any cross-platform clients that send CRLF.
+	scanner.Split(bufio.ScanLines)
+
+	enc := json.NewEncoder(raw)
+
+	// Connection write mutex: response writes from the dispatcher and
+	// future server-pushes (activity stream) share the connection.
+	var writeMu sync.Mutex
+
+	// Per-connection ctx so a malformed peer disconnect cancels its
+	// own in-flight handlers without affecting others.
+	connCtx, cancelConn := context.WithCancel(ctx)
+	defer cancelConn()
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		// Copy the line — Scanner reuses its buffer. We hand the
+		// bytes to a goroutine for concurrent dispatch, so the bytes
+		// must outlive the next call to Scan.
+		buf := make([]byte, len(line))
+		copy(buf, line)
+
+		var req Request
+		if err := json.Unmarshal(buf, &req); err != nil {
+			writeMu.Lock()
+			_ = enc.Encode(Response{
+				JSONRPC: jsonRPCVersion,
+				Error: &RPCError{
+					Code:    codeParseError,
+					Message: "parse error: " + err.Error(),
+				},
+			})
+			writeMu.Unlock()
+			continue
+		}
+
+		// Dispatch happens inline (one in-flight RPC per connection),
+		// not in a goroutine. JSON-RPC 2.0 allows pipelining but most
+		// clients don't, and serialising avoids the response-ordering
+		// surprise: a slow `start_site` followed by a fast
+		// `list_sites` should not let the second response overtake
+		// the first on the same conn.
+		s.dispatch(connCtx, conn, req, &writeMu, enc)
+
+		if isShutdown(s.shutdownCh) {
+			return
+		}
+	}
+
+	// scanner.Err returns nil on EOF (the normal client-disconnect
+	// path). Any other error is logged at debug because a hostile
+	// peer that overruns MaxMessageBytes shouldn't make noise in
+	// production logs.
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		s.logger.Debug("conn read err", "err", err.Error())
+	}
+}
+
+// dispatch resolves the method, enforces profile + scope gating, calls
+// the handler, and writes the response.
+func (s *Server) dispatch(ctx context.Context, conn *Conn, req Request, mu *sync.Mutex, enc *json.Encoder) {
+	resp := Response{JSONRPC: jsonRPCVersion, ID: req.ID}
+
+	if req.JSONRPC != "" && req.JSONRPC != jsonRPCVersion {
+		resp.Error = &RPCError{Code: codeInvalidRequest, Message: "unsupported jsonrpc version"}
+		writeResponse(mu, enc, resp)
+		return
+	}
+
+	// Built-in methods: client.hello (declares peer kind / scope /
+	// profile) is intercepted before the handler map so clients can
+	// initialise their own metadata. server.shutdown is intentionally
+	// NOT exposed over IPC — only the GUI's window-close path drives
+	// shutdown today.
+	switch req.Method {
+	case "client.hello":
+		s.handleHello(conn, req, mu, enc)
+		return
+	case "server.info":
+		s.handleServerInfo(conn, req, mu, enc)
+		return
+	}
+
+	entry, ok := s.handlers[req.Method]
+	if !ok {
+		resp.Error = &RPCError{Code: codeMethodNotFound, Message: "method not found: " + req.Method}
+		writeResponse(mu, enc, resp)
+		return
+	}
+	if conn.Profile == ProfileReadOnly && !entry.readOnly {
+		resp.Error = &RPCError{Code: CodeForbidden, Message: "method not permitted in readonly profile: " + req.Method}
+		writeResponse(mu, enc, resp)
+		return
+	}
+	if entry.siteScoped && conn.MCPScope != "" {
+		if err := enforceScope(conn.MCPScope, req.Params); err != nil {
+			resp.Error = &RPCError{Code: CodeForbidden, Message: err.Error()}
+			writeResponse(mu, enc, resp)
+			return
+		}
+	}
+
+	// Handler invocation. We catch panics so a bug in one method
+	// doesn't bring down the daemon — log + return CodeInternalError.
+	result, err := func() (out any, retErr error) {
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Error("handler panic", "method", req.Method, "panic", fmt.Sprint(r))
+				retErr = NewMethodError(codeInternalError, "internal error", nil)
+			}
+		}()
+		return entry.handler(ctx, conn, req.Params)
+	}()
+	if err != nil {
+		var me *MethodError
+		if errors.As(err, &me) {
+			resp.Error = &RPCError{Code: me.Code, Message: me.Error()}
+		} else {
+			resp.Error = &RPCError{Code: codeInternalError, Message: err.Error()}
+		}
+		writeResponse(mu, enc, resp)
+		return
+	}
+
+	body, err := json.Marshal(result)
+	if err != nil {
+		resp.Error = &RPCError{Code: codeInternalError, Message: "marshal result: " + err.Error()}
+		writeResponse(mu, enc, resp)
+		return
+	}
+	resp.Result = body
+	writeResponse(mu, enc, resp)
+}
+
+// handleHello processes the client.hello handshake. The client
+// declares its kind / profile / scope; the daemon stamps the conn
+// metadata and replies with server.info.
+func (s *Server) handleHello(conn *Conn, req Request, mu *sync.Mutex, enc *json.Encoder) {
+	type helloParams struct {
+		PeerKind string `json:"peerKind"`
+		Profile  string `json:"profile,omitempty"`
+		MCPScope string `json:"mcpScope,omitempty"`
+	}
+	var p helloParams
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &p); err != nil {
+			writeResponse(mu, enc, Response{
+				JSONRPC: jsonRPCVersion, ID: req.ID,
+				Error: &RPCError{Code: codeInvalidParams, Message: "hello: " + err.Error()},
+			})
+			return
+		}
+	}
+	conn.PeerKind = p.PeerKind
+	if p.Profile != "" {
+		switch p.Profile {
+		case ProfileFull, ProfileReadOnly:
+			conn.Profile = p.Profile
+		default:
+			writeResponse(mu, enc, Response{
+				JSONRPC: jsonRPCVersion, ID: req.ID,
+				Error: &RPCError{Code: codeInvalidParams, Message: "unknown profile: " + p.Profile},
+			})
+			return
+		}
+	}
+	conn.MCPScope = p.MCPScope
+
+	body, _ := json.Marshal(serverInfo{Version: jsonRPCVersion, Profile: conn.Profile})
+	writeResponse(mu, enc, Response{JSONRPC: jsonRPCVersion, ID: req.ID, Result: body})
+}
+
+// handleServerInfo returns daemon metadata so a CLI can verify it's
+// talking to a compatible daemon version. Profile is always reported as
+// the conn's effective profile.
+func (s *Server) handleServerInfo(conn *Conn, req Request, mu *sync.Mutex, enc *json.Encoder) {
+	body, _ := json.Marshal(serverInfo{Version: jsonRPCVersion, Profile: conn.Profile})
+	writeResponse(mu, enc, Response{JSONRPC: jsonRPCVersion, ID: req.ID, Result: body})
+}
+
+type serverInfo struct {
+	Version string `json:"version"`
+	Profile string `json:"profile"`
+}
+
+// Profile names the trust tier a connection has selected. Wire-stable
+// so MCP clients can pin them.
+const (
+	ProfileFull     = "full"
+	ProfileReadOnly = "readonly"
+)
+
+// enforceScope is the dispatcher-side gate for SiteScoped methods. We
+// tolerate either a "siteId" string (the canonical UUID) or a "slug"
+// string (human-friendly) — both are matched against the scope, which
+// itself may be either form. The MCP scope contract (D6 in the plan)
+// requires the daemon — not the client — to enforce this.
+func enforceScope(scope string, params json.RawMessage) error {
+	if len(params) == 0 {
+		return errors.New("mcp scope: method requires site id but params are empty")
+	}
+	var holder struct {
+		SiteID string `json:"siteId"`
+		Slug   string `json:"slug"`
+	}
+	if err := json.Unmarshal(params, &holder); err != nil {
+		return errors.New("mcp scope: params must include siteId or slug")
+	}
+	switch {
+	case holder.SiteID != "" && holder.SiteID == scope:
+		return nil
+	case holder.Slug != "" && holder.Slug == scope:
+		return nil
+	}
+	return fmt.Errorf("mcp scope: requested %q does not match conn scope %q",
+		firstNonEmpty(holder.SiteID, holder.Slug), scope)
+}
+
+func firstNonEmpty(s ...string) string {
+	for _, v := range s {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// writeResponse encodes resp under mu so concurrent dispatchers on the
+// same conn don't interleave bytes on the wire.
+func writeResponse(mu *sync.Mutex, enc *json.Encoder, resp Response) {
+	mu.Lock()
+	defer mu.Unlock()
+	_ = enc.Encode(resp)
+}
+
+// isShutdown reports whether the shutdown channel has been closed.
+// Cheap non-blocking peek used in the read/accept loops.
+func isShutdown(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,0 +1,291 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/hooks"
+	"github.com/PeterBooker/locorum/internal/sites"
+	"github.com/PeterBooker/locorum/internal/storage"
+	"github.com/PeterBooker/locorum/internal/types"
+)
+
+// fakeService implements SiteService for round-trip tests. Just enough
+// to exercise the dispatcher's parameter parsing, scope enforcement,
+// and JSON-RPC framing.
+type fakeService struct {
+	sites    []types.Site
+	startErr error
+
+	startedID string
+	stoppedID string
+}
+
+func (f *fakeService) DescribeAll(_ context.Context, _ sites.DescribeOptions) ([]sites.SiteDescription, error) {
+	out := make([]sites.SiteDescription, len(f.sites))
+	for i, s := range f.sites {
+		out[i] = sites.SiteDescription{ID: s.ID, Slug: s.Slug, Name: s.Name, URL: "https://" + s.Domain}
+	}
+	return out, nil
+}
+
+func (f *fakeService) Describe(_ context.Context, id string, _ sites.DescribeOptions) (*sites.SiteDescription, error) {
+	for _, s := range f.sites {
+		if s.ID == id {
+			return &sites.SiteDescription{ID: s.ID, Slug: s.Slug, Name: s.Name}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeService) StartSite(_ context.Context, id string) error {
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.startedID = id
+	return nil
+}
+
+func (f *fakeService) StopSite(_ context.Context, id string) error {
+	f.stoppedID = id
+	return nil
+}
+
+func (f *fakeService) RecentActivity(_ string) ([]storage.ActivityEvent, error) { return nil, nil }
+func (f *fakeService) GetActivity(_ string, _ int) ([]storage.ActivityEvent, error) {
+	return nil, nil
+}
+func (f *fakeService) GetContainerLogs(_ context.Context, _, _ string, _ int) (string, error) {
+	return "", nil
+}
+func (f *fakeService) ExecWPCLI(_ context.Context, _ string, _ []string) (string, error) {
+	return "", nil
+}
+func (f *fakeService) Snapshot(_ context.Context, _ string, _ string) (string, error) {
+	return "", nil
+}
+func (f *fakeService) ListSnapshots(_ string) ([]sites.SnapshotInfo, error) { return nil, nil }
+func (f *fakeService) RestoreSnapshot(_ context.Context, _, _ string, _ sites.RestoreSnapshotOptions) error {
+	return nil
+}
+func (f *fakeService) CreateWorktreeSite(_ context.Context, _ sites.CreateWorktreeOptions) (*sites.CreateWorktreeResult, error) {
+	return nil, nil
+}
+func (f *fakeService) DeleteSiteWithOptions(_ context.Context, _ string, _ sites.DeleteOptions) error {
+	return nil
+}
+func (f *fakeService) RunHookNow(_ context.Context, _ hooks.Hook) (hooks.Result, error) {
+	return hooks.Result{}, nil
+}
+func (f *fakeService) ListSiteHooks(_ string) ([]hooks.Hook, error) { return nil, nil }
+func (f *fakeService) GetSites() ([]types.Site, error)              { return f.sites, nil }
+
+// startTestServer wires a Server + Listener and returns a connected
+// client. Both are torn down at t.Cleanup.
+func startTestServer(t *testing.T, svc SiteService) *Client {
+	t.Helper()
+
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "ipc.sock")
+
+	ln, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	srv := NewServer(ln, nil)
+	RegisterMethods(srv, svc)
+
+	srvCtx, cancel := context.WithCancel(context.Background())
+	go func() { _ = srv.Serve(srvCtx) }()
+
+	t.Cleanup(func() {
+		cancel()
+		srv.Shutdown(time.Second)
+	})
+
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Second)
+	defer dialCancel()
+	cli, err := DialClient(dialCtx, sock, HelloOptions{PeerKind: "test"})
+	if err != nil {
+		t.Fatalf("DialClient: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+	return cli
+}
+
+func TestServer_RoundTrip_SiteList(t *testing.T) {
+	svc := &fakeService{
+		sites: []types.Site{
+			{ID: "id1", Slug: "first", Name: "First", Domain: "first.localhost"},
+			{ID: "id2", Slug: "second", Name: "Second", Domain: "second.localhost"},
+		},
+	}
+	cli := startTestServer(t, svc)
+
+	var out []sites.SiteDescription
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cli.Call(ctx, "site.list", map[string]any{}, &out); err != nil {
+		t.Fatalf("Call site.list: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("got %d sites, want 2", len(out))
+	}
+	if out[0].Slug != "first" {
+		t.Fatalf("first site slug: %q", out[0].Slug)
+	}
+}
+
+func TestServer_RoundTrip_SiteStart_BySlug(t *testing.T) {
+	svc := &fakeService{
+		sites: []types.Site{{ID: "id1", Slug: "shop", Name: "Shop"}},
+	}
+	cli := startTestServer(t, svc)
+
+	var out map[string]any
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cli.Call(ctx, "site.start", map[string]any{"slug": "shop"}, &out); err != nil {
+		t.Fatalf("Call site.start: %v", err)
+	}
+	if svc.startedID != "id1" {
+		t.Fatalf("StartSite was not called with the right id: got %q", svc.startedID)
+	}
+}
+
+func TestServer_NotFound_BySlug(t *testing.T) {
+	svc := &fakeService{}
+	cli := startTestServer(t, svc)
+
+	var out map[string]any
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := cli.Call(ctx, "site.start", map[string]any{"slug": "missing"}, &out)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	rpcErr, ok := err.(*RPCError)
+	if !ok {
+		t.Fatalf("expected RPCError, got %T", err)
+	}
+	if rpcErr.Code != CodeNotFound {
+		t.Fatalf("expected CodeNotFound (%d), got %d", CodeNotFound, rpcErr.Code)
+	}
+}
+
+func TestServer_ReadOnlyRejectsMutating(t *testing.T) {
+	svc := &fakeService{
+		sites: []types.Site{{ID: "id1", Slug: "shop"}},
+	}
+
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "ipc.sock")
+	ln, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	srv := NewServer(ln, nil)
+	RegisterMethods(srv, svc)
+
+	srvCtx, cancel := context.WithCancel(context.Background())
+	go func() { _ = srv.Serve(srvCtx) }()
+	t.Cleanup(func() {
+		cancel()
+		srv.Shutdown(time.Second)
+	})
+
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Second)
+	defer dialCancel()
+	cli, err := DialClient(dialCtx, sock, HelloOptions{PeerKind: "test", Profile: ProfileReadOnly})
+	if err != nil {
+		t.Fatalf("DialClient: %v", err)
+	}
+	defer cli.Close()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second)
+	defer ctxCancel()
+	var out map[string]any
+	err = cli.Call(ctx, "site.start", map[string]any{"slug": "shop"}, &out)
+	if err == nil {
+		t.Fatalf("expected forbidden error, got nil")
+	}
+	rpcErr, ok := err.(*RPCError)
+	if !ok {
+		t.Fatalf("expected RPCError, got %T", err)
+	}
+	if rpcErr.Code != CodeForbidden {
+		t.Fatalf("expected CodeForbidden, got %d", rpcErr.Code)
+	}
+
+	// Read-only methods still work.
+	var listOut []sites.SiteDescription
+	if err := cli.Call(ctx, "site.list", map[string]any{}, &listOut); err != nil {
+		t.Fatalf("readonly site.list: %v", err)
+	}
+}
+
+func TestServer_MCPScope_RejectsWrongSite(t *testing.T) {
+	svc := &fakeService{
+		sites: []types.Site{
+			{ID: "id1", Slug: "scoped"},
+			{ID: "id2", Slug: "other"},
+		},
+	}
+
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "ipc.sock")
+	ln, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	srv := NewServer(ln, nil)
+	RegisterMethods(srv, svc)
+
+	srvCtx, cancel := context.WithCancel(context.Background())
+	go func() { _ = srv.Serve(srvCtx) }()
+	t.Cleanup(func() {
+		cancel()
+		srv.Shutdown(time.Second)
+	})
+
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Second)
+	defer dialCancel()
+	cli, err := DialClient(dialCtx, sock, HelloOptions{
+		PeerKind: "mcp",
+		MCPScope: "scoped",
+	})
+	if err != nil {
+		t.Fatalf("DialClient: %v", err)
+	}
+	defer cli.Close()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second)
+	defer ctxCancel()
+	var out map[string]any
+	// Ask to start a different site than the scope. Should be refused.
+	err = cli.Call(ctx, "site.start", map[string]any{"slug": "other"}, &out)
+	if err == nil {
+		t.Fatalf("expected scope rejection, got nil")
+	}
+	rpcErr, ok := err.(*RPCError)
+	if !ok {
+		t.Fatalf("expected RPCError, got %T", err)
+	}
+	if rpcErr.Code != CodeForbidden {
+		t.Fatalf("expected CodeForbidden, got %d (msg=%s)", rpcErr.Code, rpcErr.Message)
+	}
+	if svc.startedID != "" {
+		t.Fatalf("StartSite was reached despite scope rejection")
+	}
+
+	// Sanity: scoped slug is allowed.
+	if err := cli.Call(ctx, "site.start", map[string]any{"slug": "scoped"}, &out); err != nil {
+		t.Fatalf("scoped slug should succeed, got %v", err)
+	}
+	if svc.startedID != "id1" {
+		t.Fatalf("expected startedID=id1, got %q", svc.startedID)
+	}
+}

--- a/internal/daemon/spawn_unix.go
+++ b/internal/daemon/spawn_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// configureDetached makes the spawned daemon process survive its
+// parent's exit. Setsid creates a new session so the child becomes its
+// own process group leader and is no longer attached to the controlling
+// terminal of the CLI that spawned it.
+func configureDetached(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}
+
+// nullDevice opens /dev/null in append mode for use as the daemon's
+// stdout/stderr when the canonical log path is unwritable.
+func nullDevice() *os.File {
+	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return nil
+	}
+	return f
+}

--- a/internal/daemon/spawn_windows.go
+++ b/internal/daemon/spawn_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// configureDetached spawns the daemon detached so a CLI exit does not
+// kill it. CreateNoWindow hides the console window the new process
+// would otherwise inherit when launched from a GUI Locorum binary.
+func configureDetached(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP | 0x08000000 // CREATE_NO_WINDOW
+}
+
+// nullDevice opens NUL for the daemon's stdout/stderr fallback.
+func nullDevice() *os.File {
+	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return nil
+	}
+	return f
+}

--- a/internal/daemon/transport.go
+++ b/internal/daemon/transport.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"net"
+	"time"
+)
+
+// Listener is the OS-specific listening socket the daemon accepts JSON-
+// RPC connections on. transport_unix.go and transport_windows.go each
+// provide a concrete constructor.
+type Listener interface {
+	Accept() (net.Conn, error)
+	Close() error
+	Addr() string
+}
+
+// dialTimeout is the upper bound on how long a CLI client waits for the
+// daemon's socket to become available after auto-spawn. The daemon
+// finishes binding the socket as part of its normal startup, before
+// app.Initialize touches Docker, so this only needs to be long enough
+// to cover process exec + the few syscalls before Listen returns. Two
+// seconds is generous; the goroutine is bounded by ctx anyway.
+const dialTimeout = 2 * time.Second

--- a/internal/daemon/transport_unix.go
+++ b/internal/daemon/transport_unix.go
@@ -1,0 +1,95 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+)
+
+// unixListener is a thin wrapper around net.UnixListener that pins the
+// chmod 0600 invariant: only the owner of the socket file can connect.
+// On Linux this is enforced by the filesystem perms (peer SO_PEERCRED
+// is also available but not relied on); on macOS the same perm scheme
+// is the documented protection mechanism.
+type unixListener struct {
+	*net.UnixListener
+	path string
+}
+
+func (u *unixListener) Addr() string { return u.path }
+
+func (u *unixListener) Close() error {
+	err := u.UnixListener.Close()
+	// net.UnixListener.Close removes the socket file when SetUnlinkOnClose(true)
+	// is set (Go default since 1.8). Belt-and-braces unlink in case a
+	// future Go release changes the default — leaving the file behind
+	// would block the next Acquire+Listen.
+	_ = os.Remove(u.path)
+	return err
+}
+
+// Listen creates a Unix domain socket listener at path with 0600 perms.
+// Removes a stale socket file if its owner is dead (Acquire's
+// stale-detection is the canonical place for that, but a stale .sock
+// without a matching .lock is still possible if the lock was removed by
+// hand).
+func Listen(path string) (Listener, error) {
+	if err := os.MkdirAll(parentDir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create socket dir: %w", err)
+	}
+	// Best-effort cleanup. If a live daemon were listening on this
+	// path, the lock would already have refused us, so a leftover file
+	// here is necessarily stale.
+	_ = os.Remove(path)
+
+	addr, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve unix addr: %w", err)
+	}
+	ln, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen unix: %w", err)
+	}
+	ln.SetUnlinkOnClose(true)
+
+	// Tighten perms BEFORE returning. Linux respects umask on bind, so
+	// without this chmod a permissive umask (002) leaves the socket
+	// group-writable.
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = ln.Close()
+		return nil, fmt.Errorf("chmod socket: %w", err)
+	}
+	return &unixListener{UnixListener: ln, path: path}, nil
+}
+
+// Dial connects to the daemon socket at path. Returns a net.Conn ready
+// for newline-delimited JSON-RPC. Honours ctx cancellation.
+func Dial(ctx context.Context, path string) (net.Conn, error) {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNoDaemon
+		}
+		return nil, fmt.Errorf("stat socket: %w", err)
+	}
+	d := net.Dialer{}
+	conn, err := d.DialContext(ctx, "unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("dial socket: %w", err)
+	}
+	return conn, nil
+}
+
+// parentDir returns the parent of p without pulling in path/filepath
+// for a single split. Callers pass absolute paths only.
+func parentDir(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' || p[i] == '\\' {
+			return p[:i]
+		}
+	}
+	return "."
+}

--- a/internal/daemon/transport_windows.go
+++ b/internal/daemon/transport_windows.go
@@ -1,0 +1,87 @@
+//go:build windows
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/user"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// windowsPipePrefix is the canonical Win32 named-pipe prefix. The full
+// pipe path is `\\.\pipe\locorum-{user-sid}` so two users on the same
+// machine cannot collide. SIDs (S-1-5-21-…) are unique per account and
+// do not contain reserved pipe-name chars, so they go in raw.
+const windowsPipePrefix = `\\.\pipe\locorum-`
+
+// pipeListener wraps the Microsoft/go-winio listener. Addr() returns
+// the full pipe path so the CLI dial path matches.
+type pipeListener struct {
+	net.Listener
+	path string
+}
+
+func (p *pipeListener) Addr() string { return p.path }
+
+// Listen opens a Windows named pipe at the per-user path. The path
+// argument is honoured for compatibility with the unix transport but
+// the daemon always rewrites it to the per-user pipe to avoid
+// cross-user squatting.
+func Listen(path string) (Listener, error) {
+	pipe, err := pipePath()
+	if err != nil {
+		return nil, err
+	}
+	// Owner-only ACL: D:P(A;;GA;;;OW) — Discretionary ACL, Protected,
+	// Allow Generic All to Owner. Mirrors the 0600 unix invariant.
+	cfg := &winio.PipeConfig{
+		SecurityDescriptor: "D:P(A;;GA;;;OW)",
+		MessageMode:        false, // byte mode, matches net.Conn semantics
+		InputBufferSize:    65536,
+		OutputBufferSize:   65536,
+	}
+	ln, err := winio.ListenPipe(pipe, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("listen pipe: %w", err)
+	}
+	return &pipeListener{Listener: ln, path: pipe}, nil
+}
+
+// Dial connects to the daemon's named pipe.
+func Dial(ctx context.Context, path string) (net.Conn, error) {
+	pipe, err := pipePath()
+	if err != nil {
+		return nil, err
+	}
+	conn, err := winio.DialPipeContext(ctx, pipe)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNoDaemon
+		}
+		return nil, fmt.Errorf("dial pipe: %w", err)
+	}
+	return conn, nil
+}
+
+// pipePath returns the per-user named-pipe path. SID is preferred over
+// username because it survives renames and avoids issues with non-ASCII
+// account names. Falls back to the username if SID lookup fails (rare).
+func pipePath() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("identify user: %w", err)
+	}
+	id := u.Uid
+	if id == "" {
+		id = u.Username
+	}
+	if id == "" {
+		return "", errors.New("could not identify current user")
+	}
+	return windowsPipePrefix + id, nil
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,217 @@
+// Package git wraps the user's installed git CLI for the small set of
+// operations Locorum needs: cloning a remote, fetching, listing
+// branches, creating and removing worktrees, and detecting dirty
+// state. We shell out to git rather than using go-git so the user's
+// own .gitconfig (auth helpers, signing keys, signed pushes, identity)
+// applies transparently — exactly what an agent running locally would
+// expect.
+//
+// Every function takes a context.Context. Cancellation is honoured
+// via exec.CommandContext, which sends SIGKILL on cancel; that's
+// blunt but appropriate for a multi-minute clone the user wants to
+// abort.
+package git
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Runner abstracts command execution so tests can swap in a fake.
+// Default is the OS git binary.
+type Runner interface {
+	Run(ctx context.Context, dir string, args ...string) (string, string, error)
+}
+
+// CLI is the production Runner. dir is the repository root (or empty
+// for global commands like `git clone <url> <dest>`); args are passed
+// verbatim to git.
+type CLI struct{}
+
+// Run executes git with args in dir and returns its stdout and stderr.
+// Non-zero exit codes are surfaced as a *ExitError so callers can
+// distinguish "git refused" from "git wasn't found."
+func (CLI) Run(ctx context.Context, dir string, args ...string) (string, string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// Default is the package-wide singleton used by Clone / Fetch / etc.
+// Tests swap it via WithRunner; production never reassigns.
+var Default Runner = CLI{}
+
+// withRunner returns r if non-nil, else Default. Lets tests inject a
+// fake without forcing a global swap.
+func withRunner(r Runner) Runner {
+	if r == nil {
+		return Default
+	}
+	return r
+}
+
+// ExitError is returned when git ran but reported a non-zero exit.
+// Stderr captures git's complaint so callers can show it verbatim.
+type ExitError struct {
+	Args   []string
+	Dir    string
+	Stderr string
+	Cause  error
+}
+
+func (e *ExitError) Error() string {
+	if e == nil {
+		return ""
+	}
+	stderr := strings.TrimSpace(e.Stderr)
+	if stderr != "" {
+		return fmt.Sprintf("git %s: %s", strings.Join(e.Args, " "), stderr)
+	}
+	return fmt.Sprintf("git %s: %v", strings.Join(e.Args, " "), e.Cause)
+}
+
+func (e *ExitError) Unwrap() error { return e.Cause }
+
+// run is the package-internal helper that wraps every git invocation
+// in a uniform error envelope.
+func run(ctx context.Context, r Runner, dir string, args ...string) (string, error) {
+	stdout, stderr, err := withRunner(r).Run(ctx, dir, args...)
+	if err != nil {
+		return stdout, &ExitError{Args: args, Dir: dir, Stderr: stderr, Cause: err}
+	}
+	return stdout, nil
+}
+
+// Clone shallow-clones remote into dest. Idempotent: if dest already
+// exists and is a git repo, Clone is a no-op (fetch via Fetch).
+//
+// We use --depth=1 by default to keep clones fast; agents that need
+// full history can pass extra args via CloneOptions.
+type CloneOptions struct {
+	// Runner overrides the default git CLI runner. Tests inject; nil
+	// in production.
+	Runner Runner
+
+	// Depth, when > 0, passes --depth N. Zero means full history.
+	Depth int
+
+	// Branch, when set, passes --branch B and clones only that ref.
+	// Useful when the user knows up-front which branch they want.
+	Branch string
+}
+
+// Clone runs `git clone` from a clean dest path. Returns
+// errors.New("destination is not empty") if dest already contains a
+// non-git directory; callers that want a fetch-or-clone should call
+// EnsureRepo instead.
+func Clone(ctx context.Context, remote, dest string, opts CloneOptions) error {
+	args := []string{"clone"}
+	if opts.Depth > 0 {
+		args = append(args, "--depth", fmt.Sprintf("%d", opts.Depth))
+	}
+	if opts.Branch != "" {
+		args = append(args, "--branch", opts.Branch)
+	}
+	args = append(args, remote, dest)
+	_, err := run(ctx, opts.Runner, "", args...)
+	return err
+}
+
+// Fetch updates remotes for an existing repo. Equivalent to running
+// `git fetch --all --prune` from inside the working tree.
+func Fetch(ctx context.Context, repoDir string, r Runner) error {
+	_, err := run(ctx, r, repoDir, "fetch", "--all", "--prune")
+	return err
+}
+
+// IsRepo reports whether dir is a git working tree. Cheap (single
+// `rev-parse` call) but allocates a process — callers should cache the
+// result if they're calling it in a hot loop.
+func IsRepo(ctx context.Context, dir string, r Runner) bool {
+	_, err := run(ctx, r, dir, "rev-parse", "--is-inside-work-tree")
+	return err == nil
+}
+
+// EnsureRepo clones remote into dest if dest is empty / missing,
+// otherwise runs Fetch on the existing repo. Returns the absolute
+// repo path on success. Concurrent calls for the same dest race at
+// the filesystem level — callers serialise via the per-site mutex.
+func EnsureRepo(ctx context.Context, remote, dest string, opts CloneOptions) (string, error) {
+	abs, err := filepath.Abs(dest)
+	if err != nil {
+		return "", fmt.Errorf("resolve dest: %w", err)
+	}
+	if IsRepo(ctx, abs, opts.Runner) {
+		if err := Fetch(ctx, abs, opts.Runner); err != nil {
+			return abs, err
+		}
+		return abs, nil
+	}
+	if err := Clone(ctx, remote, abs, opts); err != nil {
+		return abs, err
+	}
+	return abs, nil
+}
+
+// WorktreeAdd creates a worktree at path tracking branch. If branch
+// does not exist locally, --track is used to create it from
+// origin/<branch>. Failures during creation surface git's stderr.
+func WorktreeAdd(ctx context.Context, repoDir, path, branch string, r Runner) error {
+	if path == "" || branch == "" {
+		return errors.New("WorktreeAdd: path and branch are required")
+	}
+	// Existence check first so we don't fight a stale .git/worktrees
+	// entry. -f --force lets us reattach when git has the entry but
+	// the path is missing.
+	if branchExists(ctx, repoDir, branch, r) {
+		_, err := run(ctx, r, repoDir, "worktree", "add", path, branch)
+		return err
+	}
+	// Create the branch from origin/<branch>. If origin doesn't have
+	// it either, git will fail with a clear message that we forward.
+	_, err := run(ctx, r, repoDir, "worktree", "add", "-b", branch, path, "origin/"+branch)
+	return err
+}
+
+// WorktreeRemove removes the worktree at path. force=true uses
+// `--force` so dirty trees don't block removal — appropriate when the
+// caller has confirmed the user wants to discard changes.
+func WorktreeRemove(ctx context.Context, repoDir, path string, force bool, r Runner) error {
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, path)
+	_, err := run(ctx, r, repoDir, args...)
+	return err
+}
+
+// HasUncommittedChanges reports whether the worktree at dir has any
+// staged, unstaged, or untracked changes. Used by DeleteSite to warn
+// before removing a worktree.
+func HasUncommittedChanges(ctx context.Context, dir string, r Runner) (bool, error) {
+	out, err := run(ctx, r, dir, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
+// branchExists reports whether the given branch is present locally
+// (refs/heads/<branch>). Used by WorktreeAdd to decide between
+// `worktree add <path> <branch>` and `worktree add -b <branch>`.
+func branchExists(ctx context.Context, repoDir, branch string, r Runner) bool {
+	_, err := run(ctx, r, repoDir, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+	return err == nil
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,185 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// fakeRunner records every invocation and returns scripted responses.
+// Tests assert against the recorded args to verify that the helpers
+// build the right git command lines.
+type fakeRunner struct {
+	calls []recordedCall
+	// responses is keyed by the joined args; missing keys return
+	// empty stdout and nil error.
+	responses map[string]response
+}
+
+type recordedCall struct {
+	dir  string
+	args []string
+}
+
+type response struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func (f *fakeRunner) Run(_ context.Context, dir string, args ...string) (string, string, error) {
+	f.calls = append(f.calls, recordedCall{dir: dir, args: append([]string{}, args...)})
+	if f.responses == nil {
+		return "", "", nil
+	}
+	key := joinArgs(args)
+	r, ok := f.responses[key]
+	if !ok {
+		return "", "", nil
+	}
+	return r.stdout, r.stderr, r.err
+}
+
+func joinArgs(args []string) string {
+	out := ""
+	for i, a := range args {
+		if i > 0 {
+			out += " "
+		}
+		out += a
+	}
+	return out
+}
+
+func TestClone_Args(t *testing.T) {
+	r := &fakeRunner{}
+	if err := Clone(context.Background(), "git@x:repo.git", "/tmp/dest", CloneOptions{
+		Runner: r, Depth: 1, Branch: "main",
+	}); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(r.calls))
+	}
+	args := r.calls[0].args
+	want := []string{"clone", "--depth", "1", "--branch", "main", "git@x:repo.git", "/tmp/dest"}
+	if joinArgs(args) != joinArgs(want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+}
+
+func TestEnsureRepo_FetchPathOnExistingRepo(t *testing.T) {
+	r := &fakeRunner{
+		responses: map[string]response{
+			"rev-parse --is-inside-work-tree": {stdout: "true\n"},
+		},
+	}
+	abs, _ := filepath.Abs("/tmp/repo")
+	dest, err := EnsureRepo(context.Background(), "git@x:repo.git", abs, CloneOptions{Runner: r})
+	if err != nil {
+		t.Fatalf("EnsureRepo: %v", err)
+	}
+	if dest != abs {
+		t.Fatalf("dest mismatch: %q vs %q", dest, abs)
+	}
+	// Calls: rev-parse, then fetch.
+	if len(r.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d (%v)", len(r.calls), r.calls)
+	}
+	if r.calls[1].args[0] != "fetch" {
+		t.Fatalf("expected fetch as second call, got %v", r.calls[1].args)
+	}
+}
+
+func TestEnsureRepo_ClonesWhenMissing(t *testing.T) {
+	r := &fakeRunner{
+		responses: map[string]response{
+			"rev-parse --is-inside-work-tree": {err: errors.New("not a git dir")},
+		},
+	}
+	abs, _ := filepath.Abs("/tmp/new-repo")
+	if _, err := EnsureRepo(context.Background(), "git@x:repo.git", abs, CloneOptions{Runner: r}); err != nil {
+		t.Fatalf("EnsureRepo: %v", err)
+	}
+	if len(r.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d (%v)", len(r.calls), r.calls)
+	}
+	if r.calls[1].args[0] != "clone" {
+		t.Fatalf("expected clone as second call, got %v", r.calls[1].args)
+	}
+}
+
+func TestWorktreeAdd_BranchExists(t *testing.T) {
+	r := &fakeRunner{
+		responses: map[string]response{
+			"rev-parse --verify --quiet refs/heads/feature": {stdout: "abc123\n"},
+		},
+	}
+	if err := WorktreeAdd(context.Background(), "/repo", "/tmp/wt", "feature", r); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	last := r.calls[len(r.calls)-1].args
+	want := []string{"worktree", "add", "/tmp/wt", "feature"}
+	if joinArgs(last) != joinArgs(want) {
+		t.Fatalf("args = %v, want %v", last, want)
+	}
+}
+
+func TestWorktreeAdd_BranchMissingTracksOrigin(t *testing.T) {
+	r := &fakeRunner{
+		responses: map[string]response{
+			"rev-parse --verify --quiet refs/heads/feature": {err: errors.New("no")},
+		},
+	}
+	if err := WorktreeAdd(context.Background(), "/repo", "/tmp/wt", "feature", r); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	last := r.calls[len(r.calls)-1].args
+	want := []string{"worktree", "add", "-b", "feature", "/tmp/wt", "origin/feature"}
+	if joinArgs(last) != joinArgs(want) {
+		t.Fatalf("args = %v, want %v", last, want)
+	}
+}
+
+func TestWorktreeRemove_Force(t *testing.T) {
+	r := &fakeRunner{}
+	if err := WorktreeRemove(context.Background(), "/repo", "/tmp/wt", true, r); err != nil {
+		t.Fatalf("WorktreeRemove: %v", err)
+	}
+	args := r.calls[0].args
+	want := []string{"worktree", "remove", "--force", "/tmp/wt"}
+	if joinArgs(args) != joinArgs(want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+}
+
+func TestHasUncommittedChanges_Empty(t *testing.T) {
+	r := &fakeRunner{
+		responses: map[string]response{
+			"status --porcelain": {stdout: ""},
+		},
+	}
+	dirty, err := HasUncommittedChanges(context.Background(), "/repo", r)
+	if err != nil {
+		t.Fatalf("HasUncommittedChanges: %v", err)
+	}
+	if dirty {
+		t.Fatalf("expected clean tree")
+	}
+}
+
+func TestHasUncommittedChanges_Dirty(t *testing.T) {
+	r := &fakeRunner{
+		responses: map[string]response{
+			"status --porcelain": {stdout: " M README.md\n"},
+		},
+	}
+	dirty, err := HasUncommittedChanges(context.Background(), "/repo", r)
+	if err != nil {
+		t.Fatalf("HasUncommittedChanges: %v", err)
+	}
+	if !dirty {
+		t.Fatalf("expected dirty tree")
+	}
+}

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -1,0 +1,297 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HTTP MCP transport. MCP defines a "Streamable HTTP" transport that
+// accepts a JSON-RPC request via POST /mcp and returns either a
+// regular response or a Server-Sent-Events stream. Locorum's tools
+// are short request/response so we ship the simpler subset: POST a
+// single JSON object, get a single JSON object back. A future
+// revision can add SSE for tool calls that stream output (e.g. a
+// long wp-cli run).
+//
+// Security: the listener defaults to 127.0.0.1, refuses 0.0.0.0
+// without an explicit --bind flag, and requires a per-process bearer
+// token (token.go). Filesystem perms on the token file (0600) limit
+// the attack surface to other processes running as the same user.
+
+// HTTPServer is the HTTP frontend for an existing daemon client. One
+// goroutine handles the listen + accept loop; per-request dispatch is
+// stateless so the http.Handler is goroutine-safe by construction.
+type HTTPServer struct {
+	addr     string
+	token    string
+	mux      *http.ServeMux
+	listener net.Listener
+	srv      *http.Server
+	core     *Server // wraps the same dispatch logic as stdio mode
+	logger   *slog.Logger
+
+	mu      sync.Mutex
+	stopped bool
+}
+
+// HTTPOptions configures the HTTP server. Bind is the listen address
+// (e.g. "127.0.0.1:2484"); Token is the bearer secret clients send in
+// `Authorization: Bearer <token>`.
+type HTTPOptions struct {
+	Bind   string
+	Token  string
+	Server *Server // typically constructed via NewServer with stdio I/O wired to nil
+	Logger *slog.Logger
+}
+
+// NewHTTPServer wires an HTTP listener around the existing dispatch
+// engine. The caller must have already initialised opts.Server with a
+// daemon Client; we don't second-guess the trust profile.
+//
+// Refuses non-loopback binds unless the caller explicitly asks for
+// one by passing a pre-resolved IP — we only check the literal Bind
+// string against a safe-list. The CLI shows a clear error before
+// reaching this point so the message reads naturally.
+func NewHTTPServer(opts HTTPOptions) (*HTTPServer, error) {
+	if opts.Server == nil {
+		return nil, errors.New("http mcp: server is required")
+	}
+	if opts.Token == "" {
+		return nil, errors.New("http mcp: token is required")
+	}
+	if err := validateBind(opts.Bind); err != nil {
+		return nil, err
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	h := &HTTPServer{
+		addr:   opts.Bind,
+		token:  opts.Token,
+		mux:    http.NewServeMux(),
+		core:   opts.Server,
+		logger: logger.With("subsys", "mcp.http"),
+	}
+	h.mux.HandleFunc("/mcp", h.handleMCP)
+	h.mux.HandleFunc("/healthz", h.handleHealth)
+	return h, nil
+}
+
+// Serve binds the listener and serves requests until ctx cancels or
+// Shutdown is called.
+func (h *HTTPServer) Serve(ctx context.Context) error {
+	ln, err := net.Listen("tcp", h.addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", h.addr, err)
+	}
+	h.listener = ln
+	h.srv = &http.Server{
+		Handler:           h,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		// Allow the user's prompt to span multiple sentences; 1 MiB
+		// covers typical tool calls without giving an attacker free
+		// memory.
+		MaxHeaderBytes: 1 << 20,
+	}
+	go func() {
+		<-ctx.Done()
+		_ = h.Shutdown()
+	}()
+	h.logger.Info("http mcp listening", "addr", h.actualAddr())
+	if err := h.srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+// actualAddr returns the bound address as the OS reports it (so a
+// :0 port shows up as a real number). Falls back to the requested
+// addr when the listener is nil.
+func (h *HTTPServer) actualAddr() string {
+	if h.listener == nil {
+		return h.addr
+	}
+	return h.listener.Addr().String()
+}
+
+// Addr returns the bound listen address. Useful in tests that pass
+// :0 to pick a free port.
+func (h *HTTPServer) Addr() string { return h.actualAddr() }
+
+// Shutdown stops accepting new connections and waits up to 5s for
+// in-flight requests to finish.
+func (h *HTTPServer) Shutdown() error {
+	h.mu.Lock()
+	if h.stopped {
+		h.mu.Unlock()
+		return nil
+	}
+	h.stopped = true
+	h.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if h.srv != nil {
+		return h.srv.Shutdown(ctx)
+	}
+	return nil
+}
+
+// ServeHTTP is the http.Handler entry point — delegates to the mux.
+// Defined explicitly so the type satisfies http.Handler with a
+// custom error / log path.
+func (h *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mux.ServeHTTP(w, r)
+}
+
+// handleMCP is the JSON-RPC endpoint. Accepts POST /mcp with one
+// JSON object in the body, dispatches via the same engine as stdio,
+// and writes the response as a single JSON object. Notifications
+// (id missing) return 204 No Content.
+func (h *HTTPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	if !h.checkAuth(r) {
+		// 401 with a generic message — no hint about why so a probing
+		// attacker can't tell whether the token was wrong or absent.
+		w.Header().Set("WWW-Authenticate", `Bearer realm="locorum-mcp"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 8*1024*1024))
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	r.Body.Close()
+
+	// Reuse the stdio Server's dispatch by passing the body through
+	// its in/out streams. We construct a one-shot pair: the request
+	// goes in, the response comes out, then we tear down.
+	var (
+		in  = bytes.NewReader(append(body, '\n'))
+		out bytes.Buffer
+	)
+	once := h.core.cloneForOneShot(in, &out)
+	if err := once.Serve(r.Context()); err != nil {
+		h.logger.Warn("dispatch failed", "err", err.Error())
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if out.Len() == 0 {
+		// Notification — no response body per JSON-RPC spec.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	// Strip trailing newline json.Encoder added — most HTTP clients
+	// don't care, but unit tests are easier without it.
+	resp := bytes.TrimRight(out.Bytes(), "\n")
+	_, _ = w.Write(resp)
+}
+
+// handleHealth is a tiny endpoint MCP clients can hit to verify the
+// server is up before sending a real request. Returns 200 with a
+// short JSON body. Authentication is NOT required — we surface no
+// secrets and the bind is loopback by default.
+func (h *HTTPServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, `{"status":"ok","name":"locorum"}`)
+}
+
+// checkAuth pulls the Authorization header and constant-time-compares
+// against the configured token. Header parsing is intentionally
+// strict — we accept only "Bearer <token>" with no whitespace
+// tolerance beyond a single space, so a malformed header is a hint
+// the client is misconfigured rather than an attempt to bypass us.
+func (h *HTTPServer) checkAuth(r *http.Request) bool {
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return false
+	}
+	got := auth[len(prefix):]
+	return CompareTokens(got, h.token)
+}
+
+// validateBind enforces the localhost-default rule. We only allow:
+//
+//   - empty (caller will let net.Listen pick) — refused so the user
+//     always sees an explicit address in logs
+//   - 127.0.0.1:PORT or [::1]:PORT — explicit loopback
+//   - localhost:PORT — also loopback after DNS resolution, but reject
+//     because hostnames are inherently ambiguous (a hostile DNS could
+//     point at 0.0.0.0); require the literal IP for clarity
+//   - any other IPv4/IPv6 address — rejected with a clear message so
+//     a user typing `--bind :2484` can't accidentally serve to the
+//     network. They can override via `--bind 0.0.0.0:2484` in code,
+//     but the CLI gates that path behind a separate flag.
+func validateBind(bind string) error {
+	if bind == "" {
+		return errors.New("bind address is required (e.g. 127.0.0.1:2484)")
+	}
+	host, port, err := net.SplitHostPort(bind)
+	if err != nil {
+		return fmt.Errorf("invalid bind %q: %w", bind, err)
+	}
+	if port == "" {
+		return fmt.Errorf("invalid bind %q: missing port", bind)
+	}
+	switch host {
+	case "127.0.0.1", "::1":
+		return nil
+	case "":
+		return fmt.Errorf("bind %q omits host; use 127.0.0.1:%s explicitly", bind, port)
+	}
+	// Anything else: caller must opt in by passing the literal
+	// address. This is intentionally inflexible — the right answer
+	// for "expose to my LAN" is "use a tunnel" or "wire your own
+	// reverse proxy."
+	return fmt.Errorf("bind %q is not a loopback address; use 127.0.0.1:%s", bind, port)
+}
+
+// cloneForOneShot returns a Server pointing at fresh in/out streams,
+// sharing the same daemon client + profile + scope. Used by the HTTP
+// handler so concurrent requests don't share scanner state.
+//
+// The clone is NOT thread-safe with itself — caller dispatches one
+// frame and discards. New per-request because the underlying
+// bufio.Scanner cannot be reused after EOF.
+//
+// We construct the clone field-by-field rather than by struct-copy:
+// `*s` would copy the inner sync.Mutex and tip vet's copylocks check.
+func (s *Server) cloneForOneShot(in io.Reader, out io.Writer) *Server {
+	return &Server{
+		in:      in,
+		out:     out,
+		client:  s.client,
+		logger:  s.logger,
+		scope:   s.scope,
+		profile: s.profile,
+		version: s.version,
+	}
+}
+
+// SetCoreInOut lets the HTTP harness swap the underlying server's
+// streams in tests. Unused outside the test binary; defined here so
+// the test file doesn't need to reach into unexported fields.
+func (s *Server) SetCoreInOut(in io.Reader, out io.Writer) {
+	s.in = in
+	s.out = out
+}

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -1,0 +1,199 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+)
+
+// startHTTPServer spins up the HTTP MCP server on :0 (free port) so
+// concurrent tests don't collide.
+func startHTTPServer(t *testing.T, profile string) (*HTTPServer, string) {
+	t.Helper()
+	core := NewServer(Options{
+		In:      strings.NewReader(""), // unused; HTTP swaps streams
+		Out:     io.Discard,
+		Profile: profile,
+		Version: "test",
+	})
+	srv, err := NewHTTPServer(HTTPOptions{
+		Bind:   "127.0.0.1:0",
+		Token:  "secret-token-123",
+		Server: core,
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPServer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ready := make(chan string, 1)
+	go func() {
+		// Block briefly so Serve binds the listener; the test then
+		// reads Addr.
+		go func() {
+			for i := 0; i < 50; i++ {
+				if a := srv.Addr(); a != "" && !strings.HasSuffix(a, ":0") {
+					ready <- a
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			ready <- ""
+		}()
+		_ = srv.Serve(ctx)
+	}()
+	addr := <-ready
+	if addr == "" {
+		t.Fatalf("server did not bind")
+	}
+	t.Cleanup(func() { _ = srv.Shutdown() })
+	return srv, addr
+}
+
+func TestHTTP_ValidateBind_LoopbackOnly(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1:2484": true,
+		"[::1]:2484":     true,
+		"0.0.0.0:2484":   false,
+		"localhost:2484": false,
+		":2484":          false,
+		"":               false,
+		"badform":        false,
+	}
+	for in, ok := range cases {
+		t.Run(in, func(t *testing.T) {
+			err := validateBind(in)
+			if ok && err != nil {
+				t.Fatalf("want allow %q, got %v", in, err)
+			}
+			if !ok && err == nil {
+				t.Fatalf("want reject %q", in)
+			}
+		})
+	}
+}
+
+func TestHTTP_AuthRequired(t *testing.T) {
+	_, addr := startHTTPServer(t, daemon.ProfileFull)
+
+	// No auth header → 401.
+	resp, err := http.Post("http://"+addr+"/mcp", "application/json", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status: got %d want 401", resp.StatusCode)
+	}
+	if got := resp.Header.Get("WWW-Authenticate"); got == "" {
+		t.Fatalf("expected WWW-Authenticate header, got empty")
+	}
+}
+
+func TestHTTP_WrongTokenRejected(t *testing.T) {
+	_, addr := startHTTPServer(t, daemon.ProfileFull)
+
+	req, _ := http.NewRequest("POST", "http://"+addr+"/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status: got %d want 401", resp.StatusCode)
+	}
+}
+
+func TestHTTP_InitializeHandshake(t *testing.T) {
+	_, addr := startHTTPServer(t, daemon.ProfileReadOnly)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	req, _ := http.NewRequest("POST", "http://"+addr+"/mcp", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer secret-token-123")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: %d, body=%s", resp.StatusCode, buf)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	var parsed struct {
+		Result struct {
+			ServerInfo struct {
+				Name string `json:"name"`
+			} `json:"serverInfo"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		t.Fatalf("parse response: %v body=%s", err, respBody)
+	}
+	if parsed.Result.ServerInfo.Name != "locorum" {
+		t.Fatalf("server name: %q", parsed.Result.ServerInfo.Name)
+	}
+}
+
+func TestHTTP_HealthzNoAuth(t *testing.T) {
+	_, addr := startHTTPServer(t, daemon.ProfileFull)
+
+	resp, err := http.Get("http://" + addr + "/healthz")
+	if err != nil {
+		t.Fatalf("GET healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("ok")) {
+		t.Fatalf("healthz body: %s", body)
+	}
+}
+
+func TestHTTP_PostOnly(t *testing.T) {
+	_, addr := startHTTPServer(t, daemon.ProfileFull)
+	resp, err := http.Get("http://" + addr + "/mcp")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestHTTP_TokenFile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	tok, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreateToken: %v", err)
+	}
+	if tok == "" {
+		t.Fatalf("empty token")
+	}
+	again, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if again != tok {
+		t.Fatalf("token mismatch on re-load: %q vs %q", again, tok)
+	}
+	rotated, err := RotateToken(dir)
+	if err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	if rotated == tok {
+		t.Fatalf("rotate didn't change token")
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -1,0 +1,121 @@
+// Package mcp implements a Model Context Protocol server that exposes
+// Locorum's daemon as a curated set of tools to local AI agents.
+//
+// Locorum's MCP server is a thin shim: every tool call is forwarded to
+// the daemon over the IPC socket. The daemon enforces the security
+// boundary (per-site mutex, profile gating, scope checks). This package
+// owns the protocol surface and the tool catalogue.
+//
+// MCP (https://spec.modelcontextprotocol.io) is JSON-RPC 2.0 over
+// either stdio (one frame per line) or Streamable HTTP. Locorum ships
+// stdio first; HTTP is a follow-on (see AGENTS-SUPPORT.md P2).
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// MCPProtocolVersion is the version we declare in the initialize
+// response. Negotiated against the client's claimed version; we accept
+// any version for now and just echo back our own.
+const MCPProtocolVersion = "2024-11-05"
+
+// ServerName is the user-visible name reported in initialize. Pinned
+// so MCP clients (Claude Code, Cursor, Continue) can recognise the
+// server in their config UIs.
+const ServerName = "locorum"
+
+// Wire-format constants. MCP is JSON-RPC 2.0; reusing the same code
+// values as the daemon keeps round-trip error mapping trivial.
+const (
+	jsonRPCVersion = "2.0"
+
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+)
+
+// request is one inbound MCP frame. Notifications (no id) and
+// requests (with id) share the same wire shape; the server branches
+// on whether ID is present.
+type request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// response is one outbound MCP frame. Exactly one of Result or Error
+// is set on a reply; notifications never produce a response.
+type response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// initializeResult is the fixed response shape MCP clients expect from
+// initialize. Capabilities advertise which features we support — only
+// "tools" today; resources/prompts can land in a follow-on.
+type initializeResult struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	ServerInfo      serverInfo         `json:"serverInfo"`
+	Capabilities    serverCapabilities `json:"capabilities"`
+	Instructions    string             `json:"instructions,omitempty"`
+}
+
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type serverCapabilities struct {
+	Tools *toolsCapability `json:"tools,omitempty"`
+}
+
+type toolsCapability struct {
+	// ListChanged tells the client whether the server may emit
+	// `notifications/tools/list_changed`. We don't today (the tool
+	// list is fixed at process start), so this is false.
+	ListChanged bool `json:"listChanged"`
+}
+
+// toolListResult is the response shape for `tools/list`.
+type toolListResult struct {
+	Tools []toolDescriptor `json:"tools"`
+}
+
+// toolDescriptor matches MCP's required tool shape: name, description,
+// JSON Schema for input. Title is the optional human-friendly name.
+type toolDescriptor struct {
+	Name        string          `json:"name"`
+	Title       string          `json:"title,omitempty"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+// toolCallResult is the response shape for `tools/call`. Content is a
+// list of content parts; we always return one text part containing the
+// pretty-printed result (or an error string with isError=true).
+type toolCallResult struct {
+	Content []contentPart `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+type contentPart struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// errStop is the sentinel returned by the read loop when stdin is
+// closed (the controlling MCP client has gone away). Caught at the
+// top level to terminate cleanly.
+var errStop = errors.New("mcp: stdin closed")

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,269 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+)
+
+// Server is the MCP stdio server. Constructed once per process; the
+// caller wires stdin/stdout and a daemon client, then calls Serve.
+//
+// Server is safe to use from a single goroutine only. MCP stdio is
+// one-frame-at-a-time, no pipelining required by the spec.
+type Server struct {
+	in     io.Reader
+	out    io.Writer
+	client *daemon.Client
+	logger *slog.Logger
+
+	// scope is the LOCORUM_MCP_SCOPE site identifier the parent set
+	// at process start. Empty means "no scope; the agent may target
+	// any site." Non-empty values are forwarded to the daemon at
+	// hello time so the daemon — not the client — enforces scope.
+	scope string
+
+	// profile is the trust tier for this MCP server. Determines which
+	// tools appear in tools/list and which the dispatcher refuses to
+	// call. Sandbox is reserved (Part 6).
+	profile string
+
+	// version is the locorum version string, surfaced to MCP clients
+	// in the initialize response.
+	version string
+
+	// initialized is set after the client sends notifications/initialized
+	// per the MCP handshake. Tools/* calls are accepted regardless
+	// (some clients call them eagerly), but we don't emit
+	// notifications until the handshake completes.
+	mu          sync.Mutex
+	initialized bool
+}
+
+// Options configures a new MCP server.
+type Options struct {
+	In      io.Reader // defaults to os.Stdin
+	Out     io.Writer // defaults to os.Stdout
+	Client  *daemon.Client
+	Logger  *slog.Logger
+	Scope   string // optional MCP scope (LOCORUM_MCP_SCOPE)
+	Profile string // "full" or "readonly"
+	Version string // locorum binary version
+}
+
+// NewServer constructs a Server. The caller is responsible for opening
+// the daemon client and passing it in: this package never auto-spawns
+// a daemon (the parent process — `locorum mcp serve` — does that
+// before instantiating us).
+func NewServer(opts Options) *Server {
+	in := opts.In
+	if in == nil {
+		in = os.Stdin
+	}
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	profile := opts.Profile
+	if profile == "" {
+		profile = daemon.ProfileFull
+	}
+	return &Server{
+		in:      in,
+		out:     out,
+		client:  opts.Client,
+		logger:  logger.With("subsys", "mcp"),
+		scope:   opts.Scope,
+		profile: profile,
+		version: opts.Version,
+	}
+}
+
+// Serve runs the read/dispatch loop until stdin closes or ctx cancels.
+// Returns nil on a clean stdin close; other errors are propagated.
+func (s *Server) Serve(ctx context.Context) error {
+	scanner := bufio.NewScanner(s.in)
+	// MCP spec doesn't bound message size; reuse the daemon's 8 MiB
+	// cap as a sane upper bound. A larger payload than this is almost
+	// certainly a bug.
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var req request
+		if err := json.Unmarshal(line, &req); err != nil {
+			s.writeError(nil, codeParseError, "parse error: "+err.Error())
+			continue
+		}
+		if err := s.dispatch(ctx, req); err != nil {
+			if errors.Is(err, errStop) {
+				return nil
+			}
+			s.logger.Warn("dispatch error", "method", req.Method, "err", err.Error())
+		}
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+// dispatch handles one request/notification.
+func (s *Server) dispatch(ctx context.Context, req request) error {
+	if req.JSONRPC != "" && req.JSONRPC != jsonRPCVersion {
+		s.writeError(req.ID, codeInvalidRequest, "unsupported jsonrpc version")
+		return nil
+	}
+
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "notifications/initialized":
+		s.mu.Lock()
+		s.initialized = true
+		s.mu.Unlock()
+		return nil
+	case "ping":
+		s.writeResult(req.ID, struct{}{})
+		return nil
+	case "tools/list":
+		s.writeResult(req.ID, toolListResult{Tools: s.toolList()})
+		return nil
+	case "tools/call":
+		return s.handleToolCall(ctx, req)
+	default:
+		// Notifications other than the ones we handle: silently
+		// drop. Requests: respond with method-not-found.
+		if len(req.ID) == 0 {
+			return nil
+		}
+		s.writeError(req.ID, codeMethodNotFound, "method not found: "+req.Method)
+		return nil
+	}
+}
+
+// handleInitialize echoes the protocol handshake.
+func (s *Server) handleInitialize(req request) error {
+	instructions := "Locorum exposes site-management tools backed by a local daemon. " +
+		"Mutating tools require Profile=full; readonly returns only inspection tools. " +
+		"When MCP scope is set, every site-targeted tool is forced to that site by the daemon."
+	s.writeResult(req.ID, initializeResult{
+		ProtocolVersion: MCPProtocolVersion,
+		ServerInfo:      serverInfo{Name: ServerName, Version: s.version},
+		Capabilities:    serverCapabilities{Tools: &toolsCapability{ListChanged: false}},
+		Instructions:    instructions,
+	})
+	return nil
+}
+
+// handleToolCall parses the tool name + arguments, runs the
+// implementation, and writes a tools/call response.
+func (s *Server) handleToolCall(ctx context.Context, req request) error {
+	type toolCallParams struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments,omitempty"`
+	}
+	var p toolCallParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		s.writeError(req.ID, codeInvalidParams, "invalid tools/call params: "+err.Error())
+		return nil
+	}
+
+	tool, ok := s.findTool(p.Name)
+	if !ok {
+		s.writeError(req.ID, codeMethodNotFound, "unknown tool: "+p.Name)
+		return nil
+	}
+	if tool.requireFull && s.profile != daemon.ProfileFull {
+		s.writeToolError(req.ID, fmt.Sprintf("tool %q requires the full profile (current: %s)", p.Name, s.profile))
+		return nil
+	}
+
+	out, err := tool.impl(ctx, s, p.Arguments)
+	if err != nil {
+		// Tool errors translate to isError=true (per MCP spec) so the
+		// agent sees the message inline rather than treating it as a
+		// transport failure.
+		s.writeToolError(req.ID, err.Error())
+		return nil
+	}
+	body, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		s.writeError(req.ID, codeInternalError, "marshal tool result: "+err.Error())
+		return nil
+	}
+	s.writeResult(req.ID, toolCallResult{
+		Content: []contentPart{{Type: "text", Text: string(body)}},
+	})
+	return nil
+}
+
+// writeResult encodes a successful response on stdout. MCP clients
+// expect one frame per line; we use json.Encoder which adds a newline.
+func (s *Server) writeResult(id json.RawMessage, result any) {
+	body, err := json.Marshal(result)
+	if err != nil {
+		s.writeError(id, codeInternalError, "marshal result: "+err.Error())
+		return
+	}
+	resp := response{JSONRPC: jsonRPCVersion, ID: id, Result: body}
+	s.write(resp)
+}
+
+// writeError encodes a transport-level error.
+func (s *Server) writeError(id json.RawMessage, code int, msg string) {
+	resp := response{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Error:   &rpcError{Code: code, Message: msg},
+	}
+	s.write(resp)
+}
+
+// writeToolError encodes a tool-level error inside a successful
+// response (isError=true). MCP separates these so the agent can
+// recover from a tool failure without treating it as a fatal RPC bug.
+func (s *Server) writeToolError(id json.RawMessage, msg string) {
+	body, _ := json.Marshal(toolCallResult{
+		Content: []contentPart{{Type: "text", Text: msg}},
+		IsError: true,
+	})
+	resp := response{JSONRPC: jsonRPCVersion, ID: id, Result: body}
+	s.write(resp)
+}
+
+// write encodes a frame on stdout, holding a mutex so a slow producer
+// goroutine cannot interleave bytes with a notification.
+func (s *Server) write(resp response) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	enc := json.NewEncoder(s.out)
+	if err := enc.Encode(resp); err != nil {
+		s.logger.Warn("write frame failed", "err", err.Error())
+	}
+}
+
+// callDaemon is a convenience that proxies an IPC call. Tools use it
+// rather than reaching into s.client directly so future cross-cutting
+// behaviour (telemetry, retry on disconnect) lands in one place.
+func (s *Server) callDaemon(ctx context.Context, method string, params, out any) error {
+	return s.client.Call(ctx, method, params, out)
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,133 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+)
+
+// TestServer_ToolListReadOnly verifies the readonly profile filters out
+// every mutating tool from the catalogue. This is the load-bearing
+// guarantee of the readonly profile: an agent dropped into a readonly
+// MCP can't even discover that mutation tools exist.
+func TestServer_ToolListReadOnly(t *testing.T) {
+	srv := NewServer(Options{
+		Profile: daemon.ProfileReadOnly,
+		Version: "test",
+	})
+	tools := srv.toolList()
+	for _, t := range tools {
+		switch t.Name {
+		case "start_site", "stop_site", "wp_cli",
+			"create_snapshot", "restore_snapshot", "run_hook":
+			panic("readonly profile leaked mutating tool: " + t.Name)
+		}
+	}
+	if len(tools) == 0 {
+		t.Fatalf("readonly profile exposes no tools")
+	}
+}
+
+// TestServer_ToolListFull covers the full profile: every registered
+// tool should appear, including mutators.
+func TestServer_ToolListFull(t *testing.T) {
+	srv := NewServer(Options{
+		Profile: daemon.ProfileFull,
+		Version: "test",
+	})
+	tools := srv.toolList()
+	names := map[string]bool{}
+	for _, t := range tools {
+		names[t.Name] = true
+	}
+	for _, want := range []string{"list_sites", "describe_site", "start_site", "wp_cli", "create_snapshot"} {
+		if !names[want] {
+			t.Fatalf("full profile missing tool: %s", want)
+		}
+	}
+}
+
+// TestServer_InitializeHandshake exercises the JSON-RPC handshake using
+// in-memory pipes. Confirms the initialize response shape MCP clients
+// rely on.
+func TestServer_InitializeHandshake(t *testing.T) {
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n")
+	var out bytes.Buffer
+	srv := NewServer(Options{
+		In:      in,
+		Out:     &out,
+		Profile: daemon.ProfileReadOnly,
+		Version: "test-1.2.3",
+	})
+
+	if err := srv.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	var resp struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id"`
+		Result  json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response (%q): %v", out.String(), err)
+	}
+	if resp.JSONRPC != "2.0" {
+		t.Fatalf("jsonrpc: %q", resp.JSONRPC)
+	}
+	if resp.ID != 1 {
+		t.Fatalf("id: %d", resp.ID)
+	}
+	if !strings.Contains(string(resp.Result), `"name":"locorum"`) {
+		t.Fatalf("result missing server name: %s", resp.Result)
+	}
+	if !strings.Contains(string(resp.Result), `"version":"test-1.2.3"`) {
+		t.Fatalf("result missing version: %s", resp.Result)
+	}
+}
+
+// TestServer_ToolsListShape confirms tools/list returns a plausible
+// JSON Schema for a known tool.
+func TestServer_ToolsListShape(t *testing.T) {
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n")
+	var out bytes.Buffer
+	srv := NewServer(Options{
+		In:      in,
+		Out:     &out,
+		Profile: daemon.ProfileFull,
+		Version: "test",
+	})
+	if err := srv.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	var resp struct {
+		Result struct {
+			Tools []struct {
+				Name        string          `json:"name"`
+				InputSchema json.RawMessage `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, out.String())
+	}
+	if len(resp.Result.Tools) == 0 {
+		t.Fatalf("tools/list returned empty list")
+	}
+	for _, tool := range resp.Result.Tools {
+		// Each tool must have a non-empty input schema (an object,
+		// possibly with no properties).
+		var schema map[string]any
+		if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+			t.Fatalf("tool %q schema is not valid JSON: %v", tool.Name, err)
+		}
+		if schema["type"] != "object" {
+			t.Fatalf("tool %q schema must be type=object, got %v", tool.Name, schema["type"])
+		}
+	}
+}

--- a/internal/mcp/token.go
+++ b/internal/mcp/token.go
@@ -1,0 +1,87 @@
+package mcp
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TokenFilename is the basename of the auth token file under
+// ~/.locorum/state/. The full path is built by TokenPath.
+const TokenFilename = "mcp_token"
+
+// TokenByteLen is the size of the random source for an MCP HTTP
+// auth token, before base64-encoding. 32 bytes (256 bits) gives a
+// 43-char URL-safe string — well above the brute-force horizon for
+// any local-network attacker.
+const TokenByteLen = 32
+
+// TokenPath returns the absolute path to the MCP token file under
+// homeDir. Sits next to owner.lock + locorum.sock in
+// ~/.locorum/state/, which is already 0700 owner-only.
+func TokenPath(homeDir string) string {
+	return filepath.Join(homeDir, ".locorum", "state", TokenFilename)
+}
+
+// LoadOrCreateToken returns the auth token, creating a new random one
+// on first use. The file is written 0600 so peer users on the host
+// cannot lift the token from disk. Idempotent across processes — the
+// HTTP server reads the same value the user pastes into their MCP
+// client.
+func LoadOrCreateToken(homeDir string) (string, error) {
+	path := TokenPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create state dir: %w", err)
+	}
+	if body, err := os.ReadFile(path); err == nil {
+		token := strings.TrimSpace(string(body))
+		if token != "" {
+			return token, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("read token: %w", err)
+	}
+	return rotateTokenAt(path)
+}
+
+// RotateToken regenerates the token, replacing whatever was there.
+// The old token stops working immediately; existing MCP clients must
+// pick up the new value from disk (or be re-pasted into the IDE
+// config).
+func RotateToken(homeDir string) (string, error) {
+	path := TokenPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create state dir: %w", err)
+	}
+	return rotateTokenAt(path)
+}
+
+// rotateTokenAt is the shared body of LoadOrCreateToken and
+// RotateToken. Writes via O_TRUNC so a partial write doesn't leave
+// half a token on disk.
+func rotateTokenAt(path string) (string, error) {
+	buf := make([]byte, TokenByteLen)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(buf)
+	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+		return "", fmt.Errorf("write token: %w", err)
+	}
+	return token, nil
+}
+
+// CompareTokens performs a constant-time comparison so a length-leak
+// or timing-leak doesn't reveal token characters to an attacker. The
+// strings package's == would be timing-leaky.
+func CompareTokens(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,571 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/PeterBooker/locorum/internal/daemon"
+)
+
+// toolDef pairs a wire descriptor with its implementation. requireFull
+// gates the tool to the full profile; readonly tools omit it.
+type toolDef struct {
+	descriptor  toolDescriptor
+	impl        func(ctx context.Context, s *Server, args json.RawMessage) (any, error)
+	requireFull bool
+}
+
+// findTool looks up a tool by name, honouring the profile gate. Returns
+// (toolDef, true) when the tool is reachable in the current profile.
+func (s *Server) findTool(name string) (toolDef, bool) {
+	for _, t := range allTools {
+		if t.descriptor.Name != name {
+			continue
+		}
+		if s.profile == daemon.ProfileReadOnly && t.requireFull {
+			return toolDef{}, false
+		}
+		return t, true
+	}
+	return toolDef{}, false
+}
+
+// toolList returns the descriptors visible in the current profile. The
+// readonly profile sees a strict subset.
+func (s *Server) toolList() []toolDescriptor {
+	out := make([]toolDescriptor, 0, len(allTools))
+	for _, t := range allTools {
+		if s.profile == daemon.ProfileReadOnly && t.requireFull {
+			continue
+		}
+		out = append(out, t.descriptor)
+	}
+	return out
+}
+
+// schemaSiteRef is the JSON Schema for tools that target one site.
+// "siteId" or "slug" — whichever the agent has handy. The daemon
+// rejects calls missing both.
+const schemaSiteRef = `{
+  "type": "object",
+  "properties": {
+    "siteId": {"type": "string", "description": "Canonical UUID of the site"},
+    "slug":   {"type": "string", "description": "Human-friendly slug (e.g. \"my-shop\")"}
+  },
+  "anyOf": [
+    {"required": ["siteId"]},
+    {"required": ["slug"]}
+  ]
+}`
+
+// allTools is the registered tool catalogue. Order is presentation-
+// stable: list_sites first, then describe_site, then mutating actions.
+var allTools = []toolDef{
+	{
+		descriptor: toolDescriptor{
+			Name:        "list_sites",
+			Title:       "List sites",
+			Description: "Return every Locorum site with name, slug, status, URL, and runtime versions. Cheap and side-effect-free.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		},
+		impl: callListSites,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:        "describe_site",
+			Title:       "Describe a site",
+			Description: "Return the full SiteDescription for one site (containers, hooks, snapshots count, recent activity). When the MCP server has a scope set, the scoped site is used by default if no siteId or slug is given.",
+			InputSchema: json.RawMessage(schemaSiteRef),
+		},
+		impl: callDescribeSite,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:        "recent_activity",
+			Title:       "Recent activity",
+			Description: "Return the most recent lifecycle events for a site (start / stop / clone / snapshot etc.). Read-only.",
+			InputSchema: json.RawMessage(schemaSiteRef),
+		},
+		impl: callRecentActivity,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:  "read_log",
+			Title: "Read container log",
+			Description: "Return the trailing N lines of one of a site's service container logs. Service must be one of web/php/database/redis. " +
+				"Use this to debug a failing site without granting RCE-equivalent exec access.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "siteId":  {"type": "string"},
+    "slug":    {"type": "string"},
+    "service": {"type": "string", "enum": ["web", "php", "database", "redis"]},
+    "lines":   {"type": "integer", "minimum": 1, "maximum": 5000, "default": 200}
+  },
+  "required": ["service"]
+}`),
+		},
+		impl: callReadLog,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:        "list_snapshots",
+			Title:       "List snapshots",
+			Description: "Return the disk-backed database snapshots for a site, newest first. Each entry has filename, size, and engine/version stamps.",
+			InputSchema: json.RawMessage(schemaSiteRef),
+		},
+		impl: callListSnapshots,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:        "list_hooks",
+			Title:       "List hooks",
+			Description: "Return the configured lifecycle hooks for a site. Read-only; running a hook needs run_hook (full profile).",
+			InputSchema: json.RawMessage(schemaSiteRef),
+		},
+		impl: callListHooks,
+	},
+
+	// ─── Mutating tools (full profile) ─────────────────────────────────
+	{
+		descriptor: toolDescriptor{
+			Name:        "start_site",
+			Title:       "Start a site",
+			Description: "Bring a site's containers up. Idempotent — calling on a running site is a no-op.",
+			InputSchema: json.RawMessage(schemaSiteRef),
+		},
+		impl:        callStartSite,
+		requireFull: true,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:        "stop_site",
+			Title:       "Stop a site",
+			Description: "Stop a site's containers (volumes preserved). Idempotent.",
+			InputSchema: json.RawMessage(schemaSiteRef),
+		},
+		impl:        callStopSite,
+		requireFull: true,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:  "wp_cli",
+			Title: "Run wp-cli",
+			Description: "Execute a wp-cli command inside the site's PHP container. Args are passed verbatim (no shell). " +
+				"Example: {\"slug\": \"shop\", \"args\": [\"option\", \"get\", \"siteurl\"]}.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "siteId": {"type": "string"},
+    "slug":   {"type": "string"},
+    "args":   {"type": "array", "items": {"type": "string"}, "minItems": 1}
+  },
+  "required": ["args"]
+}`),
+		},
+		impl:        callWPCLI,
+		requireFull: true,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:  "create_snapshot",
+			Title: "Create a database snapshot",
+			Description: "Take a compressed database snapshot of the site. Returns the absolute path on the host. " +
+				"Use this before any risky mutation as a recovery point.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "siteId": {"type": "string"},
+    "slug":   {"type": "string"},
+    "label":  {"type": "string", "maxLength": 32, "default": "manual"}
+  }
+}`),
+		},
+		impl:        callCreateSnapshot,
+		requireFull: true,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:        "restore_snapshot",
+			Title:       "Restore a database snapshot",
+			Description: "Replace the site's database with the contents of a snapshot file. Pass force=true to override engine/version checks.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "siteId": {"type": "string"},
+    "slug":   {"type": "string"},
+    "path":   {"type": "string"},
+    "force":  {"type": "boolean", "default": false}
+  },
+  "required": ["path"]
+}`),
+		},
+		impl:        callRestoreSnapshot,
+		requireFull: true,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:        "run_hook",
+			Title:       "Run a hook",
+			Description: "Run a single configured hook outside the lifecycle. Requires the hookId from list_hooks.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "siteId": {"type": "string"},
+    "slug":   {"type": "string"},
+    "hookId": {"type": "integer"}
+  },
+  "required": ["hookId"]
+}`),
+		},
+		impl:        callRunHook,
+		requireFull: true,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:  "worktree_create",
+			Title: "Create a worktree-bound site",
+			Description: "Spin up a new Locorum site bound to a git worktree. The site's files dir is the worktree itself, " +
+				"so editing files in your IDE updates the running site immediately. Returns the derived slug + URL. " +
+				"Pass dryRun=true to preview the plan without committing to it.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "name":         {"type": "string", "description": "human-readable site name"},
+    "gitRemote":    {"type": "string", "description": "upstream git URL (ssh or https)"},
+    "branch":       {"type": "string", "description": "branch to track"},
+    "parentSlug":   {"type": "string", "description": "existing parent site to attach to (else auto-derived from gitRemote)"},
+    "cloneDb":      {"type": "boolean", "description": "copy parent DB + run wp search-replace; default false"},
+    "phpVersion":   {"type": "string"},
+    "dbEngine":     {"type": "string"},
+    "dbVersion":    {"type": "string"},
+    "redisVersion": {"type": "string"},
+    "worktreeRoot": {"type": "string", "description": "directory holding the worktree; default <parent>.worktrees/"},
+    "dryRun":       {"type": "boolean", "default": false}
+  },
+  "required": ["name", "gitRemote", "branch"]
+}`),
+		},
+		impl:        callWorktreeCreate,
+		requireFull: true,
+	},
+	{
+		descriptor: toolDescriptor{
+			Name:        "worktree_destroy",
+			Title:       "Destroy a site (worktree-aware)",
+			Description: "Delete a Locorum site, including the git worktree if it is one. Pass force=true to discard uncommitted changes.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "siteId":       {"type": "string"},
+    "slug":         {"type": "string"},
+    "force":        {"type": "boolean", "default": false},
+    "purgeVolume":  {"type": "boolean", "default": false},
+    "skipSnapshot": {"type": "boolean", "default": false},
+    "dryRun":       {"type": "boolean", "default": false}
+  }
+}`),
+		},
+		impl:        callWorktreeDestroy,
+		requireFull: true,
+	},
+}
+
+// ─── Tool implementations ────────────────────────────────────────────
+
+func callListSites(ctx context.Context, s *Server, _ json.RawMessage) (any, error) {
+	var out any
+	if err := s.callDaemon(ctx, "site.list", map[string]any{}, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callDescribeSite(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	params, err := siteRefArgs(s, args)
+	if err != nil {
+		return nil, err
+	}
+	params["includeActivity"] = true
+	params["activityLimit"] = 20
+	params["includeSnapshots"] = true
+	params["includeHostPort"] = true
+	var out any
+	if err := s.callDaemon(ctx, "site.describe", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callRecentActivity(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	params, err := siteRefArgs(s, args)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := s.callDaemon(ctx, "site.recentActivity", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callReadLog(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	type p struct {
+		SiteID  string `json:"siteId"`
+		Slug    string `json:"slug"`
+		Service string `json:"service"`
+		Lines   int    `json:"lines"`
+	}
+	var parsed p
+	if err := json.Unmarshal(args, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	params := siteRefMap(s, parsed.SiteID, parsed.Slug)
+	params["service"] = parsed.Service
+	if parsed.Lines > 0 {
+		params["lines"] = parsed.Lines
+	}
+	var out any
+	if err := s.callDaemon(ctx, "site.logs", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callListSnapshots(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	params, err := siteRefArgs(s, args)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := s.callDaemon(ctx, "snapshot.list", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callListHooks(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	params, err := siteRefArgs(s, args)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := s.callDaemon(ctx, "hook.list", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callStartSite(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	params, err := siteRefArgs(s, args)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := s.callDaemon(ctx, "site.start", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callStopSite(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	params, err := siteRefArgs(s, args)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := s.callDaemon(ctx, "site.stop", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callWPCLI(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	type p struct {
+		SiteID string   `json:"siteId"`
+		Slug   string   `json:"slug"`
+		Args   []string `json:"args"`
+	}
+	var parsed p
+	if err := json.Unmarshal(args, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	if len(parsed.Args) == 0 {
+		return nil, errors.New("args is required and must be a non-empty list of wp-cli arguments")
+	}
+	params := siteRefMap(s, parsed.SiteID, parsed.Slug)
+	params["args"] = parsed.Args
+	var out any
+	if err := s.callDaemon(ctx, "site.wp", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callCreateSnapshot(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	type p struct {
+		SiteID string `json:"siteId"`
+		Slug   string `json:"slug"`
+		Label  string `json:"label"`
+	}
+	var parsed p
+	if err := json.Unmarshal(args, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	params := siteRefMap(s, parsed.SiteID, parsed.Slug)
+	if parsed.Label != "" {
+		params["label"] = parsed.Label
+	}
+	var out any
+	if err := s.callDaemon(ctx, "snapshot.create", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callRestoreSnapshot(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	type p struct {
+		SiteID string `json:"siteId"`
+		Slug   string `json:"slug"`
+		Path   string `json:"path"`
+		Force  bool   `json:"force"`
+	}
+	var parsed p
+	if err := json.Unmarshal(args, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	if parsed.Path == "" {
+		return nil, errors.New("path is required")
+	}
+	params := siteRefMap(s, parsed.SiteID, parsed.Slug)
+	params["path"] = parsed.Path
+	params["force"] = parsed.Force
+	var out any
+	if err := s.callDaemon(ctx, "snapshot.restore", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callWorktreeCreate(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	// Pass through verbatim — the daemon validates and applies its own
+	// shape rules. Forward the raw arguments as the params object.
+	var raw map[string]any
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &raw); err != nil {
+			return nil, fmt.Errorf("invalid args: %w", err)
+		}
+	} else {
+		raw = map[string]any{}
+	}
+	var out any
+	if err := s.callDaemon(ctx, "site.create_worktree", raw, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callWorktreeDestroy(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	type p struct {
+		SiteID       string `json:"siteId"`
+		Slug         string `json:"slug"`
+		Force        bool   `json:"force"`
+		PurgeVolume  bool   `json:"purgeVolume"`
+		SkipSnapshot bool   `json:"skipSnapshot"`
+		DryRun       bool   `json:"dryRun"`
+	}
+	var parsed p
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &parsed); err != nil {
+			return nil, fmt.Errorf("invalid args: %w", err)
+		}
+	}
+	params := siteRefMap(s, parsed.SiteID, parsed.Slug)
+	params["forceWorktree"] = parsed.Force
+	params["purgeVolume"] = parsed.PurgeVolume
+	params["skipSnapshot"] = parsed.SkipSnapshot
+	params["dryRun"] = parsed.DryRun
+	var out any
+	if err := s.callDaemon(ctx, "site.delete", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+func callRunHook(ctx context.Context, s *Server, args json.RawMessage) (any, error) {
+	type p struct {
+		SiteID string `json:"siteId"`
+		Slug   string `json:"slug"`
+		HookID int64  `json:"hookId"`
+	}
+	var parsed p
+	if err := json.Unmarshal(args, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid args: %w", err)
+	}
+	if parsed.HookID == 0 {
+		return nil, errors.New("hookId is required")
+	}
+	params := siteRefMap(s, parsed.SiteID, parsed.Slug)
+	params["hookId"] = parsed.HookID
+	var out any
+	if err := s.callDaemon(ctx, "hook.run", params, &out); err != nil {
+		return nil, mapDaemonErr(err)
+	}
+	return out, nil
+}
+
+// ─── helpers ────────────────────────────────────────────────────────
+
+// siteRefArgs decodes a tools/call argument blob and returns the
+// site-ref params map ready to forward to the daemon. Honours the
+// MCP scope: when no explicit siteId/slug is set, fall back to the
+// scope (which we know is one of the two forms — daemon will accept
+// it as a slug if it matches).
+func siteRefArgs(s *Server, args json.RawMessage) (map[string]any, error) {
+	type ref struct {
+		SiteID string `json:"siteId"`
+		Slug   string `json:"slug"`
+	}
+	var parsed ref
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &parsed); err != nil {
+			return nil, fmt.Errorf("invalid args: %w", err)
+		}
+	}
+	return siteRefMap(s, parsed.SiteID, parsed.Slug), nil
+}
+
+// siteRefMap builds a {siteId, slug} map, falling back to s.scope when
+// neither was provided. Empty maps are still valid (the daemon will
+// reject them with a clear "params must include siteId or slug" error).
+func siteRefMap(s *Server, siteID, slug string) map[string]any {
+	out := map[string]any{}
+	if siteID == "" && slug == "" && s.scope != "" {
+		// We don't know whether the scope is a UUID or slug; pass it
+		// as slug — the daemon's resolver tries both.
+		out["slug"] = s.scope
+		return out
+	}
+	if siteID != "" {
+		out["siteId"] = siteID
+	}
+	if slug != "" {
+		out["slug"] = slug
+	}
+	return out
+}
+
+// mapDaemonErr re-shapes daemon RPC errors so the MCP agent sees a
+// clean message without the "rpc error: code=… message=…" framing.
+func mapDaemonErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var rpc *daemon.RPCError
+	if errors.As(err, &rpc) {
+		return errors.New(rpc.Message)
+	}
+	return err
+}

--- a/internal/orch/dryrun.go
+++ b/internal/orch/dryrun.go
@@ -1,0 +1,109 @@
+package orch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Describer is the optional interface a Step implements to opt into
+// dry-run reporting. Steps without Describe still run under Dry but
+// surface a generic "(no preview)" line; that's intentional so a Plan
+// can be partially dry-run-clean even before every step has been
+// updated.
+//
+// Implementations must be pure: the Describe call is allowed to read
+// configuration (e.g. inspect a docker spec), but must not write
+// anywhere or call out to the network. The contract is "describe what
+// Apply would do without committing to it."
+type Describer interface {
+	Describe(ctx context.Context) (string, error)
+}
+
+// DryResult is the structured outcome of Dry. Not the same shape as
+// Result: dry-run never fails individual steps and never rolls back,
+// because nothing was applied.
+type DryResult struct {
+	PlanName string
+	Started  time.Time
+	Duration time.Duration
+	Steps    []DryStepResult
+}
+
+// DryStepResult is one step's preview line. Description is the user-
+// visible string the Describer returned, or a sentinel for steps that
+// don't implement Describer.
+type DryStepResult struct {
+	Name        string
+	Description string
+	Implemented bool
+	Error       error
+}
+
+// noPreview is the sentinel used when a step doesn't implement
+// Describer. Surfaced verbatim so dry-run output keeps every step's
+// position even when some are silent.
+const noPreview = "(no preview available — step does not implement orch.Describer)"
+
+// Dry runs plan in describe-only mode. Each step is interrogated via
+// Describer; non-implementers fall back to noPreview. The plan's
+// real Apply is never invoked, so Dry is always safe to call against
+// production state.
+//
+// Errors from Describe surface in the per-step DryStepResult.Error;
+// Dry itself returns a non-nil error only when ctx is cancelled (so
+// callers can distinguish "user gave up" from "describe surfaced a
+// problem").
+func Dry(ctx context.Context, plan Plan) (DryResult, error) {
+	res := DryResult{
+		PlanName: plan.Name,
+		Started:  time.Now(),
+		Steps:    make([]DryStepResult, 0, len(plan.Steps)),
+	}
+	for _, s := range plan.Steps {
+		if ctx.Err() != nil {
+			res.Duration = time.Since(res.Started)
+			return res, ctx.Err()
+		}
+		entry := DryStepResult{Name: s.Name()}
+		if d, ok := s.(Describer); ok {
+			entry.Implemented = true
+			line, err := safeDescribe(ctx, d)
+			entry.Description = line
+			if err != nil {
+				entry.Error = err
+			}
+		} else {
+			entry.Description = noPreview
+		}
+		res.Steps = append(res.Steps, entry)
+	}
+	res.Duration = time.Since(res.Started)
+	return res, nil
+}
+
+func safeDescribe(ctx context.Context, d Describer) (out string, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = errors.New("describe panicked: " + recString(rec))
+		}
+	}()
+	return d.Describe(ctx)
+}
+
+// Format renders the dry-run result as a multi-line string suitable
+// for `locorum site delete --dry-run` output.
+func (r DryResult) Format() string {
+	out := fmt.Sprintf("Plan: %s (%d steps)\n", r.PlanName, len(r.Steps))
+	for i, s := range r.Steps {
+		out += fmt.Sprintf("  %d. %s\n", i+1, s.Name)
+		if s.Error != nil {
+			out += fmt.Sprintf("     ! describe error: %s\n", s.Error)
+		}
+		if s.Description != "" {
+			out += fmt.Sprintf("     - %s\n", s.Description)
+		}
+	}
+	return out
+}

--- a/internal/orch/dryrun_test.go
+++ b/internal/orch/dryrun_test.go
@@ -1,0 +1,92 @@
+package orch
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeStep struct {
+	name string
+	desc string
+	err  error
+}
+
+func (f *fakeStep) Name() string                               { return f.name }
+func (f *fakeStep) Apply(_ context.Context) error              { return errors.New("dry-run must not Apply") }
+func (f *fakeStep) Rollback(_ context.Context) error           { return nil }
+func (f *fakeStep) Describe(_ context.Context) (string, error) { return f.desc, f.err }
+
+type silentStep struct{ name string }
+
+func (s *silentStep) Name() string                     { return s.name }
+func (s *silentStep) Apply(_ context.Context) error    { return errors.New("must not run") }
+func (s *silentStep) Rollback(_ context.Context) error { return nil }
+
+func TestDry_DescribesEverySupportingStep(t *testing.T) {
+	plan := Plan{
+		Name: "test",
+		Steps: []Step{
+			&fakeStep{name: "first", desc: "do first"},
+			&fakeStep{name: "second", desc: "do second"},
+			&silentStep{name: "no-describer"},
+		},
+	}
+	res, err := Dry(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Dry: %v", err)
+	}
+	if len(res.Steps) != 3 {
+		t.Fatalf("expected 3 step results, got %d", len(res.Steps))
+	}
+	if res.Steps[0].Description != "do first" || !res.Steps[0].Implemented {
+		t.Fatalf("step 0 wrong: %+v", res.Steps[0])
+	}
+	if res.Steps[2].Implemented {
+		t.Fatalf("silentStep should report Implemented=false")
+	}
+	if !strings.Contains(res.Steps[2].Description, "no preview") {
+		t.Fatalf("silentStep description: %q", res.Steps[2].Description)
+	}
+}
+
+func TestDry_RecoversFromPanic(t *testing.T) {
+	plan := Plan{
+		Name: "panicky",
+		Steps: []Step{
+			&panicStep{name: "boom"},
+		},
+	}
+	res, err := Dry(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Dry: %v", err)
+	}
+	if res.Steps[0].Error == nil {
+		t.Fatalf("expected error from panicked describe")
+	}
+}
+
+func TestDry_FormatHumanReadable(t *testing.T) {
+	plan := Plan{
+		Name:  "delete-site:foo",
+		Steps: []Step{&fakeStep{name: "stop-containers", desc: "stop nginx, php"}},
+	}
+	res, _ := Dry(context.Background(), plan)
+	out := res.Format()
+	if !strings.Contains(out, "delete-site:foo") {
+		t.Fatalf("format missing plan name: %s", out)
+	}
+	if !strings.Contains(out, "stop nginx, php") {
+		t.Fatalf("format missing description: %s", out)
+	}
+}
+
+type panicStep struct{ name string }
+
+func (p *panicStep) Name() string                     { return p.name }
+func (p *panicStep) Apply(_ context.Context) error    { return nil }
+func (p *panicStep) Rollback(_ context.Context) error { return nil }
+func (p *panicStep) Describe(_ context.Context) (string, error) {
+	panic("describe boom")
+}

--- a/internal/sites/describe.go
+++ b/internal/sites/describe.go
@@ -1,0 +1,292 @@
+package sites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/dbengine"
+	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/hooks"
+	"github.com/PeterBooker/locorum/internal/storage"
+	"github.com/PeterBooker/locorum/internal/types"
+)
+
+// SiteDescription is the canonical, side-effect-free snapshot of a site
+// for any client that needs to read its state without touching SiteManager
+// internals: the GUI's overview panel, the CLI's `site describe`, the MCP
+// server's describe_site tool. JSON tags pin the wire format for IPC and
+// MCP — rename fields here only with a coordinated client bump.
+type SiteDescription struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Slug      string `json:"slug"`
+	Domain    string `json:"domain"`
+	URL       string `json:"url"`
+	FilesDir  string `json:"filesDir"`
+	PublicDir string `json:"publicDir"`
+
+	Started bool `json:"started"`
+
+	WebServer string `json:"webServer"`
+	Multisite string `json:"multisite,omitempty"`
+
+	PHP      VersionInfo `json:"php"`
+	Database DBInfo      `json:"database"`
+	Redis    VersionInfo `json:"redis"`
+
+	Containers []ContainerInfo `json:"containers,omitempty"`
+
+	Hooks    HooksSummary    `json:"hooks"`
+	Activity []ActivityEntry `json:"recentActivity,omitempty"`
+
+	SnapshotsCount int `json:"snapshotsCount"`
+
+	Profiling SPXInfo `json:"profiling,omitempty"`
+
+	CreatedAt string `json:"createdAt,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
+}
+
+// VersionInfo captures the runtime version of one of the site's services.
+type VersionInfo struct {
+	Version string `json:"version"`
+}
+
+// DBInfo describes the database service. Credentials are user-static
+// (per LEARNINGS.md §4.5) so exposing the username + db name is safe; the
+// password lives behind a separate request gate to keep it out of every
+// describe payload.
+type DBInfo struct {
+	Engine    string `json:"engine"`
+	Version   string `json:"version"`
+	Username  string `json:"username"`
+	Database  string `json:"database"`
+	Container string `json:"container,omitempty"`
+	// HostPort is the published TCP port on 127.0.0.1, or 0 when the
+	// site does not publish its DB port. Resolving the port requires a
+	// live Docker call, so callers opt in via DescribeOptions.
+	HostPort int `json:"hostPort,omitempty"`
+}
+
+// ContainerInfo names the per-service containers that back a site, so
+// clients can reference them in `exec` / `logs` calls without reverse-
+// engineering the SiteContainerName scheme.
+type ContainerInfo struct {
+	Service string `json:"service"`
+	Name    string `json:"name"`
+}
+
+// HooksSummary reports the configured hook count broken down by event so
+// agents can spot a site that will run a 30-second pre-start hook before
+// they hit "start."
+type HooksSummary struct {
+	Total  int            `json:"total"`
+	ByKind map[string]int `json:"byKind,omitempty"`
+}
+
+// ActivityEntry is a flattened ActivityEvent for the wire. Storage's
+// ActivityEvent uses unexported helpers (json.RawMessage, time.Time) that
+// don't survive JSON-RPC well; this type pins the wire shape.
+type ActivityEntry struct {
+	ID         int64     `json:"id"`
+	Time       time.Time `json:"time"`
+	Plan       string    `json:"plan"`
+	Kind       string    `json:"kind"`
+	Status     string    `json:"status"`
+	DurationMS int64     `json:"durationMs"`
+	Message    string    `json:"message,omitempty"`
+}
+
+// SPXInfo reports the profiler state for the site. Empty struct when the
+// profiler is not enabled — fields are intentionally narrow so the SPX
+// secret never leaks into a describe payload.
+type SPXInfo struct {
+	Enabled bool `json:"enabled"`
+}
+
+// DescribeOptions controls which optional sections require live Docker /
+// disk lookups. The plain Describe() takes the cheap path; richer clients
+// (CLI / MCP) can opt in.
+type DescribeOptions struct {
+	// IncludeActivity attaches the most recent activity rows to the
+	// description. Cheap (one indexed SQLite query); off by default so
+	// list_sites stays compact.
+	IncludeActivity bool
+
+	// ActivityLimit caps how many rows IncludeActivity returns. <= 0
+	// uses the same limit as RecentActivity (5). The CLI passes a
+	// larger value for `site describe`.
+	ActivityLimit int
+
+	// IncludeSnapshots counts the on-disk snapshots for the site by
+	// listing the snapshots dir. ~O(N) where N is files for that site;
+	// negligible for typical use.
+	IncludeSnapshots bool
+
+	// IncludeHostPort resolves the published DB port via Docker. Skip
+	// for batch list_sites calls — the lookup is one Docker round-trip
+	// per site.
+	IncludeHostPort bool
+}
+
+// Describe returns a SiteDescription for siteID. Pure with respect to
+// site state when opts.IncludeHostPort is false — safe to call from
+// render loops, MCP read-only profiles, and JSON-RPC handlers without
+// triggering side effects on the daemon.
+//
+// A non-existent site returns (nil, nil) so callers can distinguish
+// "not found" (cheap) from "lookup failed" (wrap).
+func (sm *SiteManager) Describe(ctx context.Context, siteID string, opts DescribeOptions) (*SiteDescription, error) {
+	site, err := sm.st.GetSite(siteID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching site: %w", err)
+	}
+	if site == nil {
+		return nil, nil
+	}
+	return sm.describeFromSite(ctx, site, opts)
+}
+
+// DescribeAll returns a SiteDescription for every site, ordered as
+// GetSites returns them. Used by `locorum site list --json` and the MCP
+// list_sites tool.
+//
+// Uses the cheap-path defaults (no host-port lookup, no activity, no
+// snapshot count) regardless of the per-call opts unless the caller
+// explicitly flips them on. The CLI takes the slow path on a single
+// site, never on the list.
+func (sm *SiteManager) DescribeAll(ctx context.Context, opts DescribeOptions) ([]SiteDescription, error) {
+	rows, err := sm.st.GetSites()
+	if err != nil {
+		return nil, fmt.Errorf("listing sites: %w", err)
+	}
+	out := make([]SiteDescription, 0, len(rows))
+	for i := range rows {
+		desc, err := sm.describeFromSite(ctx, &rows[i], opts)
+		if err != nil {
+			return nil, err
+		}
+		if desc != nil {
+			out = append(out, *desc)
+		}
+	}
+	return out, nil
+}
+
+// describeFromSite is the shared body of Describe / DescribeAll. Callers
+// guarantee site is non-nil.
+func (sm *SiteManager) describeFromSite(ctx context.Context, site *types.Site, opts DescribeOptions) (*SiteDescription, error) {
+	eng := dbengine.Resolve(site)
+
+	desc := &SiteDescription{
+		ID:        site.ID,
+		Name:      site.Name,
+		Slug:      site.Slug,
+		Domain:    site.Domain,
+		URL:       "https://" + site.Domain,
+		FilesDir:  site.FilesDir,
+		PublicDir: site.PublicDir,
+		Started:   site.Started,
+		WebServer: site.WebServer,
+		Multisite: site.Multisite,
+		PHP:       VersionInfo{Version: site.PHPVersion},
+		Database: DBInfo{
+			Engine:    site.DBEngine,
+			Version:   site.DBVersion,
+			Username:  "wordpress",
+			Database:  "wordpress",
+			Container: docker.SiteContainerName(site.Slug, "database"),
+		},
+		Redis: VersionInfo{Version: site.RedisVersion},
+		Containers: []ContainerInfo{
+			{Service: "web", Name: docker.SiteContainerName(site.Slug, "web")},
+			{Service: "php", Name: docker.SiteContainerName(site.Slug, "php")},
+			{Service: "database", Name: docker.SiteContainerName(site.Slug, "database")},
+			{Service: "redis", Name: docker.SiteContainerName(site.Slug, "redis")},
+		},
+		Profiling: SPXInfo{Enabled: site.SPXEnabled},
+		CreatedAt: site.CreatedAt,
+		UpdatedAt: site.UpdatedAt,
+	}
+	// Engine resolver fills in DBEngine when the column was NULL on
+	// legacy rows; mirror its choice into the description so clients
+	// see the same value the rest of the system uses.
+	if desc.Database.Engine == "" {
+		desc.Database.Engine = string(eng.Kind())
+	}
+
+	desc.Hooks = sm.summariseHooks(site.ID)
+
+	if opts.IncludeActivity {
+		limit := opts.ActivityLimit
+		if limit <= 0 {
+			limit = activityRecentLimit
+		}
+		rows, err := sm.st.GetActivity(site.ID, limit)
+		if err != nil {
+			return nil, fmt.Errorf("loading activity: %w", err)
+		}
+		desc.Activity = flattenActivity(rows)
+	}
+
+	if opts.IncludeSnapshots {
+		snaps, err := sm.ListSnapshots(site.Slug)
+		if err == nil {
+			desc.SnapshotsCount = len(snaps)
+		}
+	}
+
+	if opts.IncludeHostPort && site.PublishDBPort && site.Started {
+		port, err := sm.d.PublishedHostPort(ctx, desc.Database.Container, eng.DefaultPort())
+		if err == nil {
+			desc.Database.HostPort = port
+		}
+	}
+
+	return desc, nil
+}
+
+// summariseHooks counts hooks per event for the site. Returns an empty
+// summary on lookup failure rather than propagating — the description is
+// useful even when one section is missing, and the GUI's overview panel
+// already tolerates a zero summary.
+func (sm *SiteManager) summariseHooks(siteID string) HooksSummary {
+	out := HooksSummary{}
+	list, err := sm.st.ListHooks(siteID)
+	if err != nil || len(list) == 0 {
+		return out
+	}
+	out.Total = len(list)
+	out.ByKind = make(map[string]int, 4)
+	for _, h := range list {
+		ev := string(h.Event)
+		if !hooks.Event(ev).Valid() {
+			ev = "other"
+		}
+		out.ByKind[ev]++
+	}
+	return out
+}
+
+// flattenActivity turns []storage.ActivityEvent into the wire-friendly
+// []ActivityEntry. Drops the JSON details blob — clients that need it
+// can call get_activity directly.
+func flattenActivity(rows []storage.ActivityEvent) []ActivityEntry {
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]ActivityEntry, len(rows))
+	for i, r := range rows {
+		out[i] = ActivityEntry{
+			ID:         r.ID,
+			Time:       r.Time,
+			Plan:       r.Plan,
+			Kind:       string(r.Kind),
+			Status:     string(r.Status),
+			DurationMS: r.DurationMS,
+			Message:    r.Message,
+		}
+	}
+	return out
+}

--- a/internal/sites/describe_test.go
+++ b/internal/sites/describe_test.go
@@ -1,0 +1,49 @@
+package sites
+
+import (
+	"testing"
+
+	"github.com/PeterBooker/locorum/internal/storage"
+)
+
+// TestFlattenActivity covers the wire-shape conversion. The fields are
+// pure data; if this drifts, every CLI/MCP client breaks at the same
+// time.
+func TestFlattenActivity(t *testing.T) {
+	rows := []storage.ActivityEvent{
+		{
+			ID:         1,
+			SiteID:     "s1",
+			Plan:       "start-site:demo",
+			Kind:       storage.ActivityKindStart,
+			Status:     storage.ActivityStatusSucceeded,
+			DurationMS: 4000,
+			Message:    "started",
+		},
+		{
+			ID:     2,
+			SiteID: "s1",
+			Kind:   storage.ActivityKindStop,
+			Status: storage.ActivityStatusFailed,
+		},
+	}
+	out := flattenActivity(rows)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(out))
+	}
+	if out[0].Kind != "start" || out[0].Status != "succeeded" {
+		t.Fatalf("row 0 fields: %+v", out[0])
+	}
+	if out[0].DurationMS != 4000 {
+		t.Fatalf("DurationMS not preserved: %d", out[0].DurationMS)
+	}
+	if out[1].Status != "failed" {
+		t.Fatalf("row 1 status: %q", out[1].Status)
+	}
+}
+
+func TestFlattenActivity_EmptyInput(t *testing.T) {
+	if got := flattenActivity(nil); got != nil {
+		t.Fatalf("empty input should return nil, got %+v", got)
+	}
+}

--- a/internal/sites/sites.go
+++ b/internal/sites/sites.go
@@ -28,6 +28,7 @@ import (
 	"github.com/PeterBooker/locorum/internal/dbengine"
 	"github.com/PeterBooker/locorum/internal/docker"
 	"github.com/PeterBooker/locorum/internal/genmark"
+	"github.com/PeterBooker/locorum/internal/git"
 	"github.com/PeterBooker/locorum/internal/hooks"
 	"github.com/PeterBooker/locorum/internal/orch"
 	"github.com/PeterBooker/locorum/internal/router"
@@ -750,7 +751,25 @@ type DeleteOptions struct {
 	// ~/.locorum/snapshots/ first. Set true when the caller has already
 	// taken a snapshot or is intentionally discarding data.
 	SkipSnapshot bool
+
+	// ForceWorktree, on a worktree-bound site, passes --force to
+	// `git worktree remove` so dirty trees don't block the delete.
+	// Default is false: dirty worktrees raise a typed error so the
+	// CLI can prompt for confirmation. The GUI delete-confirm modal
+	// flips this when the user explicitly accepts data loss.
+	ForceWorktree bool
+
+	// DryRun reports the planned operations without committing them.
+	// Used by `locorum site delete --dry-run` to surface every
+	// destructive step before the user confirms.
+	DryRun bool
 }
+
+// ErrWorktreeDirty is returned by DeleteSite when the target site is
+// a worktree with uncommitted changes and ForceWorktree was not set.
+// Wraps the original error from `git status` so the CLI can show
+// what's dirty.
+var ErrWorktreeDirty = errors.New("worktree has uncommitted changes; pass --force to discard")
 
 func (sm *SiteManager) DeleteSite(ctx context.Context, id string) error {
 	return sm.DeleteSiteWithOptions(ctx, id, DeleteOptions{})
@@ -768,15 +787,35 @@ func (sm *SiteManager) DeleteSiteWithOptions(ctx context.Context, id string, opt
 		return nil
 	}
 
+	// Worktree dirtiness is checked BEFORE any destructive work.
+	// Without --force we abort early so the user doesn't lose
+	// uncommitted changes to a `delete site` flow.
+	if !opts.DryRun && site.WorktreePath != "" && !opts.ForceWorktree {
+		if dirty, _ := git.HasUncommittedChanges(ctx, site.WorktreePath, nil); dirty {
+			return fmt.Errorf("%w: %s", ErrWorktreeDirty, site.WorktreePath)
+		}
+	}
+
+	// Cascade-clean every worktree-child of a parent site. Children
+	// are stopped + removed first so their containers are gone before
+	// we tear down the parent's. Failures are logged; we proceed to
+	// the parent so a partial state doesn't strand the row.
+	if !opts.DryRun {
+		if children, err := sm.st.SitesByParent(id); err == nil {
+			for _, child := range children {
+				slog.Info("cascade-deleting worktree child", "parent", site.Slug, "child", child.Slug)
+				childOpts := opts
+				childOpts.ForceWorktree = true // children of a doomed parent come along
+				if err := sm.DeleteSiteWithOptions(ctx, child.ID, childOpts); err != nil {
+					slog.Warn("cascade child delete failed", "child", child.Slug, "err", err.Error())
+				}
+			}
+		}
+	}
+
 	mu := sm.siteMutex(id)
 	mu.Lock()
 	defer mu.Unlock()
-
-	// pre-delete fires BEFORE we touch storage, so the runner's hook list
-	// lookup still succeeds.
-	if err := sm.runHooks(ctx, hooks.PreDelete, site); err != nil {
-		return err
-	}
 
 	containers := specNames(sm.serviceSpecs(site))
 
@@ -811,11 +850,41 @@ func (sm *SiteManager) DeleteSiteWithOptions(ctx context.Context, id string, opt
 	if opts.PurgeVolume {
 		steps = append(steps, &sitesteps.PurgeVolumeStep{Engine: sm.d, Site: site})
 	}
+	// Worktree teardown comes LAST so the ordered Plan tries to leave
+	// the working tree in place if any earlier step fails (less to
+	// lose if the user retries).
+	if site.WorktreePath != "" {
+		parentDir := sm.parentRepoDir(site)
+		steps = append(steps, &sitesteps.RemoveWorktreeStep{
+			ParentDir:    parentDir,
+			WorktreePath: site.WorktreePath,
+			Force:        opts.ForceWorktree,
+		})
+	}
 
 	plan := orch.Plan{
 		Name:  "delete-site:" + site.Slug,
 		Steps: steps,
 	}
+
+	if opts.DryRun {
+		dr, derr := orch.Dry(ctx, plan)
+		if derr != nil {
+			return derr
+		}
+		// Dry-run never persists — we just emit a slog line so the
+		// daemon's caller can pick it up. Callers needing structured
+		// preview output should use PlanDryRunDescription instead.
+		slog.Info("dry-run delete plan", "preview", dr.Format())
+		return nil
+	}
+
+	// pre-delete fires BEFORE we touch storage so the runner's hook list
+	// lookup still succeeds.
+	if err := sm.runHooks(ctx, hooks.PreDelete, site); err != nil {
+		return err
+	}
+
 	res := sm.runPlan(ctx, site, plan)
 	if res.FinalError != nil {
 		// Even on error we continue to delete the SQL row so the GUI
@@ -837,6 +906,23 @@ func (sm *SiteManager) DeleteSiteWithOptions(ctx context.Context, id string, opt
 
 	sm.emitSitesUpdate()
 	return nil
+}
+
+// parentRepoDir resolves the host directory holding the upstream
+// checkout for a worktree-bound site. Looks up the parent row by
+// ParentSiteID; if the parent has been hand-deleted, falls back to
+// the worktree's own .git/commondir resolution would be ideal but
+// `git worktree remove` is happy to be invoked from the worktree
+// itself, so we just pass the worktree path as the working dir.
+func (sm *SiteManager) parentRepoDir(site *types.Site) string {
+	if site == nil || site.ParentSiteID == "" {
+		return site.WorktreePath
+	}
+	parent, err := sm.st.GetSite(site.ParentSiteID)
+	if err != nil || parent == nil || parent.FilesDir == "" {
+		return site.WorktreePath
+	}
+	return parent.FilesDir
 }
 
 func (sm *SiteManager) emitSitesUpdate() {

--- a/internal/sites/sitesteps/describe.go
+++ b/internal/sites/sitesteps/describe.go
@@ -1,0 +1,143 @@
+package sitesteps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/PeterBooker/locorum/internal/docker"
+)
+
+// Describe implementations for the existing step types. Adding these
+// in a separate file keeps the original sitesteps.go stable while
+// teaching every step the dry-run vocabulary the orch.Describer
+// interface expects (P4 in AGENTS-SUPPORT.md).
+//
+// Each Describe must be pure: read state, format a string, return.
+// Anything that touches Docker, the filesystem, or git belongs in
+// Apply, not Describe. The dry-run runner explicitly trusts Describe
+// to be side-effect-free; a buggy implementation that, say, pulled an
+// image during a dry-run would silently make the preview slow and
+// surprise users counting on `--dry-run` for safety.
+
+func (s *EnsureNetworkStep) Describe(_ context.Context) (string, error) {
+	if s.Site == nil {
+		return "ensure per-site network (no site)", nil
+	}
+	return fmt.Sprintf("ensure docker network for site %s", s.Site.Slug), nil
+}
+
+func (s *EnsureVolumeStep) Describe(_ context.Context) (string, error) {
+	if s.Site == nil {
+		return "ensure database volume (no site)", nil
+	}
+	return fmt.Sprintf("ensure database volume for site %s", s.Site.Slug), nil
+}
+
+func (s *PullImagesStep) Describe(_ context.Context) (string, error) {
+	images := make([]string, 0, len(s.Specs))
+	for _, sp := range s.Specs {
+		if sp.Image != "" {
+			images = append(images, sp.Image)
+		}
+	}
+	if len(images) == 0 {
+		return "pull container images (none specified)", nil
+	}
+	return "pull " + strings.Join(images, ", "), nil
+}
+
+func (s *ChownStep) Describe(_ context.Context) (string, error) {
+	if s.Site == nil {
+		return "chown bind-mounted dirs to the PHP UID/GID (no site)", nil
+	}
+	return fmt.Sprintf("chown bind-mounts of site %s to the PHP UID/GID", s.Site.Slug), nil
+}
+
+func (s *CreateContainersStep) Describe(_ context.Context) (string, error) {
+	names := specNamesLocal(s.Specs)
+	if len(names) == 0 {
+		return "create containers (none specified)", nil
+	}
+	return "create or recreate containers: " + strings.Join(names, ", "), nil
+}
+
+func (s *WaitReadyStep) Describe(_ context.Context) (string, error) {
+	if len(s.Containers) == 0 {
+		return "wait for containers to report ready (none specified)", nil
+	}
+	return "wait for ready: " + strings.Join(s.Containers, ", "), nil
+}
+
+func (s *StopContainersStep) Describe(_ context.Context) (string, error) {
+	if len(s.Containers) == 0 {
+		return "stop containers (none specified)", nil
+	}
+	return "stop containers: " + strings.Join(s.Containers, ", "), nil
+}
+
+func (s *RemoveContainersStep) Describe(_ context.Context) (string, error) {
+	if len(s.Containers) == 0 {
+		return "remove containers (none specified)", nil
+	}
+	return "remove containers: " + strings.Join(s.Containers, ", "), nil
+}
+
+func (s *RegisterRoutesStep) Describe(_ context.Context) (string, error) {
+	hosts := []string{s.Route.PrimaryHost}
+	if s.Route.WildcardHost != "" {
+		hosts = append(hosts, s.Route.WildcardHost)
+	}
+	return "register router routes for " + strings.Join(hosts, ", "), nil
+}
+
+func (s *RemoveRoutesStep) Describe(_ context.Context) (string, error) {
+	return fmt.Sprintf("remove router routes for %s", s.Slug), nil
+}
+
+func (s *RemoveNetworkStep) Describe(_ context.Context) (string, error) {
+	if s.Site == nil {
+		return "remove per-site network (no site)", nil
+	}
+	return fmt.Sprintf("remove docker network for site %s", s.Site.Slug), nil
+}
+
+func (s *RemoveSiteConfigsStep) Describe(_ context.Context) (string, error) {
+	if s.Site == nil {
+		return "remove generated site configs", nil
+	}
+	return fmt.Sprintf("remove generated configs for site %s", s.Site.Slug), nil
+}
+
+func (s *PurgeVolumeStep) Describe(_ context.Context) (string, error) {
+	if s.Site == nil {
+		return "purge database volume (no site)", nil
+	}
+	return fmt.Sprintf("DESTROY database volume for site %s (data loss!)", s.Site.Slug), nil
+}
+
+func (s *HookStep) Describe(_ context.Context) (string, error) {
+	if s.Label == "" {
+		return "run hooks", nil
+	}
+	return s.Label, nil
+}
+
+func (s *FuncStep) Describe(_ context.Context) (string, error) {
+	if s.Label == "" {
+		return "(unnamed glue step)", nil
+	}
+	return s.Label, nil
+}
+
+// specNamesLocal mirrors specNames in sites.go. Local helper so
+// describe.go doesn't reach across packages for one trivial map.
+func specNamesLocal(specs []docker.ContainerSpec) []string {
+	out := make([]string, 0, len(specs))
+	for _, sp := range specs {
+		if sp.Name != "" {
+			out = append(out, sp.Name)
+		}
+	}
+	return out
+}

--- a/internal/sites/sitesteps/sitesteps.go
+++ b/internal/sites/sitesteps/sitesteps.go
@@ -397,4 +397,24 @@ var (
 	_ orch.Step = (*EnsureSPXStep)(nil)
 	_ orch.Step = (*HookStep)(nil)
 	_ orch.Step = (*FuncStep)(nil)
+
+	// Compile-time guard: every Describer implementation here
+	// satisfies orch.Describer. Adding a new step without a Describe
+	// is a compile error here, prompting the author to either add
+	// one or accept the (no preview) sentinel.
+	_ orch.Describer = (*EnsureNetworkStep)(nil)
+	_ orch.Describer = (*EnsureVolumeStep)(nil)
+	_ orch.Describer = (*PullImagesStep)(nil)
+	_ orch.Describer = (*ChownStep)(nil)
+	_ orch.Describer = (*CreateContainersStep)(nil)
+	_ orch.Describer = (*WaitReadyStep)(nil)
+	_ orch.Describer = (*StopContainersStep)(nil)
+	_ orch.Describer = (*RemoveContainersStep)(nil)
+	_ orch.Describer = (*RegisterRoutesStep)(nil)
+	_ orch.Describer = (*RemoveRoutesStep)(nil)
+	_ orch.Describer = (*RemoveNetworkStep)(nil)
+	_ orch.Describer = (*RemoveSiteConfigsStep)(nil)
+	_ orch.Describer = (*PurgeVolumeStep)(nil)
+	_ orch.Describer = (*HookStep)(nil)
+	_ orch.Describer = (*FuncStep)(nil)
 )

--- a/internal/sites/sitesteps/worktree.go
+++ b/internal/sites/sitesteps/worktree.go
@@ -1,0 +1,153 @@
+package sitesteps
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/PeterBooker/locorum/internal/git"
+	"github.com/PeterBooker/locorum/internal/orch"
+)
+
+// Worktree-related Plan steps used by SiteManager.CreateWorktreeSite.
+// All of these implement orch.Describer so a `--dry-run` invocation
+// can preview their effect without touching the filesystem or network.
+
+// EnsureCheckoutStep clones the parent repository into ParentDir if
+// missing, otherwise runs `git fetch --all --prune` to keep refs
+// fresh. Idempotent: repeating after success is cheap and never
+// destroys local commits.
+//
+// Rollback is a no-op: the parent checkout is shared by every
+// worktree-bound site for the same repo, and one failed CreateSite
+// must not delete it for the others.
+type EnsureCheckoutStep struct {
+	Remote    string
+	ParentDir string
+	Runner    git.Runner // nil means git.Default (production)
+}
+
+func (s *EnsureCheckoutStep) Name() string { return "ensure-checkout" }
+
+func (s *EnsureCheckoutStep) Apply(ctx context.Context) error {
+	if s.Remote == "" || s.ParentDir == "" {
+		return fmt.Errorf("ensure-checkout: Remote and ParentDir are required")
+	}
+	if err := os.MkdirAll(filepath.Dir(s.ParentDir), 0o755); err != nil {
+		return fmt.Errorf("ensure-checkout: parent dir: %w", err)
+	}
+	_, err := git.EnsureRepo(ctx, s.Remote, s.ParentDir, git.CloneOptions{Runner: s.Runner})
+	return err
+}
+
+func (s *EnsureCheckoutStep) Rollback(_ context.Context) error { return nil }
+
+func (s *EnsureCheckoutStep) Describe(_ context.Context) (string, error) {
+	if s.Remote == "" {
+		return "(no-op — remote unset)", nil
+	}
+	if _, err := os.Stat(filepath.Join(s.ParentDir, ".git")); err == nil {
+		return fmt.Sprintf("git fetch in %s (existing repo)", s.ParentDir), nil
+	}
+	return fmt.Sprintf("git clone %s into %s", s.Remote, s.ParentDir), nil
+}
+
+// EnsureWorktreeStep adds a git worktree for Branch at WorktreePath.
+// On rollback, removes the worktree (with --force if AllowForce is
+// set) so a half-set-up site does not leave a dangling git
+// administrative entry behind.
+//
+// Branch is created from origin/<branch> if it doesn't exist locally.
+// That mirrors how `git worktree add -b X path origin/X` behaves and
+// keeps the agent's "create a worktree for an upstream branch" flow
+// trivially correct.
+type EnsureWorktreeStep struct {
+	ParentDir    string
+	WorktreePath string
+	Branch       string
+	Runner       git.Runner
+}
+
+func (s *EnsureWorktreeStep) Name() string { return "ensure-worktree" }
+
+func (s *EnsureWorktreeStep) Apply(ctx context.Context) error {
+	if s.ParentDir == "" || s.WorktreePath == "" || s.Branch == "" {
+		return fmt.Errorf("ensure-worktree: ParentDir, WorktreePath, Branch required")
+	}
+	// If the worktree path already contains a working tree, the
+	// caller already created it (e.g. partial recovery from a previous
+	// run). git worktree add fails in that case — short-circuit.
+	if _, err := os.Stat(filepath.Join(s.WorktreePath, ".git")); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.WorktreePath), 0o755); err != nil {
+		return fmt.Errorf("ensure-worktree: parent dir: %w", err)
+	}
+	return git.WorktreeAdd(ctx, s.ParentDir, s.WorktreePath, s.Branch, s.Runner)
+}
+
+func (s *EnsureWorktreeStep) Rollback(ctx context.Context) error {
+	if s.ParentDir == "" || s.WorktreePath == "" {
+		return nil
+	}
+	// Force on rollback: if the user's flow died after we created the
+	// worktree but before they did anything with it, there's no work
+	// to preserve.
+	return git.WorktreeRemove(ctx, s.ParentDir, s.WorktreePath, true, s.Runner)
+}
+
+func (s *EnsureWorktreeStep) Describe(_ context.Context) (string, error) {
+	return fmt.Sprintf("git worktree add %s tracking %s in %s",
+		s.WorktreePath, s.Branch, s.ParentDir), nil
+}
+
+// RemoveWorktreeStep tears down a git worktree as part of a delete
+// plan. Force is set on rollback by the caller; the typical user-
+// facing path consults DiscardChanges first.
+type RemoveWorktreeStep struct {
+	ParentDir    string
+	WorktreePath string
+	Force        bool
+	Runner       git.Runner
+}
+
+func (s *RemoveWorktreeStep) Name() string { return "remove-worktree" }
+
+func (s *RemoveWorktreeStep) Apply(ctx context.Context) error {
+	if s.ParentDir == "" || s.WorktreePath == "" {
+		return nil
+	}
+	// Tolerate "already removed": git returns nonzero with a clear
+	// message when the worktree directory is missing. Stat and skip
+	// keeps Apply idempotent.
+	if _, err := os.Stat(s.WorktreePath); os.IsNotExist(err) {
+		return nil
+	}
+	return git.WorktreeRemove(ctx, s.ParentDir, s.WorktreePath, s.Force, s.Runner)
+}
+
+func (s *RemoveWorktreeStep) Rollback(_ context.Context) error {
+	// No undo for a worktree removal: re-creating would not restore
+	// the original work. We accept the asymmetry — Apply only runs
+	// inside a delete plan.
+	return nil
+}
+
+func (s *RemoveWorktreeStep) Describe(_ context.Context) (string, error) {
+	flag := ""
+	if s.Force {
+		flag = " --force"
+	}
+	return fmt.Sprintf("git worktree remove%s %s", flag, s.WorktreePath), nil
+}
+
+// Compile-time guards.
+var (
+	_ orch.Step      = (*EnsureCheckoutStep)(nil)
+	_ orch.Describer = (*EnsureCheckoutStep)(nil)
+	_ orch.Step      = (*EnsureWorktreeStep)(nil)
+	_ orch.Describer = (*EnsureWorktreeStep)(nil)
+	_ orch.Step      = (*RemoveWorktreeStep)(nil)
+	_ orch.Describer = (*RemoveWorktreeStep)(nil)
+)

--- a/internal/sites/snapshot.go
+++ b/internal/sites/snapshot.go
@@ -24,6 +24,19 @@ import (
 	"github.com/PeterBooker/locorum/internal/types"
 )
 
+// shouldAutoSnapshot reports whether the auto-snapshot wrap is on.
+// True is the safe default; users with their own backup discipline
+// flip the snapshots.auto_before_destructive setting to disable.
+//
+// SiteManagers constructed in tests without a *config.Config (cfg ==
+// nil) get the default behaviour: auto-snapshot ON.
+func (sm *SiteManager) shouldAutoSnapshot() bool {
+	if sm == nil || sm.cfg == nil {
+		return true
+	}
+	return sm.cfg.AutoSnapshotBeforeDestructive()
+}
+
 // snapshotsRoot is the per-user directory holding all sites' snapshots.
 // Lives outside the site's files tree so an accidental `rm -rf
 // ~/locorum/sites/{slug}` does NOT take the snapshots with it — that's
@@ -407,12 +420,25 @@ type RestoreSnapshotOptions struct {
 	// false. Skip if the user is restoring a snapshot they trust without
 	// a sidecar.
 	SkipChecksum bool
+
+	// SkipAutoSnapshot disables the pre-restore safety snapshot that
+	// RestoreSnapshot otherwise takes (P4 in AGENTS-SUPPORT). Set true
+	// when the caller has already established a recovery point (e.g.
+	// the worktree clone-DB flow that snapshots the parent before
+	// touching the child) or when restoring into a known-empty DB.
+	SkipAutoSnapshot bool
 }
 
 // RestoreSnapshot reconstructs the database from a snapshot. The site
 // must be running. Engine compatibility is checked against the filename
 // metadata: a snapshot tagged `mysql8.0` will refuse to restore into a
 // `mysql5.7` site (LEARNINGS.md F18). Override with AllowEngineMismatch.
+//
+// Auto-snapshot wrap (P4): unless opts.SkipAutoSnapshot is true, a
+// "pre_restore" snapshot is taken before the destructive restore, so a
+// botched restore can be rolled back with one command. The wrap is
+// gated by snapshots.auto_before_destructive (default true) so power
+// users with their own backup discipline can disable.
 func (sm *SiteManager) RestoreSnapshot(ctx context.Context, siteID, snapshotPath string, opts RestoreSnapshotOptions) error {
 	site, err := sm.st.GetSite(siteID)
 	if err != nil {
@@ -437,6 +463,19 @@ func (sm *SiteManager) RestoreSnapshot(ctx context.Context, siteID, snapshotPath
 	mu := sm.siteMutex(siteID)
 	mu.Lock()
 	defer mu.Unlock()
+
+	// Pre-restore safety snapshot. A failure here logs and continues:
+	// refusing to restore because of a snapshot failure would strand
+	// users whose DB volume is the very thing they're trying to
+	// repair. The snapshot label `pre_restore` makes the recovery
+	// point easy to find in ListSnapshots.
+	if !opts.SkipAutoSnapshot && sm.shouldAutoSnapshot() {
+		if path, serr := sm.snapshotLocked(ctx, site, "pre_restore"); serr != nil {
+			slog.Warn("pre-restore auto-snapshot failed", "site", site.Slug, "err", serr.Error())
+		} else {
+			slog.Info("pre-restore auto-snapshot saved", "path", path)
+		}
+	}
 
 	// Verify checksum first if a sidecar exists. We do this before
 	// touching the live database so a corrupt snapshot is rejected

--- a/internal/sites/worktree.go
+++ b/internal/sites/worktree.go
@@ -1,0 +1,454 @@
+package sites
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gosimple/slug"
+
+	"github.com/PeterBooker/locorum/internal/dbengine"
+	"github.com/PeterBooker/locorum/internal/git"
+	"github.com/PeterBooker/locorum/internal/types"
+)
+
+// CreateWorktreeOptions captures the user-supplied inputs to
+// CreateWorktreeSite. Mirrors the CLI's `site create --git-remote …`
+// flag set, with sensible defaults wired in by the helper.
+type CreateWorktreeOptions struct {
+	// Name is a human-readable label for the new site row. Required.
+	// The derived slug is computed by WorktreeSlug; Name is just for
+	// the GUI list view.
+	Name string
+
+	// GitRemote is the canonical upstream URL passed to `git clone`.
+	// SSH and HTTPS forms both work — Locorum doesn't validate or
+	// rewrite the value, so the user's git config (credentials,
+	// askpass) applies.
+	GitRemote string
+
+	// Branch is the upstream branch the worktree tracks. Validated
+	// by ValidateWorktreeOpts; sanitiseBranchForSlug handles the rest.
+	Branch string
+
+	// ParentSlug, when non-empty, identifies an existing site row to
+	// use as the parent. Empty means "auto-derive a parent slug from
+	// the remote URL"; the parent site is created on the fly if it
+	// doesn't exist.
+	ParentSlug string
+
+	// CloneDB, when true, copies the parent site's database into the
+	// new worktree site and runs wp search-replace to swap the
+	// hostname. Default is false (empty WP install) — D2 in the
+	// AGENTS-SUPPORT plan.
+	CloneDB bool
+
+	// PHPVersion / DBVersion / DBEngine / RedisVersion, when set,
+	// override the parent site's runtime versions. Empty falls back
+	// to the parent or, when no parent, to engine defaults.
+	PHPVersion   string
+	DBEngine     string
+	DBVersion    string
+	RedisVersion string
+
+	// WorktreeRoot, when set, overrides the default placement
+	// (~/locorum/worktrees/<parent-slug>/<branch-slug>). Useful when
+	// the user wants the worktree alongside their existing checkout.
+	WorktreeRoot string
+
+	// DryRun reports the planned operations without committing them.
+	// When true, no SQLite rows are inserted, no git commands run, no
+	// containers are created — Describe() runs on every step and the
+	// preview is returned via the result.
+	DryRun bool
+}
+
+// CreateWorktreeResult is what CreateWorktreeSite returns on success
+// (or, in DryRun mode, on a complete preview).
+type CreateWorktreeResult struct {
+	// Site is the row inserted into SQLite. In DryRun mode this is
+	// the row that *would* have been inserted; the caller must not
+	// expect it to round-trip through GetSite.
+	Site types.Site
+
+	// DerivedSlug is the worktree-derived slug (D3). Same as
+	// Site.Slug but exposed for clarity.
+	DerivedSlug string
+
+	// DryRunPreview is non-empty when DryRun was set. Each line is
+	// one step's preview; suitable for direct CLI output.
+	DryRunPreview string
+}
+
+// CreateWorktreeSite is the agent-facing differentiator: spin up a
+// site bound to a git worktree. The flow:
+//
+//  1. Validate inputs (ValidateWorktreeOpts).
+//  2. Resolve the parent site row (existing or just-in-time created).
+//  3. Compute derived slug + worktree path.
+//  4. (Plan step) ensure-checkout — clone or fetch parent repo.
+//  5. (Plan step) ensure-worktree — git worktree add.
+//  6. Insert the site row.
+//  7. Start the site (StartSite picks up FilesDir = WorktreePath).
+//  8. (CloneDB only) snapshot parent → restore into new site →
+//     wp search-replace → auto-snapshot result.
+//
+// On any step failure, rollback runs in reverse: worktree removed,
+// SQLite row deleted (when present). Per-site mutex serialises calls
+// for the same parent — concurrent worktree creates against
+// different parents run in parallel.
+func (sm *SiteManager) CreateWorktreeSite(ctx context.Context, opts CreateWorktreeOptions) (*CreateWorktreeResult, error) {
+	if err := ValidateWorktreeOpts(opts.GitRemote, opts.Branch, opts.WorktreeRoot); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(opts.Name) == "" {
+		return nil, errors.New("name is required")
+	}
+
+	parent, parentCreated, err := sm.resolveOrCreateParent(opts)
+	if err != nil {
+		return nil, err
+	}
+	// In dry-run mode, resolveOrCreateParent may have inserted a stub
+	// parent row to make the preview meaningful. Roll it back before
+	// returning so dry-run is a true no-op (P4 invariant).
+	if opts.DryRun && parentCreated {
+		defer func() {
+			if err := sm.st.DeleteSite(parent.ID); err != nil {
+				slog.Warn("dry-run: rollback stub parent", "err", err.Error())
+			}
+		}()
+	}
+
+	parentDir := parent.FilesDir
+	if parentDir == "" {
+		// Conventional sites set FilesDir on AddSite; a parent with
+		// an empty FilesDir is malformed. Reject loudly so we don't
+		// silently scribble across an unrelated directory.
+		return nil, fmt.Errorf("parent site %q has empty FilesDir", parent.Slug)
+	}
+
+	worktreeRoot := opts.WorktreeRoot
+	if worktreeRoot == "" {
+		worktreeRoot = filepath.Join(filepath.Dir(parentDir), parent.Slug+".worktrees")
+	}
+	derivedSlug := WorktreeSlug(parent.Slug, opts.Branch, worktreeRoot)
+	worktreePath := filepath.Join(worktreeRoot, derivedSlug)
+	derivedDomain := derivedSlug + ".localhost"
+
+	// Build the row up front so DryRun can return a full preview.
+	newSite := types.Site{
+		ID:           uuid.NewString(),
+		Name:         opts.Name,
+		Slug:         derivedSlug,
+		Domain:       derivedDomain,
+		FilesDir:     worktreePath,
+		PublicDir:    parent.PublicDir,
+		WebServer:    parent.WebServer,
+		PHPVersion:   firstNonEmpty(opts.PHPVersion, parent.PHPVersion),
+		DBEngine:     firstNonEmpty(opts.DBEngine, parent.DBEngine),
+		DBVersion:    firstNonEmpty(opts.DBVersion, parent.DBVersion),
+		RedisVersion: firstNonEmpty(opts.RedisVersion, parent.RedisVersion),
+		DBPassword:   generatePassword(16),
+		GitRemote:    opts.GitRemote,
+		GitBranch:    opts.Branch,
+		WorktreePath: worktreePath,
+		ParentSiteID: parent.ID,
+	}
+	if newSite.DBEngine == "" {
+		newSite.DBEngine = string(dbengine.Default)
+	}
+	if newSite.DBVersion == "" {
+		newSite.DBVersion = dbengine.MustFor(dbengine.Kind(newSite.DBEngine)).DefaultVersion()
+	}
+	if newSite.WebServer == "" {
+		newSite.WebServer = "nginx"
+	}
+
+	if opts.DryRun {
+		preview, err := sm.previewWorktreePlan(ctx, parent, &newSite, opts)
+		if err != nil {
+			return nil, err
+		}
+		return &CreateWorktreeResult{
+			Site:          newSite,
+			DerivedSlug:   derivedSlug,
+			DryRunPreview: preview,
+		}, nil
+	}
+
+	// Acquire the parent's lock so concurrent CreateWorktreeSite
+	// calls for the same parent serialise on git operations. The
+	// per-site mutex map keys on ID, so different parents stay
+	// parallel.
+	parentMu := sm.siteMutex(parent.ID)
+	parentMu.Lock()
+	defer parentMu.Unlock()
+
+	// Run the git steps as a small Plan so failures roll back the
+	// worktree cleanly. We do NOT compose this with StartSite's plan
+	// — StartSite acquires its own per-site mutex and the rollback
+	// semantics differ (we want StartSite failures to leave the
+	// worktree in place so the user can debug, but git failures must
+	// undo the worktree).
+	gitSteps := []*sitestepFuncWrap{
+		newGitFuncStep("ensure-checkout",
+			fmt.Sprintf("git fetch / clone %s into %s", opts.GitRemote, parentDir),
+			func(ctx context.Context) error {
+				_, err := git.EnsureRepo(ctx, opts.GitRemote, parentDir, git.CloneOptions{})
+				return err
+			},
+			nil, // no rollback — shared parent dir
+		),
+		newGitFuncStep("ensure-worktree",
+			fmt.Sprintf("git worktree add %s tracking %s", worktreePath, opts.Branch),
+			func(ctx context.Context) error {
+				return git.WorktreeAdd(ctx, parentDir, worktreePath, opts.Branch, nil)
+			},
+			func(ctx context.Context) error {
+				return git.WorktreeRemove(ctx, parentDir, worktreePath, true, nil)
+			},
+		),
+	}
+	for _, step := range gitSteps {
+		if err := step.do(ctx); err != nil {
+			rollbackGitSteps(ctx, gitSteps)
+			if parentCreated {
+				_ = sm.st.DeleteSite(parent.ID)
+			}
+			return nil, err
+		}
+	}
+
+	if err := sm.st.AddSite(&newSite); err != nil {
+		rollbackGitSteps(ctx, gitSteps)
+		if parentCreated {
+			_ = sm.st.DeleteSite(parent.ID)
+		}
+		return nil, fmt.Errorf("persist new site: %w", err)
+	}
+	sm.writeConfigYAML(&newSite)
+	sm.emitSitesUpdate()
+
+	// StartSite from here on so the user sees normal progress
+	// callbacks and a green checklist on the GUI / streaming CLI.
+	if err := sm.StartSite(ctx, newSite.ID); err != nil {
+		// Worktree + DB row stay so the user can inspect; surface
+		// the start failure but do NOT auto-rollback the SQLite row,
+		// matching the existing CloneSite UX.
+		return &CreateWorktreeResult{
+			Site:        newSite,
+			DerivedSlug: derivedSlug,
+		}, fmt.Errorf("start worktree site: %w", err)
+	}
+
+	if opts.CloneDB && parent.Started {
+		if err := sm.cloneDBFromParent(ctx, parent, &newSite); err != nil {
+			slog.Warn("clone-db: parent → worktree failed", "err", err.Error())
+			// Non-fatal: empty WP is still functional, and
+			// surfacing the error to the caller would force them
+			// to clean up the partial state. A toast / log line
+			// is enough.
+		}
+	}
+
+	return &CreateWorktreeResult{Site: newSite, DerivedSlug: derivedSlug}, nil
+}
+
+// resolveOrCreateParent returns the parent site row. When
+// opts.ParentSlug names an existing row, that row is used directly.
+// When empty, the parent slug is derived from the remote URL and a
+// new conventional site is added on the fly.
+//
+// The parentCreated flag tells the caller whether they need to
+// clean up the parent on failure (only when we created it).
+func (sm *SiteManager) resolveOrCreateParent(opts CreateWorktreeOptions) (types.Site, bool, error) {
+	rows, err := sm.st.GetSites()
+	if err != nil {
+		return types.Site{}, false, err
+	}
+
+	if opts.ParentSlug != "" {
+		for _, s := range rows {
+			if s.Slug == opts.ParentSlug && s.ParentSiteID == "" {
+				return s, false, nil
+			}
+		}
+		return types.Site{}, false, fmt.Errorf("parent slug %q not found (or is itself a worktree)", opts.ParentSlug)
+	}
+
+	parentSlug := slug.Make(remoteSlugCandidate(opts.GitRemote))
+	if parentSlug == "" {
+		return types.Site{}, false, fmt.Errorf("could not derive parent slug from %q", opts.GitRemote)
+	}
+	for _, s := range rows {
+		if s.Slug == parentSlug && s.ParentSiteID == "" {
+			return s, false, nil
+		}
+	}
+
+	// Auto-create a stub parent. The parent's FilesDir holds the
+	// canonical clone; worktrees live in <parent-dir>.worktrees/.
+	homeSites := filepath.Join(sm.homeDir, "locorum", "sites", parentSlug)
+	parent := types.Site{
+		ID:        uuid.NewString(),
+		Name:      parentSlug,
+		Slug:      parentSlug,
+		Domain:    parentSlug + ".localhost",
+		FilesDir:  homeSites,
+		WebServer: "nginx",
+		GitRemote: opts.GitRemote,
+		// Default versions: pick whatever the engine says is current.
+		DBEngine:  string(dbengine.Default),
+		DBVersion: dbengine.MustFor(dbengine.Default).DefaultVersion(),
+		// Reasonable defaults — agents creating worktrees rarely
+		// care about the parent's PHP version because they'll start
+		// the worktree separately.
+		PHPVersion:   "8.4",
+		RedisVersion: "8.0",
+		DBPassword:   generatePassword(16),
+	}
+	if err := sm.st.AddSite(&parent); err != nil {
+		return types.Site{}, false, fmt.Errorf("add parent site: %w", err)
+	}
+	return parent, true, nil
+}
+
+// remoteSlugCandidate extracts a friendly slug fragment from the
+// remote URL. Strips the .git suffix and the path prefix so
+// `git@github.com:foo/bar.git` becomes `bar`. Falls back to "site"
+// for opaque URLs we can't parse.
+func remoteSlugCandidate(remote string) string {
+	r := strings.TrimSpace(remote)
+	r = strings.TrimSuffix(r, "/")
+	r = strings.TrimSuffix(r, ".git")
+	if idx := strings.LastIndexAny(r, "/:"); idx >= 0 {
+		r = r[idx+1:]
+	}
+	if r == "" {
+		return "site"
+	}
+	return r
+}
+
+// cloneDBFromParent runs the parent → worktree DB clone documented in
+// D2: snapshot parent, restore into the worktree, search-replace the
+// hostname, auto-snapshot the result.
+func (sm *SiteManager) cloneDBFromParent(ctx context.Context, parent types.Site, child *types.Site) error {
+	if !parent.Started {
+		return errors.New("parent site is not running; cannot clone DB")
+	}
+	parentSnapPath, err := sm.snapshotLocked(ctx, &parent, "for_worktree")
+	if err != nil {
+		return fmt.Errorf("snapshot parent: %w", err)
+	}
+	if err := sm.RestoreSnapshot(ctx, child.ID, parentSnapPath, RestoreSnapshotOptions{
+		// Engine + version were just copied from the parent so the
+		// match is guaranteed; no need to bypass the safety check.
+		// Skip the auto-snapshot wrap (added in P4): we already
+		// know the child's DB is empty.
+		SkipAutoSnapshot: true,
+	}); err != nil {
+		return fmt.Errorf("restore parent snapshot into worktree: %w", err)
+	}
+	if _, err := sm.wpSearchReplace(ctx, child, "https://"+parent.Domain, "https://"+child.Domain); err != nil {
+		return fmt.Errorf("search-replace https: %w", err)
+	}
+	if _, err := sm.wpSearchReplace(ctx, child, "http://"+parent.Domain, "http://"+child.Domain); err != nil {
+		return fmt.Errorf("search-replace http: %w", err)
+	}
+	if _, err := sm.wpSearchReplace(ctx, child, parent.Domain, child.Domain); err != nil {
+		return fmt.Errorf("search-replace bare: %w", err)
+	}
+	if path, err := sm.snapshotLocked(ctx, child, "post_clone_db"); err != nil {
+		slog.Warn("clone-db: post-clone snapshot failed", "err", err.Error())
+	} else {
+		slog.Info("clone-db: post-clone snapshot saved", "path", path)
+	}
+	return nil
+}
+
+// previewWorktreePlan formats the actions CreateWorktreeSite would
+// take. Output is multi-line, prefixed-bullet so it can stream to
+// stdout without further formatting.
+func (sm *SiteManager) previewWorktreePlan(_ context.Context, parent types.Site, child *types.Site, opts CreateWorktreeOptions) (string, error) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Plan: create worktree site %q\n", child.Slug)
+	fmt.Fprintf(&b, "  parent:        %s (%s)\n", parent.Slug, parent.FilesDir)
+	fmt.Fprintf(&b, "  remote:        %s\n", opts.GitRemote)
+	fmt.Fprintf(&b, "  branch:        %s\n", opts.Branch)
+	fmt.Fprintf(&b, "  derived slug:  %s\n", child.Slug)
+	fmt.Fprintf(&b, "  worktree path: %s\n", child.WorktreePath)
+	fmt.Fprintf(&b, "  domain:        https://%s\n", child.Domain)
+	fmt.Fprintf(&b, "  steps:\n")
+	fmt.Fprintf(&b, "    1. ensure-checkout — git fetch/clone %s\n", opts.GitRemote)
+	fmt.Fprintf(&b, "    2. ensure-worktree — git worktree add %s tracking %s\n", child.WorktreePath, opts.Branch)
+	fmt.Fprintf(&b, "    3. insert site row in SQLite\n")
+	fmt.Fprintf(&b, "    4. start site (full container plan)\n")
+	if opts.CloneDB {
+		fmt.Fprintf(&b, "    5. clone parent DB → worktree (with auto-snapshot)\n")
+		fmt.Fprintf(&b, "    6. wp search-replace %s → %s\n", parent.Domain, child.Domain)
+	}
+	return b.String(), nil
+}
+
+// firstNonEmpty returns the first non-empty string, or "" if all are.
+func firstNonEmpty(xs ...string) string {
+	for _, s := range xs {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// ─── small helper for the inline git step plan ─────────────────────
+
+// sitestepFuncWrap is a private inlining of orch.FuncStep with
+// preview support. We don't reuse sitesteps.FuncStep because the
+// rollback bookkeeping below is tighter than a full Plan run, and we
+// want CreateWorktreeSite's failure path to be obvious from the
+// reader's perspective.
+type sitestepFuncWrap struct {
+	name    string
+	preview string
+	apply   func(context.Context) error
+	undo    func(context.Context) error
+	applied bool
+}
+
+func newGitFuncStep(name, preview string, apply, undo func(context.Context) error) *sitestepFuncWrap {
+	return &sitestepFuncWrap{name: name, preview: preview, apply: apply, undo: undo}
+}
+
+func (s *sitestepFuncWrap) do(ctx context.Context) error {
+	if err := s.apply(ctx); err != nil {
+		return fmt.Errorf("%s: %w", s.name, err)
+	}
+	s.applied = true
+	return nil
+}
+
+func rollbackGitSteps(_ context.Context, steps []*sitestepFuncWrap) {
+	// Cleanup runs even if the parent context cancelled — losing
+	// track of an orphan worktree is worse than respecting the
+	// cancellation. Give cleanup its own deadline.
+	rbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	// Reverse order so dependents undo before dependencies.
+	for i := len(steps) - 1; i >= 0; i-- {
+		s := steps[i]
+		if !s.applied || s.undo == nil {
+			continue
+		}
+		if err := s.undo(rbCtx); err != nil {
+			slog.Warn("worktree create: rollback failed",
+				"step", s.name, "err", err.Error())
+		}
+	}
+}

--- a/internal/sites/worktree_slug.go
+++ b/internal/sites/worktree_slug.go
@@ -1,0 +1,163 @@
+package sites
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Worktree slug derivation per AGENTS-SUPPORT.md D3.
+//
+// The naive concatenation `<parent-slug>-<branch-slug>.localhost`
+// breaks for branches like `feature/long-descriptive-name` (slash is
+// illegal in DNS labels per RFC 1035, and the combined length blows
+// past the 63-char label limit on real branches). The chosen scheme:
+//
+//     <parent-slug>-<safe-branch[:18]>-<hash6>
+//
+// where:
+//   - safe-branch lower-cases the branch, replaces every non-[a-z0-9]
+//     run with a single dash, trims leading/trailing dashes, then
+//     truncates at 18 chars.
+//   - hash6 is the first 6 lowercase hex chars of
+//     sha256(parent-slug || \x00 || branch || \x00 || worktree-path).
+//     Including the worktree path means two worktrees of the same
+//     branch checked out at different host paths still resolve to
+//     distinct slugs, which matters for an agent juggling parallel
+//     experiments.
+//
+// The output is always under the 63-char DNS-label limit and contains
+// only lowercase letters, digits, and single dashes.
+
+// worktreeSlugBranchMax is the upper bound on the branch fragment baked
+// into the derived slug. 18 chars is a balance: long enough that humans
+// can recognise their branch by name, short enough to fit even when
+// combined with a 30-char parent slug.
+const worktreeSlugBranchMax = 18
+
+// worktreeHashLen is the number of hex chars from the sha256 digest
+// included in the derived slug. 6 hex chars (24 bits) means 1-in-16M
+// collision per branch — adequate when the parent + branch already
+// disambiguate at the human level.
+const worktreeHashLen = 6
+
+// dnsLabelMax is the RFC 1035 limit on a single DNS label. We never
+// emit a slug longer than this; the parent fragment is truncated if
+// the combined length would otherwise exceed it.
+const dnsLabelMax = 63
+
+// WorktreeSlug returns the derived slug for a worktree-bound site.
+// Pure function — same inputs always produce the same output, even
+// across processes and Locorum versions.
+//
+// parentSlug must already be a valid Locorum slug (lowercase, hyphens
+// only); the function does not re-sanitise it. branch and worktreePath
+// are taken verbatim and may contain any printable runes.
+func WorktreeSlug(parentSlug, branch, worktreePath string) string {
+	hash := sha256.New()
+	hash.Write([]byte(parentSlug))
+	hash.Write([]byte{0})
+	hash.Write([]byte(branch))
+	hash.Write([]byte{0})
+	hash.Write([]byte(worktreePath))
+	hashHex := hex.EncodeToString(hash.Sum(nil))[:worktreeHashLen]
+
+	safeBranch := sanitiseBranchForSlug(branch)
+	if safeBranch == "" {
+		safeBranch = "branch"
+	}
+	if len(safeBranch) > worktreeSlugBranchMax {
+		safeBranch = safeBranch[:worktreeSlugBranchMax]
+		// Re-trim a trailing dash created by the truncation so we
+		// don't emit "-x--abc123".
+		safeBranch = strings.TrimRight(safeBranch, "-")
+		if safeBranch == "" {
+			safeBranch = "branch"
+		}
+	}
+
+	// Compose. Cap parent fragment if needed to fit 63 chars total.
+	const sepLen = 2 // two single dashes between the three fragments
+	maxParent := dnsLabelMax - len(safeBranch) - worktreeHashLen - sepLen
+	if maxParent < 1 {
+		// Pathological: a 60-char branch fragment leaves nothing for
+		// the parent. Fall back to a hash-only label so the output is
+		// at least valid.
+		return safeBranch + "-" + hashHex
+	}
+	pruned := parentSlug
+	if len(pruned) > maxParent {
+		pruned = strings.TrimRight(pruned[:maxParent], "-")
+		if pruned == "" {
+			pruned = "site"
+		}
+	}
+	return pruned + "-" + safeBranch + "-" + hashHex
+}
+
+// WorktreeDomain returns the .localhost domain for a worktree slug.
+// Wraps WorktreeSlug — kept separate so calls that need both don't
+// recompute the hash.
+func WorktreeDomain(parentSlug, branch, worktreePath string) string {
+	return WorktreeSlug(parentSlug, branch, worktreePath) + ".localhost"
+}
+
+// sanitiseBranchForSlug lowercases branch and replaces every run of
+// non-[a-z0-9] characters with a single dash. Leading/trailing dashes
+// are trimmed. Returns "" only when the input contained no usable
+// alphanumerics.
+//
+// The implementation is deliberately stricter than git's branch-name
+// rules (which allow `/`, `+`, `.`, etc.) because the output flows
+// straight into a DNS label. ASCII-only by design — non-ASCII runes
+// get stripped to dashes so a branch named "fix/é" still produces a
+// valid label.
+func sanitiseBranchForSlug(branch string) string {
+	var b strings.Builder
+	b.Grow(len(branch))
+	prevDash := true // suppress leading dash by starting "as if" we just emitted one
+	for _, r := range branch {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			prevDash = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(unicode.ToLower(r))
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
+// ValidateWorktreeOpts is a defensive check on the user-supplied
+// inputs to CreateWorktreeSite. Rejects empty values and obviously-
+// hostile patterns (NUL byte, .. traversal in worktreePath). Surfaces
+// a user-readable error so the CLI can print it directly.
+func ValidateWorktreeOpts(remote, branch, worktreePath string) error {
+	if strings.TrimSpace(remote) == "" {
+		return fmt.Errorf("git remote is required")
+	}
+	if strings.TrimSpace(branch) == "" {
+		return fmt.Errorf("git branch is required")
+	}
+	if strings.ContainsRune(remote, 0) || strings.ContainsRune(branch, 0) || strings.ContainsRune(worktreePath, 0) {
+		return fmt.Errorf("input contains NUL byte")
+	}
+	if strings.Contains(worktreePath, "..") {
+		// Worktree path is bind-mounted into the PHP/web container.
+		// `..` segments are rarely intentional; reject them to keep
+		// the surface narrow.
+		return fmt.Errorf("worktreePath must not contain ..")
+	}
+	return nil
+}

--- a/internal/sites/worktree_slug_test.go
+++ b/internal/sites/worktree_slug_test.go
@@ -1,0 +1,95 @@
+package sites
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWorktreeSlug_Deterministic(t *testing.T) {
+	a := WorktreeSlug("shop", "feature/x", "/home/me/work/shop/.worktrees/feature-x")
+	b := WorktreeSlug("shop", "feature/x", "/home/me/work/shop/.worktrees/feature-x")
+	if a != b {
+		t.Fatalf("WorktreeSlug not deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestWorktreeSlug_DifferentInputsCollideRarely(t *testing.T) {
+	cases := []struct {
+		parent, branch, path string
+	}{
+		{"shop", "feature/x", "/a"},
+		{"shop", "feature/y", "/a"},
+		{"shop", "feature/x", "/b"},
+		{"site", "feature/x", "/a"},
+	}
+	seen := map[string]struct{}{}
+	for _, c := range cases {
+		s := WorktreeSlug(c.parent, c.branch, c.path)
+		if _, dup := seen[s]; dup {
+			t.Fatalf("collision for %+v: %s", c, s)
+		}
+		seen[s] = struct{}{}
+	}
+}
+
+func TestWorktreeSlug_DNSLabelLimit(t *testing.T) {
+	long := strings.Repeat("verylongbranch", 5) // 70 chars
+	s := WorktreeSlug("very-long-parent-slug-name", long, "/somewhere")
+	if len(s) > 63 {
+		t.Fatalf("slug exceeds DNS label limit (63): len=%d slug=%q", len(s), s)
+	}
+}
+
+func TestWorktreeSlug_OnlyAllowedChars(t *testing.T) {
+	s := WorktreeSlug("shop", "feature/É+thing--with junk", "/x")
+	for _, r := range s {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-'
+		if !ok {
+			t.Fatalf("unexpected rune %q in slug %q", r, s)
+		}
+	}
+	// Branch fragment should still be recognisable.
+	if !strings.Contains(s, "feature") {
+		t.Fatalf("branch fragment lost: %q", s)
+	}
+}
+
+func TestWorktreeSlug_BranchEntirelyInvalidFallsBack(t *testing.T) {
+	s := WorktreeSlug("shop", "💩///", "/x")
+	if !strings.Contains(s, "branch") {
+		t.Fatalf("expected fallback branch fragment, got %q", s)
+	}
+}
+
+func TestWorktreeSlug_NoLeadingOrTrailingDashes(t *testing.T) {
+	s := WorktreeSlug("shop", "/feature/x/", "/x")
+	if strings.HasPrefix(s, "-") || strings.HasSuffix(s, "-") {
+		t.Fatalf("dashes at edges of %q", s)
+	}
+	// And no consecutive dashes.
+	if strings.Contains(s, "--") {
+		t.Fatalf("consecutive dashes in %q", s)
+	}
+}
+
+func TestValidateWorktreeOpts(t *testing.T) {
+	cases := []struct {
+		name             string
+		remote, br, path string
+		wantErr          bool
+	}{
+		{"happy", "git@x:y", "main", "/home/p/work", false},
+		{"empty remote", "", "main", "", true},
+		{"empty branch", "git@x:y", "", "", true},
+		{"nul byte", "git@x:y", "ma\x00in", "", true},
+		{"traversal", "git@x:y", "main", "../escape", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateWorktreeOpts(tc.remote, tc.br, tc.path)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v want=%v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/sites/wpcli.go
+++ b/internal/sites/wpcli.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -94,12 +95,27 @@ func (sm *SiteManager) wpInstallDefault(ctx context.Context, site *types.Site) e
 // `--skip-columns=guid` (the WP-recommended invariant for URL rewrites:
 // guid is a permanent identifier, not a URL, despite looking like one).
 // Returns the wp-cli output verbatim so the caller can surface row counts.
+//
+// Auto-snapshot wrap (P4): when site is running and the auto-snapshot
+// setting is on, takes a "pre_search_replace" snapshot first so a
+// botched URL rewrite is one `snapshot restore` away from undone.
+// Best-effort: snapshot failures log and continue, because refusing
+// to run search-replace because we couldn't snapshot would leave
+// users stuck. The wrap is suppressed when from == to (no-op) or the
+// site isn't running (DB unreachable).
 func (sm *SiteManager) wpSearchReplace(ctx context.Context, site *types.Site, from, to string) (string, error) {
 	if from == "" || to == "" {
 		return "", errors.New("wpSearchReplace: from and to are required")
 	}
 	if from == to {
 		return "", nil
+	}
+	if site != nil && site.Started && sm.shouldAutoSnapshot() {
+		if path, err := sm.snapshotLocked(ctx, site, "pre_search_replace"); err != nil {
+			slog.Warn("pre-search-replace auto-snapshot failed", "site", site.Slug, "err", err.Error())
+		} else {
+			slog.Info("pre-search-replace auto-snapshot saved", "path", path)
+		}
 	}
 	return sm.wpcli(ctx, site,
 		"search-replace", from, to,
@@ -111,9 +127,21 @@ func (sm *SiteManager) wpSearchReplace(ctx context.Context, site *types.Site, fr
 // wpDBImport runs `wp db import <inContainerPath>`. The caller is
 // responsible for placing the dump where wp-cli can read it (typically
 // inside the bind-mounted FilesDir).
+//
+// Auto-snapshot wrap (P4): the import wholesale replaces the current
+// database, so we capture a "pre_db_import" snapshot first whenever
+// the safety setting is on. Same fail-open semantics as
+// wpSearchReplace.
 func (sm *SiteManager) wpDBImport(ctx context.Context, site *types.Site, inContainerPath string) (string, error) {
 	if inContainerPath == "" {
 		return "", errors.New("wpDBImport: empty path")
+	}
+	if site != nil && site.Started && sm.shouldAutoSnapshot() {
+		if path, err := sm.snapshotLocked(ctx, site, "pre_db_import"); err != nil {
+			slog.Warn("pre-db-import auto-snapshot failed", "site", site.Slug, "err", err.Error())
+		} else {
+			slog.Info("pre-db-import auto-snapshot saved", "path", path)
+		}
 	}
 	return sm.wpcli(ctx, site, "db", "import", inContainerPath)
 }

--- a/internal/storage/migrations/20260507000001_add_worktree.down.sql
+++ b/internal/storage/migrations/20260507000001_add_worktree.down.sql
@@ -1,0 +1,13 @@
+-- SQLite's DROP COLUMN is unreliable across the supported version
+-- range; recreate the table without the worktree columns. Mirrors the
+-- pattern used by 20260506000001_add_spx.down.sql.
+DROP INDEX IF EXISTS idx_sites_parent;
+CREATE TABLE sites_backup AS
+  SELECT id, name, slug, domain, filesDir, publicDir, started,
+         phpVersion, mysqlVersion, redisVersion, dbPassword,
+         webServer, multisite, salts, dbEngine, dbVersion,
+         publishDBPort, spxEnabled, spxKey,
+         createdAt, updatedAt
+  FROM sites;
+DROP TABLE sites;
+ALTER TABLE sites_backup RENAME TO sites;

--- a/internal/storage/migrations/20260507000001_add_worktree.up.sql
+++ b/internal/storage/migrations/20260507000001_add_worktree.up.sql
@@ -1,0 +1,26 @@
+-- Worktree-bound sites (P1, AGENTS-SUPPORT.md). A site row gains four
+-- columns identifying its git provenance and parent relationship. All
+-- four are NOT NULL with empty-string defaults so legacy rows keep
+-- working without a backfill: an empty gitRemote means "this is a
+-- conventional WordPress install, not bound to a git checkout."
+--
+--   gitRemote    — canonical remote URL, e.g. "git@github.com:foo/bar.git"
+--   gitBranch    — branch name the worktree tracks (e.g. "feature/x")
+--   worktreePath — host path of the git worktree (when bound)
+--   parentSiteID — non-empty for worktree sites; FK to sites(id)
+--
+-- parentSiteID is unconstrained at the SQL level: enforcing it as a
+-- foreign key would force the parent site to be deleted last, blocking
+-- the existing "delete a site cascade-deletes its hooks" UX. Instead,
+-- DeleteSite for a parent site purges its worktree-children first;
+-- orphaned rows from a hand-edited DB are tolerated and treated as
+-- regular sites.
+ALTER TABLE sites ADD COLUMN gitRemote    TEXT NOT NULL DEFAULT '';
+ALTER TABLE sites ADD COLUMN gitBranch    TEXT NOT NULL DEFAULT '';
+ALTER TABLE sites ADD COLUMN worktreePath TEXT NOT NULL DEFAULT '';
+ALTER TABLE sites ADD COLUMN parentSiteID TEXT NOT NULL DEFAULT '';
+
+-- Index for the "find every worktree-child of this parent" query that
+-- DeleteSite uses to cascade. parentSiteID is the empty string for
+-- regular sites, so the index covers only the rows that need it.
+CREATE INDEX IF NOT EXISTS idx_sites_parent ON sites(parentSiteID) WHERE parentSiteID != '';

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -61,7 +61,7 @@ func now() string {
 // Keep ordering aligned with the Scan / Exec arg order below — adding a
 // column means editing four call sites; the constant centralises the
 // SELECT/INSERT lists so two of those four stay in lockstep.
-const siteColumns = "id, name, slug, domain, filesDir, publicDir, started, phpVersion, mysqlVersion, redisVersion, dbPassword, webServer, multisite, salts, dbEngine, dbVersion, publishDBPort, spxEnabled, spxKey, createdAt, updatedAt"
+const siteColumns = "id, name, slug, domain, filesDir, publicDir, started, phpVersion, mysqlVersion, redisVersion, dbPassword, webServer, multisite, salts, dbEngine, dbVersion, publishDBPort, spxEnabled, spxKey, gitRemote, gitBranch, worktreePath, parentSiteID, createdAt, updatedAt"
 
 // scanSite hydrates a Site from a row scanner. Centralised so GetSite and
 // GetSites stay in lockstep with siteColumns; a missed field here means
@@ -75,6 +75,7 @@ func scanSite(scan func(...any) error) (*types.Site, error) {
 		&site.WebServer, &site.Multisite, &site.Salts,
 		&site.DBEngine, &site.DBVersion, &site.PublishDBPort,
 		&site.SPXEnabled, &site.SPXKey,
+		&site.GitRemote, &site.GitBranch, &site.WorktreePath, &site.ParentSiteID,
 		&site.CreatedAt, &site.UpdatedAt,
 	); err != nil {
 		return nil, err
@@ -143,12 +144,13 @@ func (s *Storage) AddSite(site *types.Site) error {
 	}
 
 	_, err := s.db.Exec(
-		"INSERT INTO sites ("+siteColumns+") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		"INSERT INTO sites ("+siteColumns+") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 		site.ID, site.Name, site.Slug, site.Domain, site.FilesDir, site.PublicDir, site.Started,
 		site.PHPVersion, site.MySQLVersion, site.RedisVersion, site.DBPassword,
 		site.WebServer, site.Multisite, site.Salts,
 		site.DBEngine, site.DBVersion, boolToInt(site.PublishDBPort),
 		boolToInt(site.SPXEnabled), site.SPXKey,
+		site.GitRemote, site.GitBranch, site.WorktreePath, site.ParentSiteID,
 		site.CreatedAt, site.UpdatedAt,
 	)
 	if err != nil {
@@ -167,12 +169,13 @@ func (s *Storage) UpdateSite(site *types.Site) (*types.Site, error) {
 	}
 
 	_, err := s.db.Exec(
-		"UPDATE sites SET name = ?, slug = ?, domain = ?, filesDir = ?, publicDir = ?, started = ?, phpVersion = ?, mysqlVersion = ?, redisVersion = ?, dbPassword = ?, webServer = ?, multisite = ?, salts = ?, dbEngine = ?, dbVersion = ?, publishDBPort = ?, spxEnabled = ?, spxKey = ?, updatedAt = ? WHERE id = ?",
+		"UPDATE sites SET name = ?, slug = ?, domain = ?, filesDir = ?, publicDir = ?, started = ?, phpVersion = ?, mysqlVersion = ?, redisVersion = ?, dbPassword = ?, webServer = ?, multisite = ?, salts = ?, dbEngine = ?, dbVersion = ?, publishDBPort = ?, spxEnabled = ?, spxKey = ?, gitRemote = ?, gitBranch = ?, worktreePath = ?, parentSiteID = ?, updatedAt = ? WHERE id = ?",
 		site.Name, site.Slug, site.Domain, site.FilesDir, site.PublicDir, site.Started,
 		site.PHPVersion, site.MySQLVersion, site.RedisVersion, site.DBPassword,
 		site.WebServer, site.Multisite, site.Salts,
 		site.DBEngine, site.DBVersion, boolToInt(site.PublishDBPort),
 		boolToInt(site.SPXEnabled), site.SPXKey,
+		site.GitRemote, site.GitBranch, site.WorktreePath, site.ParentSiteID,
 		site.UpdatedAt, site.ID,
 	)
 	if err != nil {
@@ -180,6 +183,29 @@ func (s *Storage) UpdateSite(site *types.Site) (*types.Site, error) {
 	}
 
 	return site, nil
+}
+
+// SitesByParent returns every worktree-bound site whose ParentSiteID
+// matches parentID. Used by DeleteSite to cascade-clean its workers
+// before removing the parent row.
+func (s *Storage) SitesByParent(parentID string) ([]types.Site, error) {
+	if parentID == "" {
+		return nil, nil
+	}
+	rows, err := s.db.Query("SELECT "+siteColumns+" FROM sites WHERE parentSiteID = ?", parentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []types.Site
+	for rows.Next() {
+		site, err := scanSite(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *site)
+	}
+	return out, rows.Err()
 }
 
 // DeleteSite removes the Site with the given ID from the database.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -54,6 +54,29 @@ type Site struct {
 	// produce a byte-identical file (idempotent writes).
 	Salts string `json:"-"`
 
+	// GitRemote is the canonical remote URL of the upstream repository
+	// for worktree-bound sites (P1, AGENTS-SUPPORT.md). Empty for
+	// conventional sites; non-empty implies worktreePath / gitBranch
+	// are also set and FilesDir points at a git worktree.
+	GitRemote string `json:"gitRemote,omitempty"`
+
+	// GitBranch is the branch the worktree tracks. Same shape rules
+	// as GitRemote: empty for conventional sites, set for worktrees.
+	GitBranch string `json:"gitBranch,omitempty"`
+
+	// WorktreePath is the host path of the git worktree directory.
+	// For worktree-bound sites this is also FilesDir; we keep both so
+	// a future flavour B (plugin/theme mode) can have FilesDir point
+	// at a scratch WP install while WorktreePath identifies the
+	// underlying checkout to remove via `git worktree remove`.
+	WorktreePath string `json:"worktreePath,omitempty"`
+
+	// ParentSiteID identifies the parent (conventional) site that
+	// owns the upstream checkout. Worktree sites point at this row so
+	// parent-delete can cascade-clean its workers; conventional sites
+	// leave it empty.
+	ParentSiteID string `json:"parentSiteID,omitempty"`
+
 	CreatedAt string `json:"createdAt"`
 	UpdatedAt string `json:"updatedAt"`
 }

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 
 	application "github.com/PeterBooker/locorum/internal/app"
 	settings "github.com/PeterBooker/locorum/internal/config"
+	"github.com/PeterBooker/locorum/internal/daemon"
 	"github.com/PeterBooker/locorum/internal/docker"
 	"github.com/PeterBooker/locorum/internal/health"
 	"github.com/PeterBooker/locorum/internal/hooks"
@@ -34,11 +35,25 @@ import (
 var config embed.FS
 
 func main() {
+	// CLI clients are dispatched before any Gio / Docker setup. The CLI
+	// process is a thin IPC wrapper — it must not duplicate
+	// app.Initialize, must not bring up the Gio window, and must exit
+	// quickly enough for shell scripts that loop over `locorum site
+	// list`. See internal/cli/.
+	if code, handled := dispatchCLI(); handled {
+		os.Exit(code)
+	}
+
 	// Hard-fail before Gio loads if we're an amd64 binary translated by
 	// Rosetta on Apple Silicon. See preflight_darwin.go.
 	runPreflight()
 
-	slog.Info("starting Locorum", "version", version.Version, "commit", version.Commit, "date", version.Date)
+	// daemonMode is set when the binary was started as `locorum daemon`
+	// or auto-spawned by a CLI client. The init flow is identical to
+	// GUI mode minus the window event loop.
+	daemonMode := isDaemonMode()
+
+	slog.Info("starting Locorum", "version", version.Version, "commit", version.Commit, "date", version.Date, "daemon", daemonMode)
 
 	// Identify the host once. platform.Get() is then safe to call from
 	// any goroutine for the rest of the process lifetime.
@@ -47,8 +62,9 @@ func main() {
 	// On WSL2, force the X11 backend. WSLg's Wayland compositor does not
 	// fully support window-management actions (minimize/maximize). The
 	// canonical signal lives in platform.Get().WSL.Active — we still
-	// branch on it before Gio touches the display.
-	if plat.WSL.Active {
+	// branch on it before Gio touches the display. Skip in daemon mode:
+	// no Gio, no need to disturb display env.
+	if plat.WSL.Active && !daemonMode {
 		os.Unsetenv("WAYLAND_DISPLAY")
 		os.Setenv("GSETTINGS_BACKEND", "memory")
 		if _, ok := os.LookupEnv("DBUS_SESSION_BUS_ADDRESS"); !ok {
@@ -115,6 +131,12 @@ func main() {
 
 	sm := sites.NewSiteManager(st, a.GetClient(), d, rtr, hookRunner, config, homeDir, cfg)
 
+	if daemonMode {
+		runDaemonMode(homeDir, sm, a, d)
+		st.Close()
+		return
+	}
+
 	userInterface := ui.New(sm)
 
 	// Hydrate the toast-suppression set from the persisted JSON so we
@@ -172,6 +194,20 @@ func main() {
 		})
 	}
 
+	// daemonHandle holds the lock + IPC server we acquire after
+	// a.Initialize succeeds. They survive for the lifetime of the GUI
+	// process; the eventLoop teardown releases them.
+	var daemonLock *daemon.Lock
+	var daemonServer *daemon.Server
+	defer func() {
+		if daemonServer != nil {
+			daemonServer.Shutdown(2 * time.Second)
+		}
+		if daemonLock != nil {
+			_ = daemonLock.Release()
+		}
+	}()
+
 	initFunc := func() {
 		d.SetClient(a.GetClient())
 
@@ -180,6 +216,20 @@ func main() {
 			slog.Error("Error initializing: " + err.Error())
 			userInterface.State.SetInitError(err.Error())
 			return
+		}
+
+		// Bind the IPC server now that Docker is up. Failure here
+		// (e.g. another GUI is already running) does NOT block the
+		// rest of startup — the user still gets a usable window, just
+		// without CLI/MCP wiring. The daemon owner can be inspected
+		// via the lock-error log.
+		if daemonLock == nil {
+			lock, srv, err := startDaemonServices(context.Background(), homeDir, sm)
+			if err != nil {
+				reportLockError(err)
+			} else {
+				daemonLock, daemonServer = lock, srv
+			}
 		}
 
 		if err := sm.ReconcileState(); err != nil {
@@ -249,6 +299,18 @@ func main() {
 
 		if err := eventLoop(w, userInterface); err != nil {
 			slog.Error("Window error: " + err.Error())
+		}
+
+		// Tear down daemon services BEFORE app.Shutdown so a CLI
+		// client mid-call gets a clean "connection closed" rather
+		// than racing the Docker label-wipe.
+		if daemonServer != nil {
+			daemonServer.Shutdown(2 * time.Second)
+			daemonServer = nil
+		}
+		if daemonLock != nil {
+			_ = daemonLock.Release()
+			daemonLock = nil
 		}
 
 		_ = a.Shutdown(context.Background())


### PR DESCRIPTION
# Add agent-friendly control surface (CLI, IPC daemon, MCP, worktree sites)

Implements the AGENTS-SUPPORT.md roadmap up through P4. The same `locorum`
binary now serves as a GUI, a headless daemon, a CLI client, and a Model
Context Protocol server — without ever running two instances of
`app.Initialize` against the same Docker socket.

## What lands

### Daemon-and-clients split (M1)

- `~/.locorum/state/owner.lock` (flock on POSIX, `LockFileEx` on Windows)
  with stale-PID takeover.
- JSON-RPC 2.0 IPC over a Unix domain socket (chmod 0600) / Windows named
  pipe (per-user SID, owner-only ACL). Newline-framed, 8 MiB cap, panic
  recovery.
- `client.hello` handshake stamps `peerKind` + `profile` + `mcpScope` on
  the connection. Profile gating (`full` / `readonly`) and site-scope
  enforcement run on the **daemon side**, not the client.
- CLI auto-spawns a detached `locorum daemon` if none is running.

### CLI (M1 + P1)

```
locorum site list / describe / start / stop / wp / logs / create / delete
locorum snapshot list / create / restore
locorum hook list / run
locorum mcp serve --stdio | --http 127.0.0.1:2484
locorum mcp rotate-token
locorum daemon
locorum version
```

`--json` available everywhere; documented exit codes (0 OK, 3 no daemon,
4 not found, 5 forbidden, 6 conflict).

### MCP server (M2 + P2)

- **stdio** for Claude Code / Cursor / Continue.
- **HTTP** loopback-only bind, 256-bit bearer token at
  `~/.locorum/state/mcp_token` (0600), `WWW-Authenticate` 401,
  constant-time compare, `--rotate-token` to invalidate.
- Curated 13-tool catalogue (`list_sites`, `describe_site`, `read_log`,
  `wp_cli`, snapshots, hooks, `worktree_create` / `worktree_destroy`).
- Readonly profile filters mutating tools out of `tools/list` so an agent
  can't even discover them.

### Worktree-bound sites (P1, Flavour A)

- Schema migration adds `gitRemote`, `gitBranch`, `worktreePath`,
  `parentSiteID` columns + cascade index.
- `WorktreeSlug(parent, branch, path)` derives `<parent>-<safe[:18]>-<sha6>`
  — guaranteed under the 63-char DNS label limit, deterministic, slash-safe
  (D3 in the plan).
- `internal/git` package shells out to the user's `git` so SSH keys, signing
  config, and credential helpers all apply.
- `SiteManager.CreateWorktreeSite` runs ensure-checkout → ensure-worktree →
  insert row → `StartSite` as an orchestrated plan with rollback. Auto-creates
  a stub parent site when one doesn't exist; resolves to existing parents by
  slug otherwise.
- Optional `--clone-db` snapshots the parent DB → restores into the worktree
  → triple `wp search-replace` (`https://`, `http://`, bare host) →
  auto-snapshot the result.
- `DeleteSite` for a parent cascade-deletes its workers; for a worktree,
  refuses dirty trees unless `--force` is set, then runs `git worktree remove`.

### Dry-run + auto-snapshot wraps (P4)

- `orch.Describer` optional interface; `orch.Dry(ctx, plan)` previews every
  step without applying. All existing + new steps implement it.
- `--dry-run` on `site create` and `site delete`. Stub parent rows created
  by dry-run get rolled back on the way out — dry-run is a true no-op.
- Auto-snapshot wraps `RestoreSnapshot`, `wpDBImport`, and `wpSearchReplace`.
  Gated by `snapshots.auto_before_destructive` (default ON). Failures log
  and continue rather than stranding users mid-operation.

## Load-bearing invariants preserved

- UI still never calls Docker / SQLite directly — every CLI/MCP call goes
  through `SiteManager` exactly like the GUI does.
- Per-site mutex still serialises lifecycle calls. Worktree creates against
  different parents stay parallel.
- All Docker resources still carry `io.locorum.platform=locorum`. The
  daemon-and-clients split exists specifically to keep the existing
  label-wipe contract from racing with itself.