### PR TITLE
Implement UX Improvements

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,17 +72,45 @@ func (a *App) Initialize(ctx context.Context) error {
 	// creating new ones. ReconcileNetworks is the explicit "remove orphans"
 	// pass that prevents same-name network create from failing after a
 	// daemon crash.
-	if err := a.cleanupExistingResources(ctx); err != nil {
+	if err := a.WipeLabelled(ctx); err != nil {
 		return err
 	}
 	if err := a.d.ReconcileNetworks(ctx); err != nil {
 		slog.Warn("reconcile networks: " + err.Error())
 	}
 
+	return a.BringUpGlobals(ctx)
+}
+
+// WipeLabelled removes every Locorum-owned container and network. Used
+// at startup (to clear state from a crashed previous session) and from
+// SiteManager.ResetInfrastructure (to give the user a one-click recovery
+// path). Volumes are deliberately preserved — site DB data persists
+// across both flows.
+//
+// Idempotent: safe to call when nothing is running.
+func (a *App) WipeLabelled(ctx context.Context) error {
+	labels := map[string]string{docker.LabelPlatform: docker.PlatformValue}
+	if err := a.d.RemoveContainersByLabel(ctx, labels); err != nil {
+		return fmt.Errorf("remove labelled containers: %w", err)
+	}
+	if err := a.d.RemoveNetworksByLabel(ctx, labels); err != nil {
+		return fmt.Errorf("remove labelled networks: %w", err)
+	}
+	return nil
+}
+
+// BringUpGlobals creates the global network, brings up mail + adminer,
+// and (re)starts the router with the canonical service routes pre-
+// registered. Used at the end of Initialize and from
+// SiteManager.ResetInfrastructure.
+//
+// Each step propagates the underlying error verbatim. The router itself
+// returns sentinels (router.ErrPortInUse) the UI can branch on.
+func (a *App) BringUpGlobals(ctx context.Context) error {
 	if _, err := a.d.EnsureNetwork(ctx, docker.GlobalNetworkSpec()); err != nil {
 		return fmt.Errorf("create global network: %w", err)
 	}
-
 	if err := a.ensureGlobalContainer(ctx, docker.MailSpec()); err != nil {
 		return fmt.Errorf("global mail: %w", err)
 	}
@@ -125,30 +153,29 @@ func (a *App) ensureGlobalContainer(ctx context.Context, spec docker.ContainerSp
 	return nil
 }
 
-// cleanupExistingResources wipes Locorum-owned containers and networks.
-// Resources are matched by the io.locorum.platform label.
-func (a *App) cleanupExistingResources(ctx context.Context) error {
-	labels := map[string]string{docker.LabelPlatform: docker.PlatformValue}
-	if err := a.d.RemoveContainersByLabel(ctx, labels); err != nil {
-		return err
-	}
-	if err := a.d.RemoveNetworksByLabel(ctx, labels); err != nil {
-		return err
-	}
-	return nil
-}
-
 func (a *App) Shutdown(ctx context.Context) error {
 	_ = utils.DeleteDirFiles(path.Join(a.homeDir, ".locorum", "config", "nginx", "sites"))
 	_ = utils.DeleteDirFiles(path.Join(a.homeDir, ".locorum", "config", "apache", "sites"))
 	_ = utils.DeleteDirFiles(path.Join(a.homeDir, ".locorum", "router", "dynamic"))
+	return a.WipeLabelled(ctx)
+}
 
-	labels := map[string]string{docker.LabelPlatform: docker.PlatformValue}
-	if err := a.d.RemoveContainersByLabel(ctx, labels); err != nil {
-		return err
+// ResetInfrastructure wipes every Locorum-owned container and network,
+// then re-runs the global startup sequence (network + mail + adminer +
+// router). Volumes are preserved — site DB data is untouched. Per-site
+// containers are removed and the caller is expected to reconcile the
+// "started" state in storage.
+//
+// User-facing flow: Settings → Diagnostics → "Reset Locorum
+// Infrastructure" with a confirmation modal. Idempotent and safe to
+// retry; failures bubble up verbatim so the UI banner shows what went
+// wrong.
+func (a *App) ResetInfrastructure(ctx context.Context) error {
+	if err := a.WipeLabelled(ctx); err != nil {
+		return fmt.Errorf("reset: wipe: %w", err)
 	}
-	if err := a.d.RemoveNetworksByLabel(ctx, labels); err != nil {
-		return err
+	if err := a.BringUpGlobals(ctx); err != nil {
+		return fmt.Errorf("reset: bring-up: %w", err)
 	}
 	return nil
 }

--- a/internal/applog/applog.go
+++ b/internal/applog/applog.go
@@ -1,0 +1,215 @@
+// Package applog wires the process-wide slog handler that fan-outs to
+// stderr and a rolling text log under ~/.locorum/logs/locorum.log.
+//
+// Init is idempotent: subsequent calls swap the active sink under a mutex
+// and close the previous file. The shared LevelVar lets the Settings
+// "Debug Mode" toggle flip log levels at runtime without rebuilding the
+// handler (a non-atomic swap would race with in-flight Log calls).
+package applog
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/PeterBooker/locorum/internal/utils"
+)
+
+// LogFileName is the canonical filename inside the configured log dir.
+// Tests and external callers should refer to this constant rather than
+// duplicating the literal.
+const LogFileName = "locorum.log"
+
+const (
+	// MaxBytes triggers rotation. 10 MiB is a generous bound for a desktop
+	// app — a typical session writes well under 1 MiB of structured logs.
+	MaxBytes = 10 * 1024 * 1024
+	// Keep is the number of historical files (locorum.log.1 .. .Keep)
+	// retained after rotation.
+	Keep = 3
+	// MaxLineBytes caps a single log entry. Multi-line errors with deep
+	// stack traces past this cap are truncated to keep the rotate cadence
+	// predictable.
+	MaxLineBytes = 8 * 1024
+)
+
+// Init configures the process-wide slog handler. It opens (and creates if
+// needed) <dir>/locorum.log, fan-outs every record to stderr and the file,
+// and installs the result as slog.Default. The returned io.Closer flushes
+// and closes the file when the process exits — main.go should defer it.
+//
+// On any failure to open the file, the handler is installed with stderr
+// only and the error is returned alongside a nop-Closer so the caller can
+// surface a warning without dropping the rest of startup.
+//
+// The shared LevelVar starts at slog.LevelInfo; SetDebug toggles between
+// Info and Debug at runtime. Reads of slog.Default after Init see the
+// new sink immediately because Default uses an atomic.Pointer internally.
+func Init(dir string) (io.Closer, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if err := utils.EnsureDir(dir); err != nil {
+		installStderrOnly()
+		return nopCloser{}, fmt.Errorf("applog: ensure dir: %w", err)
+	}
+
+	logPath := filepath.Join(dir, LogFileName)
+	if err := utils.RotateIfLarge(logPath, MaxBytes, Keep); err != nil {
+		// Non-fatal: continue with whatever shape the file is in. A
+		// pathological rotate failure (e.g. ENOSPC) will surface again
+		// at write time and be logged as an error to stderr.
+		fmt.Fprintf(os.Stderr, "applog: rotate failed: %v\n", err)
+	}
+
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		installStderrOnly()
+		return nopCloser{}, fmt.Errorf("applog: open %q: %w", logPath, err)
+	}
+
+	// Truncated-line writer caps a single entry to MaxLineBytes — protects
+	// the file against an upstream bug that floods megabyte-long lines.
+	// stderr is unwrapped: the user already sees those at the terminal.
+	fw := &truncatedWriter{w: f, max: MaxLineBytes}
+	rw := newRotatingWriter(f, fw, logPath, MaxBytes, Keep)
+
+	multi := io.MultiWriter(os.Stderr, rw)
+	handler := slog.NewTextHandler(multi, &slog.HandlerOptions{Level: levelVar})
+	slog.SetDefault(slog.New(handler))
+
+	// Close the previous file before publishing the new one so we don't
+	// hold two FDs open for the typical "called once at startup" case.
+	if currentFile != nil && currentFile != f {
+		_ = currentFile.Close()
+	}
+	currentFile = f
+	currentRotater = rw
+	return closerFunc(closeCurrent), nil
+}
+
+// SetDebug toggles between Info (false) and Debug (true) at runtime. The
+// underlying handler is never rebuilt — slog.LevelVar is the documented
+// concurrency-safe knob for this.
+func SetDebug(on bool) {
+	if on {
+		levelVar.Set(slog.LevelDebug)
+	} else {
+		levelVar.Set(slog.LevelInfo)
+	}
+}
+
+// IsDebug reports whether the current level is Debug. Cheap; safe from
+// any goroutine.
+func IsDebug() bool {
+	return levelVar.Level() == slog.LevelDebug
+}
+
+// LogPath returns the absolute path of the active log file. Returns ""
+// before Init or if Init failed to open the file. Used by the in-app
+// "Open Log Folder" / "Copy Last 200 Lines" affordances.
+func LogPath() string {
+	mu.Lock()
+	defer mu.Unlock()
+	if currentFile == nil {
+		return ""
+	}
+	return currentFile.Name()
+}
+
+// LogDir returns the directory containing the active log file. Returns ""
+// before Init.
+func LogDir() string {
+	p := LogPath()
+	if p == "" {
+		return ""
+	}
+	return filepath.Dir(p)
+}
+
+// TailLines reads the trailing n lines of the active log file. Returns
+// nil and the underlying error if the file is unavailable. n <= 0 returns
+// an empty slice.
+func TailLines(n int) ([]string, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+	path := LogPath()
+	if path == "" {
+		return nil, errors.New("applog: not initialised")
+	}
+	return tailLines(path, n)
+}
+
+// ────────────────────────────────────────────────────────────────────────
+
+var (
+	mu             sync.Mutex
+	currentFile    *os.File
+	currentRotater *rotatingWriter
+	levelVar       = func() *slog.LevelVar {
+		v := new(slog.LevelVar)
+		v.Set(slog.LevelInfo)
+		return v
+	}()
+)
+
+// installStderrOnly is the fallback path when the log file cannot be opened.
+// Caller must hold mu.
+func installStderrOnly() {
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: levelVar})
+	slog.SetDefault(slog.New(handler))
+	if currentFile != nil {
+		_ = currentFile.Close()
+		currentFile = nil
+	}
+	currentRotater = nil
+}
+
+// closeCurrent flushes and closes the active log file. Safe to call when
+// no file is open.
+func closeCurrent() error {
+	mu.Lock()
+	defer mu.Unlock()
+	if currentFile == nil {
+		return nil
+	}
+	err := currentFile.Close()
+	currentFile = nil
+	currentRotater = nil
+	return err
+}
+
+type closerFunc func() error
+
+func (c closerFunc) Close() error { return c() }
+
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }
+
+// truncatedWriter caps a single Write call to max bytes. Longer writes
+// are silently truncated with a "…[truncated]\n" suffix. Multiple short
+// writes are passed through unchanged.
+type truncatedWriter struct {
+	w   io.Writer
+	max int
+}
+
+func (t *truncatedWriter) Write(p []byte) (int, error) {
+	if len(p) <= t.max {
+		return t.w.Write(p)
+	}
+	suffix := []byte("…[truncated]\n")
+	out := make([]byte, 0, t.max+len(suffix))
+	out = append(out, p[:t.max]...)
+	out = append(out, suffix...)
+	if _, err := t.w.Write(out); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/internal/applog/applog_test.go
+++ b/internal/applog/applog_test.go
@@ -1,0 +1,161 @@
+package applog
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitWritesToFile(t *testing.T) {
+	dir := t.TempDir()
+	closer, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+
+	slog.Info("hello-test", "x", 42)
+	// flush by closing+reopening for the read.
+	_ = closer.Close()
+
+	body, err := os.ReadFile(filepath.Join(dir, LogFileName))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(body), "hello-test") {
+		t.Fatalf("log missing message; got %q", string(body))
+	}
+}
+
+func TestSetDebugFlipsLevel(t *testing.T) {
+	if IsDebug() {
+		t.Fatalf("IsDebug initially true; want false")
+	}
+	SetDebug(true)
+	t.Cleanup(func() { SetDebug(false) })
+	if !IsDebug() {
+		t.Fatalf("after SetDebug(true), IsDebug = false")
+	}
+	if levelVar.Level() != slog.LevelDebug {
+		t.Fatalf("levelVar = %v, want Debug", levelVar.Level())
+	}
+	SetDebug(false)
+	if levelVar.Level() != slog.LevelInfo {
+		t.Fatalf("after SetDebug(false), levelVar = %v, want Info", levelVar.Level())
+	}
+}
+
+func TestTailLinesReturnsLastN(t *testing.T) {
+	dir := t.TempDir()
+	closer, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+
+	// Write 50 lines via slog.
+	for i := 0; i < 50; i++ {
+		slog.Info("line", "i", i)
+	}
+
+	got, err := TailLines(10)
+	if err != nil {
+		t.Fatalf("TailLines: %v", err)
+	}
+	if len(got) != 10 {
+		t.Fatalf("got %d lines, want 10", len(got))
+	}
+	// The last line should mention i=49.
+	if !strings.Contains(got[len(got)-1], "i=49") {
+		t.Fatalf("last line = %q, want it to contain i=49", got[len(got)-1])
+	}
+}
+
+func TestTailLinesShorterThanRequest(t *testing.T) {
+	dir := t.TempDir()
+	closer, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+
+	slog.Info("only-one")
+
+	got, err := TailLines(50)
+	if err != nil {
+		t.Fatalf("TailLines: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d lines, want 1", len(got))
+	}
+}
+
+func TestRotationAtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, LogFileName)
+
+	// Pre-seed a file at the rotation threshold so the first Write inside
+	// Init triggers a rotate.
+	big := make([]byte, MaxBytes+1)
+	for i := range big {
+		big[i] = 'x'
+	}
+	if err := os.WriteFile(logPath, big, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	closer, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = closer.Close() })
+
+	if _, err := os.Stat(logPath + ".1"); err != nil {
+		t.Fatalf("rotation .1 missing: %v", err)
+	}
+	// New current file should be small (just the "Init opened" record from
+	// any subsequent Info call below).
+	slog.Info("post-rotate")
+	_ = closer.Close()
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(body), "post-rotate") {
+		t.Fatalf("post-rotate write missing; got %q", string(body))
+	}
+	if len(body) > 1024 {
+		t.Fatalf("post-rotate file unexpectedly large: %d bytes", len(body))
+	}
+}
+
+func TestTruncatedWriterCapsLongLines(t *testing.T) {
+	var buf strings.Builder
+	tw := &truncatedWriter{w: &buf, max: 16}
+	long := strings.Repeat("y", 1024)
+	n, err := tw.Write([]byte(long))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != 1024 {
+		t.Fatalf("Write returned %d, want 1024", n)
+	}
+	if !strings.HasSuffix(buf.String(), "[truncated]\n") {
+		t.Fatalf("output missing truncated marker; got %q", buf.String())
+	}
+	if len(buf.String()) > 16+len("…[truncated]\n") {
+		t.Fatalf("output longer than expected: %d bytes", len(buf.String()))
+	}
+}
+
+func TestFormatTail(t *testing.T) {
+	if got := FormatTail(nil); got != "" {
+		t.Fatalf("FormatTail(nil) = %q, want empty", got)
+	}
+	got := FormatTail([]string{"a", "b"})
+	if got != "a\nb\n" {
+		t.Fatalf("FormatTail = %q, want %q", got, "a\nb\n")
+	}
+}

--- a/internal/applog/rotate.go
+++ b/internal/applog/rotate.go
@@ -1,0 +1,96 @@
+package applog
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/PeterBooker/locorum/internal/utils"
+)
+
+// rotatingWriter wraps the truncated file writer with size-based rotation.
+// It tracks bytes written since the last rotation and triggers a rotate
+// when the threshold is crossed.
+//
+// Concurrent Write calls are serialised by mu. The size counter is atomic
+// so the cheap "do we need to rotate?" check happens outside the lock for
+// the steady-state case.
+type rotatingWriter struct {
+	mu       sync.Mutex
+	f        *os.File
+	inner    io.Writer // truncatedWriter wrapping f
+	logPath  string
+	maxBytes int64
+	keep     int
+	written  atomic.Int64
+}
+
+func newRotatingWriter(f *os.File, inner io.Writer, logPath string, maxBytes int64, keep int) *rotatingWriter {
+	rw := &rotatingWriter{
+		f:        f,
+		inner:    inner,
+		logPath:  logPath,
+		maxBytes: maxBytes,
+		keep:     keep,
+	}
+	if info, err := f.Stat(); err == nil {
+		rw.written.Store(info.Size())
+	}
+	return rw
+}
+
+func (r *rotatingWriter) Write(p []byte) (int, error) {
+	if r.written.Load()+int64(len(p)) > r.maxBytes {
+		if err := r.rotate(); err != nil {
+			// Non-fatal: keep writing to the existing file. A failed
+			// rotate just means the file grows past the soft cap.
+			fmt.Fprintf(os.Stderr, "applog: rotate failed: %v\n", err)
+		}
+	}
+	r.mu.Lock()
+	n, err := r.inner.Write(p)
+	r.mu.Unlock()
+	if n > 0 {
+		r.written.Add(int64(n))
+	}
+	return n, err
+}
+
+func (r *rotatingWriter) rotate() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.f == nil {
+		return errors.New("applog: rotate on closed writer")
+	}
+	if err := r.f.Close(); err != nil {
+		return fmt.Errorf("close current: %w", err)
+	}
+	if err := utils.RotateIfLarge(r.logPath, 1, r.keep); err != nil {
+		// Reopen so subsequent writes don't disappear; surface the error.
+		f, openErr := os.OpenFile(r.logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if openErr != nil {
+			return errors.Join(err, openErr)
+		}
+		r.f = f
+		r.inner = &truncatedWriter{w: f, max: MaxLineBytes}
+		return err
+	}
+	f, err := os.OpenFile(r.logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("reopen after rotate: %w", err)
+	}
+	r.f = f
+	r.inner = &truncatedWriter{w: f, max: MaxLineBytes}
+	r.written.Store(0)
+
+	// Update the package-level handle so closeCurrent() targets the
+	// active fd.
+	mu.Lock()
+	currentFile = f
+	mu.Unlock()
+	return nil
+}

--- a/internal/applog/tail.go
+++ b/internal/applog/tail.go
@@ -1,0 +1,85 @@
+package applog
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"strings"
+)
+
+// tailLines reads the trailing n lines from path. The implementation is
+// chunked from the back of the file so a 10 MiB log doesn't materialise
+// in memory just to grab the last 200 lines.
+//
+// Returns at most n lines, oldest first. If the file is shorter than
+// n lines, all available lines are returned.
+func tailLines(path string, n int) ([]string, error) {
+	if n <= 0 {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := info.Size()
+	if size == 0 {
+		return nil, nil
+	}
+
+	const chunk = 64 * 1024
+	var (
+		buf   []byte
+		lines []string
+		off   = size
+	)
+	for off > 0 && len(lines) <= n {
+		read := int64(chunk)
+		if off < read {
+			read = off
+		}
+		off -= read
+		tmp := make([]byte, read)
+		if _, err := f.ReadAt(tmp, off); err != nil && err != io.EOF {
+			return nil, err
+		}
+		buf = append(tmp, buf...)
+		lines = splitLines(buf)
+		if off == 0 {
+			break
+		}
+	}
+
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines, nil
+}
+
+// splitLines breaks buf on '\n'. A trailing newline does not produce an
+// empty final entry; bufio.Scanner handles that distinction.
+func splitLines(buf []byte) []string {
+	scanner := bufio.NewScanner(bytes.NewReader(buf))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var out []string
+	for scanner.Scan() {
+		out = append(out, scanner.Text())
+	}
+	return out
+}
+
+// FormatTail returns a clipboard-ready string of the given lines: newline
+// joined, with a single trailing newline so paste targets that strip the
+// last line behave consistently.
+func FormatTail(lines []string) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,11 @@ func allKeys() []string {
 		KeyHealthDiskWarnGB,
 		KeyHealthDiskBlockerGB,
 		KeyHealthLastSeen,
+		KeyAutoSnapshotBeforeDestructive,
+		KeyDebugLogging,
+		KeyTelemetryDecided,
+		KeyUpdateDismissedVersion,
+		KeyUpdateLastAvailable,
 	}
 }
 
@@ -433,6 +438,60 @@ func (c *Config) SetHealthDiskBlockerGB(v int) error {
 		return fmt.Errorf("config: blocker threshold (%d GB) must be smaller than warn threshold (%d GB)", v, warn)
 	}
 	return c.Set(KeyHealthDiskBlockerGB, strconv.Itoa(v))
+}
+
+// ── Diagnostics ─────────────────────────────────────────────────────
+
+// DebugLogging reports whether the applog handler should emit Debug
+// records. Default false.
+func (c *Config) DebugLogging() bool {
+	return parseBool(c.raw(KeyDebugLogging), false)
+}
+
+// SetDebugLogging persists the toggle. The caller is responsible for
+// applying the new level via applog.SetDebug.
+func (c *Config) SetDebugLogging(on bool) error {
+	return c.Set(KeyDebugLogging, formatBool(on))
+}
+
+// ── Telemetry decision tri-state ────────────────────────────────────
+
+// TelemetryDecided reports whether the user has answered the first-launch
+// telemetry prompt. The first-launch modal flips this to true on any
+// answer; afterwards it never shows again. Independent of TelemetryOptIn
+// so we can distinguish "user said no" from "user hasn't been asked."
+func (c *Config) TelemetryDecided() bool {
+	return parseBool(c.raw(KeyTelemetryDecided), false)
+}
+
+// SetTelemetryDecided records that the modal has been dismissed.
+func (c *Config) SetTelemetryDecided(v bool) error {
+	return c.Set(KeyTelemetryDecided, formatBool(v))
+}
+
+// ── Update-check banner state ───────────────────────────────────────
+
+// UpdateDismissedVersion returns the version string the user last clicked
+// "Dismiss this version" on, or "" if nothing has been dismissed.
+func (c *Config) UpdateDismissedVersion() string {
+	return c.raw(KeyUpdateDismissedVersion)
+}
+
+// SetUpdateDismissedVersion persists the dismissed version.
+func (c *Config) SetUpdateDismissedVersion(v string) error {
+	return c.Set(KeyUpdateDismissedVersion, v)
+}
+
+// UpdateLastAvailable returns the most recent latest-available version
+// surfaced by the periodic update check. "" until the first check
+// completes.
+func (c *Config) UpdateLastAvailable() string {
+	return c.raw(KeyUpdateLastAvailable)
+}
+
+// SetUpdateLastAvailable persists the snapshot.
+func (c *Config) SetUpdateLastAvailable(v string) error {
+	return c.Set(KeyUpdateLastAvailable, v)
 }
 
 // HealthLastSeen returns the persisted last-seen-finding-keys JSON blob.

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -74,6 +74,29 @@ const (
 	// container. Power users with their own backup discipline can
 	// disable.
 	KeyAutoSnapshotBeforeDestructive = "snapshots.auto_before_destructive"
+
+	// KeyDebugLogging is the Settings → Diagnostics "Debug Mode" toggle.
+	// When true, the applog handler emits Debug-level records too (UI
+	// only — the runner cadence is unaffected). Default false.
+	KeyDebugLogging = "diagnostics.debug_logging"
+
+	// KeyTelemetryDecided records whether the user has answered the
+	// first-launch telemetry prompt. Distinct from KeyTelemetryOptIn,
+	// which collapses unset and "false" into the same boolean. The modal
+	// flips this to true on Opt-in, Decline, OR explicit dismiss; once
+	// flipped, the modal never shows again.
+	KeyTelemetryDecided = "telemetry.decided"
+
+	// KeyUpdateDismissedVersion records the latest available version the
+	// user dismissed via the "Dismiss this version" button on the
+	// Diagnostics card. The banner is suppressed while
+	// semver(latest) <= semver(this).
+	KeyUpdateDismissedVersion = "update_check.dismissed_version"
+
+	// KeyUpdateLastAvailable records the most recent latest-available
+	// version surfaced by the update check, so the Settings card has
+	// something to render on a fresh launch before the next fetch.
+	KeyUpdateLastAvailable = "update_check.last_available"
 )
 
 // Documented default values for every accessor. Centralising these

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -2,6 +2,8 @@ package docker
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 
@@ -45,11 +47,20 @@ func (d *Docker) HasClient() bool {
 	return d.cli != nil
 }
 
-// Ping verifies the engine is reachable. Wraps client.Ping with our context
-// plumbing.
+// Ping verifies the engine is reachable. A nil client (SetClient has not
+// been called yet) and any underlying transport failure are wrapped in
+// ErrDaemonUnreachable so callers can branch with errors.Is.
 func (d *Docker) Ping(ctx context.Context) error {
-	_, err := d.cli.Ping(ctx)
-	return err
+	if d.cli == nil {
+		return fmt.Errorf("%w: docker client not initialised", ErrDaemonUnreachable)
+	}
+	if _, err := d.cli.Ping(ctx); err != nil {
+		// errors.Join keeps the SDK error chain intact (so the test
+		// suite still sees the underlying transport error) while
+		// adding our sentinel for branchable handling.
+		return errors.Join(ErrDaemonUnreachable, err)
+	}
+	return nil
 }
 
 // CheckDockerAvailable is a backward-compatible alias for Ping that logs

--- a/internal/docker/engine.go
+++ b/internal/docker/engine.go
@@ -58,6 +58,13 @@ type Engine interface {
 	// stdout+stderr, demultiplexed for human reading.
 	ContainerLogs(ctx context.Context, name string, lines int) (string, error)
 
+	// StreamContainerLogs follows a container's stdout+stderr. The caller
+	// MUST cancel ctx to release the underlying SDK connection. Pass the
+	// zero time.Time to start at the live tail; pass a real time to
+	// resume after a reconnect. The channel closes when ctx is cancelled,
+	// the container exits, or an unrecoverable read error occurs.
+	StreamContainerLogs(ctx context.Context, name string, since time.Time) (<-chan LogLine, error)
+
 	// ChownVolume runs a privileged one-shot alpine container that
 	// recursively chowns every file in the volume to uid:gid. Used before
 	// service start so PHP-FPM/MySQL can write into the bind without

--- a/internal/docker/engine_logstream.go
+++ b/internal/docker/engine_logstream.go
@@ -1,0 +1,211 @@
+package docker
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+// LogStream identifies which container stream a LogLine came from. Knowing
+// stdout vs stderr lets the UI colour stderr lines red without applying a
+// fragile regex to the text.
+type LogStream uint8
+
+const (
+	LogStreamStdout LogStream = iota
+	LogStreamStderr
+)
+
+// LogLine is one line of streamed output. Time is the container-emitted
+// timestamp (truncated to millisecond resolution); Stream identifies the
+// origin; Text is the line contents *without* trailing newline.
+type LogLine struct {
+	Time   time.Time
+	Stream LogStream
+	Text   string
+}
+
+// streamChannelBuf caps the in-flight LogLine queue. A consumer that
+// can't keep up will see the oldest lines dropped silently — preferring
+// freshness to completeness for an interactive viewer. The on-disk
+// container log retains everything, so nothing is permanently lost.
+const streamChannelBuf = 1024
+
+// StreamContainerLogs follows the named container's combined stdout +
+// stderr. The since argument selects the starting timestamp: pass the
+// zero time.Time to stream from the live tail (with the last 100 lines
+// of historical context); pass a real time to resume after a reconnect.
+//
+// The returned channel closes when ctx is cancelled, the container exits,
+// or an unrecoverable read error occurs. Callers ranging over the channel
+// MUST cancel the supplied context before returning to release the
+// underlying SDK connection.
+//
+// The first error (if any) is reported through the optional second
+// channel; nil means "channel closed cleanly." Returns ErrNotFound when
+// the container does not exist at start; transient mid-stream read
+// failures are logged via slog and result in the channel closing.
+func (d *Docker) StreamContainerLogs(ctx context.Context, name string, since time.Time) (<-chan LogLine, error) {
+	if d.cli == nil {
+		return nil, fmt.Errorf("%w: docker client not initialised", ErrDaemonUnreachable)
+	}
+
+	info, err := d.cli.ContainerInspect(ctx, name)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: container %q", ErrNotFound, name)
+		}
+		return nil, fmt.Errorf("inspect %q: %w", name, err)
+	}
+	tty := info.Config != nil && info.Config.Tty
+
+	opts := container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+		Timestamps: true,
+		Tail:       "100",
+	}
+	if !since.IsZero() {
+		// Docker's API expects unix-seconds with optional nanos as a
+		// string; UnixNano keeps the resolution we receive back.
+		opts.Since = strconv.FormatInt(since.Unix(), 10)
+		// Don't replay the historical tail when resuming — the caller
+		// already has it.
+		opts.Tail = "0"
+	}
+
+	rc, err := d.cli.ContainerLogs(ctx, name, opts)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: container %q", ErrNotFound, name)
+		}
+		return nil, fmt.Errorf("stream logs %q: %w", name, err)
+	}
+
+	out := make(chan LogLine, streamChannelBuf)
+	go func() {
+		defer close(out)
+		defer rc.Close()
+
+		var stdout, stderr io.Writer
+		if tty {
+			// Tty containers don't multiplex; one stream is the source.
+			pump(ctx, out, rc, LogStreamStdout)
+			return
+		}
+
+		// stdcopy writes demuxed bytes into the supplied writers; we
+		// wrap each in a line-based pump that pushes into the LogLine
+		// channel.
+		stdoutW, stdoutDone := newLinePump(ctx, out, LogStreamStdout)
+		stderrW, stderrDone := newLinePump(ctx, out, LogStreamStderr)
+		stdout, stderr = stdoutW, stderrW
+
+		_, copyErr := stdcopy.StdCopy(stdout, stderr, rc)
+		stdoutW.Close()
+		stderrW.Close()
+		<-stdoutDone
+		<-stderrDone
+
+		if copyErr != nil && !errors.Is(copyErr, context.Canceled) && !errors.Is(copyErr, io.EOF) {
+			// Surface unexpected mid-stream errors via a synthetic
+			// stderr LogLine so the user sees something rather than
+			// silent disconnect.
+			select {
+			case out <- LogLine{Time: time.Now(), Stream: LogStreamStderr, Text: "[stream error: " + copyErr.Error() + "]"}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+	return out, nil
+}
+
+// pump reads r line-by-line and pushes each line into out. Honours ctx
+// cancellation between reads. Strips a leading RFC3339Nano timestamp
+// emitted by the Docker SDK when Timestamps=true.
+func pump(ctx context.Context, out chan<- LogLine, r io.Reader, stream LogStream) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		t, text := splitTimestamp(scanner.Text())
+		select {
+		case out <- LogLine{Time: t, Stream: stream, Text: text}:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// linePump writes bytes from the StdCopy demuxer; it splits on newlines
+// and pushes each completed line into the target channel. Exposed via an
+// io.WriteCloser so the demuxer can drive it directly.
+type linePump struct {
+	ctx    context.Context
+	out    chan<- LogLine
+	stream LogStream
+	done   chan struct{}
+	pipe   *io.PipeWriter
+}
+
+func newLinePump(ctx context.Context, out chan<- LogLine, stream LogStream) (*linePump, <-chan struct{}) {
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	lp := &linePump{ctx: ctx, out: out, stream: stream, done: done, pipe: pw}
+	go func() {
+		defer close(done)
+		defer pr.Close()
+		pump(ctx, out, pr, stream)
+	}()
+	return lp, done
+}
+
+func (l *linePump) Write(p []byte) (int, error) {
+	return l.pipe.Write(p)
+}
+
+func (l *linePump) Close() error {
+	return l.pipe.Close()
+}
+
+// splitTimestamp peels the leading RFC3339Nano timestamp the Docker SDK
+// prepends when Timestamps=true. Format: "2006-01-02T15:04:05.000000000Z message".
+// Falls back to time.Now() when parsing fails so the rest of the line is
+// still surfaced.
+func splitTimestamp(line string) (time.Time, string) {
+	const minLen = 30 // "2006-01-02T15:04:05.000000000Z" plus space
+	if len(line) < minLen {
+		return time.Now(), line
+	}
+	idx := indexByte(line, ' ')
+	if idx <= 0 {
+		return time.Now(), line
+	}
+	t, err := time.Parse(time.RFC3339Nano, line[:idx])
+	if err != nil {
+		return time.Now(), line
+	}
+	return t, line[idx+1:]
+}
+
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/docker/errors.go
+++ b/internal/docker/errors.go
@@ -30,4 +30,12 @@ var (
 	// ErrSpecAmbiguous is returned by spec validation when a Mount has more
 	// than one of {Bind, Volume, Tmpfs} populated, or none of them.
 	ErrSpecAmbiguous = errors.New("mount spec must have exactly one of bind/volume/tmpfs")
+
+	// ErrDaemonUnreachable is returned by Ping (and wrapped by lifecycle
+	// methods) when the Docker daemon socket is unreachable — Docker
+	// Desktop closed, the systemd unit stopped, the user's group is wrong,
+	// etc. UI code branches on errors.Is(err, ErrDaemonUnreachable) to
+	// surface a banner action ("Show how to start Docker") instead of a
+	// raw stack trace.
+	ErrDaemonUnreachable = errors.New("docker daemon unreachable")
 )

--- a/internal/docker/fake/engine.go
+++ b/internal/docker/fake/engine.go
@@ -47,16 +47,22 @@ type Engine struct {
 	// Disk-usage scripting for the health package's disk-low check.
 	DiskReport docker.DiskReport
 	DiskErr    error
+
+	// LogStreamHook overrides StreamContainerLogs when non-nil. Tests
+	// that need a long-lived stream (rather than a one-shot script)
+	// install a custom channel here.
+	LogStreamHook func(ctx context.Context, name string, since time.Time) (<-chan docker.LogLine, error)
 }
 
 // Container is the fake's record of a created container.
 type Container struct {
-	ID      string
-	Name    string
-	Spec    docker.ContainerSpec
-	Running bool
-	Healthy bool
-	Logs    string
+	ID          string
+	Name        string
+	Spec        docker.ContainerSpec
+	Running     bool
+	Healthy     bool
+	Logs        string
+	StreamLines []docker.LogLine
 }
 
 // Network is the fake's record of a created network.
@@ -220,6 +226,29 @@ func (e *Engine) ContainerLogs(_ context.Context, name string, _ int) (string, e
 		return "", fmt.Errorf("%w: %s", docker.ErrNotFound, name)
 	}
 	return c.Logs, nil
+}
+
+// StreamContainerLogs returns a channel that immediately yields any
+// pre-seeded LogLines from Containers[name].StreamLines (for tests that
+// want to script the stream) and then closes. Tests that need a
+// long-lived stream can override LogStreamHook.
+func (e *Engine) StreamContainerLogs(ctx context.Context, name string, since time.Time) (<-chan docker.LogLine, error) {
+	e.mu.Lock()
+	c, ok := e.Containers[name]
+	hook := e.LogStreamHook
+	e.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, name, since)
+	}
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", docker.ErrNotFound, name)
+	}
+	ch := make(chan docker.LogLine, len(c.StreamLines))
+	for _, ln := range c.StreamLines {
+		ch <- ln
+	}
+	close(ch)
+	return ch, nil
 }
 
 func (e *Engine) ChownVolume(_ context.Context, vol string, uid, gid int) error {

--- a/internal/router/errors.go
+++ b/internal/router/errors.go
@@ -1,0 +1,10 @@
+package router
+
+import "errors"
+
+// ErrPortInUse is returned by Router.EnsureRunning implementations when
+// the configured HTTP or HTTPS host port is already bound by something
+// other than the router itself. Defined on the interface package so UI
+// code can branch with errors.Is without importing a specific routing
+// engine implementation.
+var ErrPortInUse = errors.New("router host port already in use")

--- a/internal/router/traefik/errors.go
+++ b/internal/router/traefik/errors.go
@@ -1,0 +1,37 @@
+package traefik
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/PeterBooker/locorum/internal/router"
+)
+
+// classifyDockerStartError translates the opaque Docker CreateContainer /
+// ContainerStart error string into one of our sentinels when the pattern
+// is recognisable. Returns the original error untouched when nothing
+// matches.
+//
+// Daemon error strings vary across Docker SDK versions and platforms; we
+// match on the substrings the SDK consistently surfaces:
+//
+//   - "address already in use"  (Linux userland-proxy)
+//   - "port is already allocated" (Docker Engine API)
+//   - "bind: An attempt was made..." (Windows Docker Desktop)
+//
+// Update this list when a new variant shows up rather than spraying string
+// matches across the codebase.
+func classifyDockerStartError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "address already in use"),
+		strings.Contains(msg, "port is already allocated"),
+		strings.Contains(msg, "only one usage of each socket address"),
+		strings.Contains(msg, "bind: an attempt was made"):
+		return errors.Join(router.ErrPortInUse, err)
+	}
+	return err
+}

--- a/internal/router/traefik/traefik.go
+++ b/internal/router/traefik/traefik.go
@@ -202,7 +202,7 @@ func (r *Router) EnsureRunning(ctx context.Context) error {
 		return fmt.Errorf("writing api config: %w", err)
 	}
 	if err := r.createContainer(ctx); err != nil {
-		return fmt.Errorf("create router container: %w", err)
+		return fmt.Errorf("create router container: %w", classifyDockerStartError(err))
 	}
 	if err := r.waitReady(ctx); err != nil {
 		return fmt.Errorf("router did not become ready: %w", err)

--- a/internal/sites/audit.go
+++ b/internal/sites/audit.go
@@ -2,8 +2,6 @@ package sites
 
 import (
 	"encoding/json"
-	"errors"
-	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -11,6 +9,7 @@ import (
 	"time"
 
 	"github.com/PeterBooker/locorum/internal/orch"
+	"github.com/PeterBooker/locorum/internal/utils"
 )
 
 // auditMaxBytes caps the audit log size before rotation. 10 MiB is a
@@ -39,7 +38,7 @@ func writeAuditLog(homeDir string, res orch.Result) {
 	defer auditMu.Unlock()
 
 	logPath := filepath.Join(homeDir, ".locorum", "lifecycle.log")
-	if err := rotateIfLarge(logPath, auditMaxBytes); err != nil {
+	if err := utils.RotateIfLarge(logPath, auditMaxBytes, 1); err != nil {
 		slog.Warn("audit log rotate failed", "err", err.Error())
 	}
 
@@ -100,20 +99,4 @@ func writeAuditLog(homeDir string, res orch.Result) {
 	if _, err := f.Write(buf); err != nil {
 		slog.Warn("audit log write failed", "err", err.Error())
 	}
-}
-
-// rotateIfLarge renames logPath to logPath.1 if it exceeds maxBytes. Old
-// .1 files are overwritten — the audit log is operational, not legal hold.
-func rotateIfLarge(logPath string, maxBytes int64) error {
-	info, err := os.Stat(logPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-	if info.Size() < maxBytes {
-		return nil
-	}
-	return os.Rename(logPath, logPath+".1")
 }

--- a/internal/sites/audit_test.go
+++ b/internal/sites/audit_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/PeterBooker/locorum/internal/orch"
+	"github.com/PeterBooker/locorum/internal/utils"
 )
 
 func TestWriteAuditLog_AppendsJSONLine(t *testing.T) {
@@ -67,7 +68,7 @@ func TestRotateIfLarge(t *testing.T) {
 	if err := os.WriteFile(logPath, []byte("small"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := rotateIfLarge(logPath, 1024); err != nil {
+	if err := utils.RotateIfLarge(logPath, 1024, 1); err != nil {
 		t.Fatalf("rotate: %v", err)
 	}
 	if _, err := os.Stat(logPath + ".1"); !os.IsNotExist(err) {
@@ -79,7 +80,7 @@ func TestRotateIfLarge(t *testing.T) {
 	if err := os.WriteFile(logPath, []byte(big), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := rotateIfLarge(logPath, 1024); err != nil {
+	if err := utils.RotateIfLarge(logPath, 1024, 1); err != nil {
 		t.Fatalf("rotate: %v", err)
 	}
 	if _, err := os.Stat(logPath + ".1"); err != nil {

--- a/internal/sites/errors.go
+++ b/internal/sites/errors.go
@@ -1,0 +1,10 @@
+package sites
+
+import "errors"
+
+// ErrSiteNotRunning is returned by lifecycle methods that require the
+// site's containers to be up — wp-cli, link-check, snapshot, db import,
+// etc. The UI branches on errors.Is to render a banner with a "Start
+// site" action that kicks off StartSite (it does NOT auto-retry the
+// original action; the user re-clicks once the site is healthy).
+var ErrSiteNotRunning = errors.New("site is not running")

--- a/internal/sites/import.go
+++ b/internal/sites/import.go
@@ -79,7 +79,7 @@ func (sm *SiteManager) ImportDB(ctx context.Context, siteID, hostPath string, op
 		return fmt.Errorf("site %q not found", siteID)
 	}
 	if !site.Started {
-		return errors.New("site must be running to import a database")
+		return fmt.Errorf("%w: cannot import database", ErrSiteNotRunning)
 	}
 	if hostPath == "" {
 		return errors.New("import path is empty")

--- a/internal/sites/sites.go
+++ b/internal/sites/sites.go
@@ -983,6 +983,88 @@ func (sm *SiteManager) PickDirectory() (string, error) {
 	return dir, nil
 }
 
+// StreamLogs follows the named service container for siteID. The
+// returned channel closes when ctx is cancelled, the container exits, or
+// the engine reports an unrecoverable read failure. When the channel
+// closes while ctx is still live AND the site is still marked started,
+// StreamLogs auto-reattaches up to 5 times with a 1-second delay between
+// attempts (each new ContainerLogs call resumes from the last seen
+// timestamp).
+//
+// service is one of "web", "php", "database", "redis" — the per-site
+// service alias. ErrNotFound on the first attach means the container has
+// not been created yet (site never started); the caller should treat
+// that as terminal and not retry.
+func (sm *SiteManager) StreamLogs(ctx context.Context, siteID, service string) (<-chan docker.LogLine, error) {
+	site, err := sm.st.GetSite(siteID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching site: %w", err)
+	}
+	if site == nil {
+		return nil, fmt.Errorf("site %q not found", siteID)
+	}
+	containerName := docker.SiteContainerName(site.Slug, service)
+
+	out := make(chan docker.LogLine, 256)
+	go func() {
+		defer close(out)
+		var since time.Time
+		for attempt := 0; attempt <= 5; attempt++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			ch, err := sm.d.StreamContainerLogs(ctx, containerName, since)
+			if err != nil {
+				if errors.Is(err, docker.ErrNotFound) {
+					return
+				}
+				// Surface a synthetic error line and back off.
+				select {
+				case out <- docker.LogLine{Time: time.Now(), Stream: docker.LogStreamStderr, Text: "[reconnect: " + err.Error() + "]"}:
+				case <-ctx.Done():
+					return
+				}
+				if !sleepWithCtx(ctx, time.Second) {
+					return
+				}
+				continue
+			}
+			for line := range ch {
+				since = line.Time
+				select {
+				case out <- line:
+				case <-ctx.Done():
+					return
+				}
+			}
+			// Channel closed mid-stream. If the site is still marked
+			// started, sleep + retry; otherwise stop.
+			s, err := sm.st.GetSite(siteID)
+			if err != nil || s == nil || !s.Started {
+				return
+			}
+			if !sleepWithCtx(ctx, time.Second) {
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// sleepWithCtx returns false if ctx is cancelled before d elapses.
+func sleepWithCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 // GetContainerLogs returns the last N lines of logs for a site's service
 // container. Service should be one of: web, php, database, redis.
 func (sm *SiteManager) GetContainerLogs(ctx context.Context, siteID, service string, lines int) (string, error) {
@@ -1007,7 +1089,7 @@ func (sm *SiteManager) OpenAdminLogin(siteID string) error {
 		return fmt.Errorf("site %q not found", siteID)
 	}
 	if !site.Started {
-		return fmt.Errorf("site must be running")
+		return ErrSiteNotRunning
 	}
 
 	token := generatePassword(32)
@@ -1051,7 +1133,22 @@ if (isset($_GET['locorum_token']) && $_GET['locorum_token'] === '%s') {
 }
 
 // OpenSiteShell opens an interactive terminal session in the site's PHP container.
+// Returns utils.ErrNoTerminal if the host has no detectable terminal launcher;
+// callers branch on errors.Is to fall back to a "command copied" toast.
 func (sm *SiteManager) OpenSiteShell(siteID string) error {
+	return sm.OpenServiceShell(siteID, "php")
+}
+
+// OpenServiceShell opens a terminal exec'd into the named service
+// container for siteID. service is one of "web", "php", "database",
+// "redis". The shell binary is selected from a per-service map (Alpine
+// images only ship sh; everything else has bash) so users don't get a
+// "no such file or directory" when they click Open Shell on the nginx
+// container.
+//
+// Returns ErrSiteNotRunning when the site is stopped, and
+// utils.ErrNoTerminal when no terminal launcher could be found on PATH.
+func (sm *SiteManager) OpenServiceShell(siteID, service string) error {
 	site, err := sm.st.GetSite(siteID)
 	if err != nil {
 		return fmt.Errorf("fetching site: %w", err)
@@ -1060,11 +1157,33 @@ func (sm *SiteManager) OpenSiteShell(siteID string) error {
 		return fmt.Errorf("site %q not found", siteID)
 	}
 	if !site.Started {
-		return fmt.Errorf("site must be running")
+		return ErrSiteNotRunning
 	}
 
-	containerName := docker.SiteContainerName(site.Slug, "php")
-	return utils.OpenTerminalWithCommand("docker", "exec", "-it", containerName, "/bin/bash")
+	containerName := docker.SiteContainerName(site.Slug, service)
+	shell := shellBinaryForService(service)
+	return utils.OpenInTerminal([]string{"docker", "exec", "-it", containerName, shell})
+}
+
+// shellBinaryForService returns the shell path appropriate for the
+// service's image. Alpine-based images only ship /bin/sh; everything
+// else has /bin/bash. Mirrors version.go's image set:
+//
+//   - "web"      → nginx:1.28-alpine OR httpd:2.4-alpine → sh
+//   - "php"      → wodby/php:* (Alpine but ships bash)   → bash
+//   - "database" → mysql / mariadb (Debian)              → bash
+//   - "redis"    → redis:*-alpine                        → sh
+//
+// Any unknown service falls back to bash; if it's wrong the user gets a
+// clear "no such file" message inside the terminal rather than a silent
+// no-op.
+func shellBinaryForService(service string) string {
+	switch service {
+	case "web", "redis":
+		return "/bin/sh"
+	default:
+		return "/bin/bash"
+	}
 }
 
 // VersionsChange describes a desired change to a stopped site's runtime
@@ -1318,7 +1437,7 @@ func (sm *SiteManager) CheckLinks(siteID string, onProgress func(string), onDone
 		return fmt.Errorf("site %q not found", siteID)
 	}
 	if !site.Started {
-		return fmt.Errorf("site must be running")
+		return ErrSiteNotRunning
 	}
 
 	go func() {

--- a/internal/sites/snapshot.go
+++ b/internal/sites/snapshot.go
@@ -138,7 +138,7 @@ func (sm *SiteManager) Snapshot(ctx context.Context, siteID, label string) (stri
 		return "", fmt.Errorf("site %q not found", siteID)
 	}
 	if !site.Started {
-		return "", errors.New("site must be running to snapshot")
+		return "", fmt.Errorf("%w: cannot snapshot", ErrSiteNotRunning)
 	}
 	if !snapshotLabelPat.MatchString(label) {
 		return "", fmt.Errorf("invalid snapshot label %q: must match %s", label, snapshotLabelPat)
@@ -448,7 +448,7 @@ func (sm *SiteManager) RestoreSnapshot(ctx context.Context, siteID, snapshotPath
 		return fmt.Errorf("site %q not found", siteID)
 	}
 	if !site.Started {
-		return errors.New("site must be running to restore")
+		return fmt.Errorf("%w: cannot restore snapshot", ErrSiteNotRunning)
 	}
 	info := parseSnapshotName(filepath.Base(snapshotPath))
 	if info != nil && !opts.AllowEngineMismatch {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,75 @@
+// Package telemetry is the opt-in usage-event scaffold described by
+// LEARNINGS §7.3. Phase A — what's wired today — defines the Sink
+// interface, ships a no-op implementation, and exposes Track / Flush
+// helpers so the rest of the codebase can call instrumentation now and
+// the eventual transport drops in without touching call sites.
+//
+// Phase B (real transport) is deferred until a privacy doc lands and a
+// vendor is chosen. Until then, every Track call is dropped by the
+// noop sink and no network IO ever happens — even if the user opts in
+// via the Settings card.
+package telemetry
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// Sink is the destination for telemetry events. Implementations MUST be
+// safe for concurrent use. Track is non-blocking (fire-and-forget); the
+// sink is expected to buffer and flush on its own schedule, plus on
+// Flush.
+type Sink interface {
+	// Track records a single event. props is a flat map; values must be
+	// JSON-serialisable. Implementations MUST drop unknown keys (see the
+	// Phase B allow-list note in UX.md §5.2) so a typo at a call site
+	// can't leak path or credential data.
+	Track(event string, props map[string]any)
+
+	// Flush attempts to drain any buffered events before the supplied
+	// context elapses. Best-effort; nil error means "drained or empty,"
+	// non-nil means "some events remain in flight."
+	Flush(ctx context.Context) error
+}
+
+// Default returns the process-wide sink installed via SetDefault.
+// Initially the noop sink — call SetDefault from main.go after deciding
+// the user's opt-in state.
+func Default() Sink {
+	if s := defaultSink.Load(); s != nil {
+		return *s
+	}
+	return Noop{}
+}
+
+// SetDefault swaps the process-wide sink. Concurrent-safe via
+// atomic.Pointer; in-flight Track calls against the previous sink
+// continue to that sink (no shared state).
+func SetDefault(s Sink) {
+	if s == nil {
+		s = Noop{}
+	}
+	defaultSink.Store(&s)
+}
+
+// Track is a convenience wrapper around Default().Track. Callers that
+// already hold a Sink reference can use it directly; instrumentation
+// scattered across the codebase prefers this.
+func Track(event string, props map[string]any) {
+	Default().Track(event, props)
+}
+
+// Flush drains the default sink. Called from main.go on shutdown.
+func Flush(ctx context.Context) error {
+	return Default().Flush(ctx)
+}
+
+// Noop is the always-installed sink that drops every event. Bind it
+// explicitly when initialising tests so a forgotten SetDefault doesn't
+// see whichever sink the previous test left in place.
+type Noop struct{}
+
+func (Noop) Track(string, map[string]any) {}
+func (Noop) Flush(context.Context) error  { return nil }
+
+var defaultSink atomic.Pointer[Sink]

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,60 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestDefaultIsNoopUntilSet(t *testing.T) {
+	t.Parallel()
+	// Don't reset the global — other tests may run in parallel. Just
+	// verify that Default() returns a Sink whose Track is a no-op.
+	s := Default()
+	if s == nil {
+		t.Fatalf("Default() returned nil")
+	}
+	s.Track("test.event", map[string]any{"k": "v"})
+	if err := s.Flush(context.Background()); err != nil {
+		t.Fatalf("Noop.Flush returned %v", err)
+	}
+}
+
+type recordingSink struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *recordingSink) Track(name string, _ map[string]any) {
+	r.mu.Lock()
+	r.events = append(r.events, name)
+	r.mu.Unlock()
+}
+
+func (r *recordingSink) Flush(context.Context) error { return nil }
+
+func TestSetDefaultThenTrack(t *testing.T) {
+	// Sequential: this test mutates the global. Don't t.Parallel.
+	prev := Default()
+	defer SetDefault(prev)
+
+	rs := &recordingSink{}
+	SetDefault(rs)
+	Track("evt.one", nil)
+	Track("evt.two", map[string]any{"a": 1})
+
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if len(rs.events) != 2 || rs.events[0] != "evt.one" || rs.events[1] != "evt.two" {
+		t.Fatalf("recorded %+v, want [evt.one evt.two]", rs.events)
+	}
+}
+
+func TestSetDefaultNilFallsBackToNoop(t *testing.T) {
+	prev := Default()
+	defer SetDefault(prev)
+	SetDefault(nil)
+	if _, ok := Default().(Noop); !ok {
+		t.Fatalf("Default() after SetDefault(nil) = %T, want Noop", Default())
+	}
+}

--- a/internal/tls/errors.go
+++ b/internal/tls/errors.go
@@ -1,0 +1,13 @@
+package tls
+
+import "errors"
+
+// ErrMkcertMissing is returned by Issue / CARoot / InstallCA when the
+// mkcert binary is not installed on the host. The UI branches on
+// errors.Is to render a banner with a "Show me how" action that opens
+// the install instructions URL.
+//
+// Distinct from "mkcert is installed but the local CA isn't trusted yet"
+// — that case stays a regular error. The sentinel is only attached when
+// the binary itself is unreachable.
+var ErrMkcertMissing = errors.New("mkcert binary not installed")

--- a/internal/tls/mkcert.go
+++ b/internal/tls/mkcert.go
@@ -130,7 +130,7 @@ func (m *Mkcert) Issue(ctx context.Context, spec CertSpec) (CertPath, error) {
 		return CertPath{}, err
 	}
 	if !status.Installed {
-		return CertPath{}, fmt.Errorf("mkcert is not installed")
+		return CertPath{}, fmt.Errorf("%w: %s", ErrMkcertMissing, status.Message)
 	}
 	if !status.CATrusted {
 		// Refusing to issue is deliberate: a bare `mkcert <hosts>` call

--- a/internal/ui/describecache.go
+++ b/internal/ui/describecache.go
@@ -1,0 +1,163 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/sites"
+)
+
+// DescribeCache holds the most-recent SiteDescription per siteID. Layout
+// is invoked on every FrameEvent; calling sm.Describe per frame would
+// hit SQLite per frame and (with IncludeHostPort=true) Docker per frame.
+// The cache is refreshed on:
+//
+//   - first observation of a siteID (on Layout when no cached entry)
+//   - the OnSiteUpdated callback fires
+//   - lifecycle plan completion (OnPlanDone)
+//   - the DB-credentials card toggling open (one-shot Docker call for
+//     IncludeHostPort)
+//
+// Refresh is async — Layout never blocks. The cached value is available
+// the next frame after the goroutine returns.
+//
+// Wire format note: SiteDescription is the agent-facing IPC shape (see
+// AGENTS-SUPPORT.md). Any field added here is additive; renames or
+// drops require a coordinated bump because the JSON output of the
+// "Copy as JSON" button is the same shape consumed by the CLI / MCP.
+// describer is the SiteManager subset DescribeCache needs. Splitting it
+// into an interface lets unit tests pass a fake without spinning up
+// SQLite / Docker. *sites.SiteManager satisfies it directly.
+type describer interface {
+	Describe(ctx context.Context, siteID string, opts sites.DescribeOptions) (*sites.SiteDescription, error)
+}
+
+type DescribeCache struct {
+	sm    describer
+	state *UIState
+
+	mu      sync.Mutex
+	entries map[string]*describeEntry
+}
+
+type describeEntry struct {
+	desc         *sites.SiteDescription
+	loadedAt     time.Time
+	withHostPort bool
+	loading      bool
+}
+
+// NewDescribeCache returns an empty cache bound to a SiteManager.
+func NewDescribeCache(sm *sites.SiteManager, state *UIState) *DescribeCache {
+	return newDescribeCache(sm, state)
+}
+
+func newDescribeCache(d describer, state *UIState) *DescribeCache {
+	return &DescribeCache{
+		sm:      d,
+		state:   state,
+		entries: map[string]*describeEntry{},
+	}
+}
+
+// Get returns the cached description for siteID, or nil if no fetch has
+// completed. Triggers a background refresh if no entry exists yet.
+//
+// withHostPort=true forces a refresh that includes the published DB port.
+// If the cached entry was loaded without it, Get triggers a fresh load
+// and returns the (still-port-less) cached value for the current frame.
+func (c *DescribeCache) Get(siteID string, withHostPort bool) *sites.SiteDescription {
+	c.mu.Lock()
+	e, ok := c.entries[siteID]
+	if !ok {
+		e = &describeEntry{}
+		c.entries[siteID] = e
+	}
+	needsLoad := !e.loading && (e.desc == nil || (withHostPort && !e.withHostPort))
+	if needsLoad {
+		e.loading = true
+	}
+	cached := e.desc
+	c.mu.Unlock()
+
+	if needsLoad {
+		go c.load(siteID, withHostPort)
+	}
+	return cached
+}
+
+// Invalidate marks the cached entry stale and triggers an async refresh.
+// Call from OnSiteUpdated and OnPlanDone callbacks.
+func (c *DescribeCache) Invalidate(siteID string) {
+	c.mu.Lock()
+	e, ok := c.entries[siteID]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+	withPort := e.withHostPort
+	if e.loading {
+		c.mu.Unlock()
+		return
+	}
+	e.loading = true
+	c.mu.Unlock()
+
+	go c.load(siteID, withPort)
+}
+
+// Drop removes the cache entry — used when a site is deleted so we don't
+// leak per-site state for the lifetime of the process.
+func (c *DescribeCache) Drop(siteID string) {
+	c.mu.Lock()
+	delete(c.entries, siteID)
+	c.mu.Unlock()
+}
+
+func (c *DescribeCache) load(siteID string, withHostPort bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	desc, err := c.sm.Describe(ctx, siteID, sites.DescribeOptions{
+		IncludeHostPort:  withHostPort,
+		IncludeSnapshots: true,
+		ActivityLimit:    0,
+	})
+
+	c.mu.Lock()
+	e, ok := c.entries[siteID]
+	if !ok {
+		e = &describeEntry{}
+		c.entries[siteID] = e
+	}
+	e.loading = false
+	if err == nil && desc != nil {
+		e.desc = desc
+		e.loadedAt = time.Now()
+		e.withHostPort = withHostPort
+	}
+	c.mu.Unlock()
+
+	if c.state != nil {
+		c.state.Invalidate()
+	}
+}
+
+// AsJSON returns a pretty-printed JSON serialisation of the cached
+// description, or "" when nothing is cached. Used by the "Copy as JSON"
+// header button.
+func (c *DescribeCache) AsJSON(siteID string) string {
+	c.mu.Lock()
+	e, ok := c.entries[siteID]
+	c.mu.Unlock()
+	if !ok || e.desc == nil {
+		return ""
+	}
+	body, err := json.MarshalIndent(e.desc, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(body)
+}

--- a/internal/ui/describecache_test.go
+++ b/internal/ui/describecache_test.go
@@ -1,0 +1,161 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/sites"
+)
+
+type fakeDescriber struct {
+	mu       sync.Mutex
+	calls    atomic.Int32
+	withPort atomic.Int32
+	desc     *sites.SiteDescription
+	err      error
+	delay    time.Duration
+}
+
+func (f *fakeDescriber) Describe(ctx context.Context, siteID string, opts sites.DescribeOptions) (*sites.SiteDescription, error) {
+	f.calls.Add(1)
+	if opts.IncludeHostPort {
+		f.withPort.Add(1)
+	}
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.desc, f.err
+}
+
+func TestDescribeCacheLoadsOnceAndCaches(t *testing.T) {
+	t.Parallel()
+	f := &fakeDescriber{
+		desc: &sites.SiteDescription{ID: "site-1", Name: "demo", Slug: "demo"},
+	}
+	c := newDescribeCache(f, nil)
+
+	// First Get returns nil and triggers a load.
+	if got := c.Get("site-1", false); got != nil {
+		t.Fatalf("first Get returned non-nil cached entry: %+v", got)
+	}
+	// Wait for the async load.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := c.Get("site-1", false); got != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	got := c.Get("site-1", false)
+	if got == nil || got.ID != "site-1" {
+		t.Fatalf("Get after load = %+v, want site-1", got)
+	}
+	// Repeated Gets must not trigger more loads (debounce).
+	for i := 0; i < 5; i++ {
+		_ = c.Get("site-1", false)
+	}
+	if calls := f.calls.Load(); calls != 1 {
+		t.Fatalf("expected 1 load, got %d", calls)
+	}
+}
+
+func TestDescribeCacheRefreshesForHostPort(t *testing.T) {
+	t.Parallel()
+	f := &fakeDescriber{
+		desc: &sites.SiteDescription{ID: "site-1"},
+	}
+	c := newDescribeCache(f, nil)
+
+	c.Get("site-1", false)
+	waitFor(t, func() bool { return c.Get("site-1", false) != nil }, time.Second)
+	if f.calls.Load() != 1 {
+		t.Fatalf("first load count = %d, want 1", f.calls.Load())
+	}
+
+	// Now request with host port — must trigger a second load.
+	c.Get("site-1", true)
+	waitFor(t, func() bool { return f.withPort.Load() == 1 }, time.Second)
+	if f.calls.Load() != 2 {
+		t.Fatalf("after host-port request, calls = %d, want 2", f.calls.Load())
+	}
+
+	// Subsequent host-port Gets should not load again.
+	for i := 0; i < 3; i++ {
+		_ = c.Get("site-1", true)
+	}
+	if f.calls.Load() != 2 {
+		t.Fatalf("repeated host-port Get = %d, want 2", f.calls.Load())
+	}
+}
+
+func TestDescribeCacheInvalidateRefreshes(t *testing.T) {
+	t.Parallel()
+	f := &fakeDescriber{
+		desc: &sites.SiteDescription{ID: "site-1"},
+	}
+	c := newDescribeCache(f, nil)
+
+	c.Get("site-1", false)
+	waitFor(t, func() bool { return c.Get("site-1", false) != nil }, time.Second)
+
+	c.Invalidate("site-1")
+	waitFor(t, func() bool { return f.calls.Load() == 2 }, time.Second)
+	if f.calls.Load() != 2 {
+		t.Fatalf("after Invalidate, calls = %d, want 2", f.calls.Load())
+	}
+}
+
+func TestDescribeCacheAsJSONIncludesFields(t *testing.T) {
+	t.Parallel()
+	f := &fakeDescriber{
+		desc: &sites.SiteDescription{ID: "abc", Name: "demo", Slug: "demo"},
+	}
+	c := newDescribeCache(f, nil)
+	c.Get("abc", false)
+	waitFor(t, func() bool { return c.Get("abc", false) != nil }, time.Second)
+
+	body := c.AsJSON("abc")
+	if body == "" {
+		t.Fatalf("AsJSON returned empty after load")
+	}
+	if !strings.Contains(body, `"id": "abc"`) {
+		t.Fatalf("AsJSON missing id field; body = %s", body)
+	}
+}
+
+func TestDescribeCacheAsJSONReturnsEmptyWhenColdAndOnDrop(t *testing.T) {
+	t.Parallel()
+	f := &fakeDescriber{
+		desc: &sites.SiteDescription{ID: "abc"},
+	}
+	c := newDescribeCache(f, nil)
+
+	if got := c.AsJSON("abc"); got != "" {
+		t.Fatalf("cold AsJSON = %q, want empty", got)
+	}
+	c.Get("abc", false)
+	waitFor(t, func() bool { return c.Get("abc", false) != nil }, time.Second)
+
+	c.Drop("abc")
+	if got := c.AsJSON("abc"); got != "" {
+		t.Fatalf("AsJSON after Drop = %q, want empty", got)
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", timeout)
+}

--- a/internal/ui/diagnosticspanel.go
+++ b/internal/ui/diagnosticspanel.go
@@ -1,0 +1,187 @@
+package ui
+
+import (
+	"strconv"
+
+	"gioui.org/layout"
+	"gioui.org/unit"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+
+	"github.com/PeterBooker/locorum/internal/applog"
+	"github.com/PeterBooker/locorum/internal/sites"
+	"github.com/PeterBooker/locorum/internal/utils"
+)
+
+// DiagnosticsPanel groups developer-oriented controls used to inspect or
+// reset the running app: log file access, debug-mode toggle, and (added by
+// later sub-tasks) the update-check banner and reset-infrastructure card.
+//
+// Wired from SettingsPanel; rendered as the Settings → Diagnostics card.
+// Mutations go through sites.SiteManager.Config so persistence survives
+// restart; the in-memory level toggle goes through applog.SetDebug so the
+// next slog.Info record uses the new level without rebuilding the handler.
+type DiagnosticsPanel struct {
+	state  *UIState
+	sm     *sites.SiteManager
+	toasts *Notifications
+
+	debugMode     widget.Bool
+	openLogFolder widget.Clickable
+	copyLastLines widget.Clickable
+	debugSyncedTo bool
+
+	// Optional sub-cards rendered inside the Diagnostics block. nil means
+	// the section is omitted. UpdateBanner and ResetInfraCard are wired
+	// from main.go after the relevant subsystems are constructed.
+	updatePanel    *UpdateBannerCard
+	resetInfraCard *ResetInfraCard
+}
+
+// TailLineCount is the number of lines copied to clipboard by the
+// "Copy Last 200 Lines" affordance. Exposed as a constant so tests can
+// reference the same value without re-declaring the magic number.
+const TailLineCount = 200
+
+func NewDiagnosticsPanel(state *UIState, sm *sites.SiteManager, toasts *Notifications) *DiagnosticsPanel {
+	dp := &DiagnosticsPanel{state: state, sm: sm, toasts: toasts}
+	if cfg := sm.Config(); cfg != nil {
+		dp.debugMode.Value = cfg.DebugLogging()
+		dp.debugSyncedTo = dp.debugMode.Value
+	}
+	return dp
+}
+
+// SetUpdateBanner wires (or clears) the update-check sub-card. Safe to
+// call before or after Layout — the card is only rendered when set.
+func (dp *DiagnosticsPanel) SetUpdateBanner(c *UpdateBannerCard) { dp.updatePanel = c }
+
+// SetResetInfraCard wires (or clears) the reset-infrastructure sub-card.
+func (dp *DiagnosticsPanel) SetResetInfraCard(c *ResetInfraCard) { dp.resetInfraCard = c }
+
+func (dp *DiagnosticsPanel) HandleUserInteractions(gtx layout.Context) {
+	if dp.debugMode.Update(gtx) && dp.debugMode.Value != dp.debugSyncedTo {
+		dp.debugSyncedTo = dp.debugMode.Value
+		applog.SetDebug(dp.debugMode.Value)
+		if cfg := dp.sm.Config(); cfg != nil {
+			if err := cfg.SetDebugLogging(dp.debugMode.Value); err != nil {
+				dp.state.ShowError("Debug logging: " + err.Error())
+			}
+		}
+	}
+	if dp.openLogFolder.Clicked(gtx) {
+		dir := applog.LogDir()
+		if dir == "" {
+			dp.toasts.ShowError("Log folder unavailable — file logging is disabled")
+		} else if err := utils.OpenDirectory(dir); err != nil {
+			dp.toasts.ShowError("Open log folder: " + err.Error())
+		}
+	}
+	if dp.copyLastLines.Clicked(gtx) {
+		lines, err := applog.TailLines(TailLineCount)
+		switch {
+		case err != nil:
+			dp.toasts.ShowError("Read log: " + err.Error())
+		case len(lines) == 0:
+			dp.toasts.ShowInfo("Log is empty")
+		default:
+			CopyToClipboard(gtx, applog.FormatTail(lines))
+			dp.toasts.ShowSuccess("Copied last " + strconv.Itoa(len(lines)) + " lines")
+		}
+	}
+	if dp.updatePanel != nil {
+		dp.updatePanel.HandleUserInteractions(gtx)
+	}
+	if dp.resetInfraCard != nil {
+		dp.resetInfraCard.HandleUserInteractions(gtx)
+	}
+}
+
+func (dp *DiagnosticsPanel) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			if dp.updatePanel == nil {
+				return layout.Dimensions{}
+			}
+			return dp.updatePanel.Layout(gtx, th)
+		}),
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			return panel(gtx, th, "Diagnostics", func(gtx layout.Context) layout.Dimensions {
+				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						lbl := material.Body2(th.Theme, "Inspect logs and toggle verbose output. Logs live under ~/.locorum/logs.")
+						lbl.Color = th.Color.Fg2
+						lbl.TextSize = th.Sizes.Body
+						return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, lbl.Layout)
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						cb := material.CheckBox(th.Theme, &dp.debugMode, "Debug Mode (verbose logging)")
+						cb.Color = th.Color.Fg
+						cb.IconColor = th.Color.Accent
+						cb.Size = unit.Dp(20)
+						cb.TextSize = th.Sizes.Body
+						return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, cb.Layout)
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+							layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+								return SecondaryButton(gtx, th, &dp.openLogFolder, "Open Log Folder")
+							}),
+							layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+								return layout.Inset{Left: th.Spacing.SM}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+									return SecondaryButton(gtx, th, &dp.copyLastLines, "Copy Last 200 Lines")
+								})
+							}),
+						)
+					}),
+				)
+			})
+		}),
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			if dp.resetInfraCard == nil {
+				return layout.Dimensions{}
+			}
+			return dp.resetInfraCard.Layout(gtx, th)
+		}),
+	)
+}
+
+// UpdateBannerCard and ResetInfraCard are placeholders for the cards
+// added by §7.4 and §7.6 respectively. They are declared here so the
+// DiagnosticsPanel compiles standalone; the per-task files supply the
+// actual implementations and the wiring fills these closures in.
+type UpdateBannerCard struct {
+	HandleUserInteractionsFn func(layout.Context)
+	LayoutFn                 func(layout.Context, *Theme) layout.Dimensions
+}
+
+func (c *UpdateBannerCard) HandleUserInteractions(gtx layout.Context) {
+	if c.HandleUserInteractionsFn != nil {
+		c.HandleUserInteractionsFn(gtx)
+	}
+}
+
+func (c *UpdateBannerCard) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	if c.LayoutFn == nil {
+		return layout.Dimensions{}
+	}
+	return c.LayoutFn(gtx, th)
+}
+
+type ResetInfraCard struct {
+	HandleUserInteractionsFn func(layout.Context)
+	LayoutFn                 func(layout.Context, *Theme) layout.Dimensions
+}
+
+func (c *ResetInfraCard) HandleUserInteractions(gtx layout.Context) {
+	if c.HandleUserInteractionsFn != nil {
+		c.HandleUserInteractionsFn(gtx)
+	}
+}
+
+func (c *ResetInfraCard) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	if c.LayoutFn == nil {
+		return layout.Dimensions{}
+	}
+	return c.LayoutFn(gtx, th)
+}

--- a/internal/ui/erractions.go
+++ b/internal/ui/erractions.go
@@ -1,0 +1,101 @@
+package ui
+
+import (
+	"errors"
+
+	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/router"
+	"github.com/PeterBooker/locorum/internal/sites"
+	"github.com/PeterBooker/locorum/internal/tls"
+	"github.com/PeterBooker/locorum/internal/utils"
+)
+
+// External documentation links surfaced by the typed-error banner
+// actions. URLs live here (not scattered through call sites) so a future
+// rebrand or doc move is one search-and-replace.
+const (
+	dockerStartHelpURL   = "https://docs.docker.com/desktop/"
+	mkcertInstallHelpURL = "https://github.com/FiloSottile/mkcert#installation"
+)
+
+// SurfaceError translates a backend error into the appropriate banner
+// presentation. Recognised sentinels get an action button that points
+// the user at the next step (start the daemon, install mkcert, free up
+// the port, start the site). Anything unrecognised falls back to the
+// plain "<prefix>: <err>" toast.
+//
+// `prefix` is the user-facing context for the unrecognised path ("Failed
+// to start site"). For sentinel branches the prefix is ignored and the
+// banner shows the canonical message tied to that sentinel.
+//
+// The starter argument is invoked by the ErrSiteNotRunning branch's
+// "Start site" button. Pass nil if the calling context does not have a
+// site in hand (e.g. settings-page errors); the action is then omitted.
+//
+// CLAUDE.md invariant 1 keeps the UI on a strict diet of internal/sites,
+// internal/types, orch.StepResult, and docker.PullProgress. The added
+// imports here (docker, router, tls) are intentionally limited to
+// sentinel-value comparison via errors.Is — no calls into those
+// packages' methods. Do not generalise this file into "the UI knows
+// docker"; if it grows past sentinels, refactor through SiteManager.
+func SurfaceError(state *UIState, prefix string, err error, starter func()) {
+	if err == nil {
+		return
+	}
+	switch {
+	case errors.Is(err, docker.ErrDaemonUnreachable):
+		state.ShowErrorWithAction(
+			"Docker isn't running. Start Docker Desktop (or your daemon) and try again.",
+			NotifyAction{
+				ID:    "open-docker-help",
+				Label: "How to start Docker",
+				Run: func() {
+					_ = utils.OpenURL(dockerStartHelpURL)
+					state.ClearErrorBanner()
+				},
+			},
+		)
+	case errors.Is(err, tls.ErrMkcertMissing):
+		state.ShowErrorWithAction(
+			"mkcert is not installed — HTTPS certificates can't be issued.",
+			NotifyAction{
+				ID:    "open-mkcert-help",
+				Label: "Show me how",
+				Run: func() {
+					_ = utils.OpenURL(mkcertInstallHelpURL)
+					state.ClearErrorBanner()
+				},
+			},
+		)
+	case errors.Is(err, router.ErrPortInUse):
+		state.ShowErrorWithAction(
+			"A required network port is already in use. Choose a different port in Settings.",
+			NotifyAction{
+				ID:    "open-network-settings",
+				Label: "Open Settings",
+				Run: func() {
+					state.SetNavView(NavViewSettings)
+					state.ClearErrorBanner()
+				},
+			},
+		)
+	case errors.Is(err, sites.ErrSiteNotRunning):
+		if starter == nil {
+			state.ShowError(prefix + ": " + err.Error())
+			return
+		}
+		state.ShowErrorWithAction(
+			"This action needs the site to be running.",
+			NotifyAction{
+				ID:    "start-site",
+				Label: "Start site",
+				Run: func() {
+					go starter()
+					state.ClearErrorBanner()
+				},
+			},
+		)
+	default:
+		state.ShowError(prefix + ": " + err.Error())
+	}
+}

--- a/internal/ui/erractions_test.go
+++ b/internal/ui/erractions_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/PeterBooker/locorum/internal/docker"
+	"github.com/PeterBooker/locorum/internal/router"
+	"github.com/PeterBooker/locorum/internal/sites"
+	"github.com/PeterBooker/locorum/internal/tls"
+)
+
+func TestSurfaceErrorNilDoesNothing(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	SurfaceError(s, "ctx", nil, nil)
+	if got := s.ErrorBannerSnapshot(); got.Message != "" {
+		t.Fatalf("nil err produced banner %q", got.Message)
+	}
+}
+
+func TestSurfaceErrorDaemonUnreachable(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	wrapped := fmt.Errorf("starting site: %w", docker.ErrDaemonUnreachable)
+	SurfaceError(s, "Failed to start site", wrapped, nil)
+	got := s.ErrorBannerSnapshot()
+	if !got.HasAction {
+		t.Fatalf("daemon-unreachable banner missing action")
+	}
+	if got.ActionID != "open-docker-help" {
+		t.Fatalf("ActionID = %q, want open-docker-help", got.ActionID)
+	}
+}
+
+func TestSurfaceErrorPortInUse(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	wrapped := fmt.Errorf("router: %w", router.ErrPortInUse)
+	SurfaceError(s, "ignored", wrapped, nil)
+	got := s.ErrorBannerSnapshot()
+	if got.ActionID != "open-network-settings" {
+		t.Fatalf("ActionID = %q, want open-network-settings", got.ActionID)
+	}
+}
+
+func TestSurfaceErrorMkcertMissing(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	SurfaceError(s, "ignored", tls.ErrMkcertMissing, nil)
+	got := s.ErrorBannerSnapshot()
+	if got.ActionID != "open-mkcert-help" {
+		t.Fatalf("ActionID = %q, want open-mkcert-help", got.ActionID)
+	}
+}
+
+func TestSurfaceErrorSiteNotRunningWithStarter(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	called := make(chan struct{}, 1)
+	starter := func() { called <- struct{}{} }
+	SurfaceError(s, "Failed to open shell", sites.ErrSiteNotRunning, starter)
+
+	got := s.ErrorBannerSnapshot()
+	if got.ActionID != "start-site" {
+		t.Fatalf("ActionID = %q, want start-site", got.ActionID)
+	}
+	if !s.TriggerErrorAction() {
+		t.Fatalf("TriggerErrorAction returned false")
+	}
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("starter never invoked")
+	}
+}
+
+func TestSurfaceErrorSiteNotRunningWithoutStarterFallsBack(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	SurfaceError(s, "Failed to do thing", sites.ErrSiteNotRunning, nil)
+	got := s.ErrorBannerSnapshot()
+	if got.HasAction {
+		t.Fatalf("starter==nil should suppress action; got %+v", got)
+	}
+	if got.Message == "" {
+		t.Fatalf("empty banner with non-nil err")
+	}
+}
+
+func TestSurfaceErrorUnknownFallsBackPlain(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	SurfaceError(s, "Boom", errors.New("garden-variety"), nil)
+	got := s.ErrorBannerSnapshot()
+	if got.HasAction {
+		t.Fatalf("unknown err should not produce action")
+	}
+	if got.Message != "Boom: garden-variety" {
+		t.Fatalf("Message = %q, want %q", got.Message, "Boom: garden-variety")
+	}
+}

--- a/internal/ui/healthpanel.go
+++ b/internal/ui/healthpanel.go
@@ -366,6 +366,7 @@ type HealthBadgeKind int
 const (
 	HealthBadgeNone    HealthBadgeKind = iota
 	HealthBadgeInfo                    // hidden in the rail; shown only in the panel
+	HealthBadgeUpdate                  // accent — surfaced when an update is available
 	HealthBadgeWarn                    // amber
 	HealthBadgeBlocker                 // red
 )
@@ -388,12 +389,14 @@ func HealthBadgeFor(snap health.Snapshot) HealthBadgeKind {
 // Used by the nav rail to flag the Settings entry. Caller is responsible
 // for positioning.
 func LayoutHealthBadge(gtx layout.Context, kind HealthBadgeKind, th *Theme) layout.Dimensions {
-	if kind == HealthBadgeNone || kind == HealthBadgeInfo {
+	switch kind {
+	case HealthBadgeNone, HealthBadgeInfo:
 		return layout.Dimensions{}
+	case HealthBadgeUpdate:
+		return severityDot(gtx, th.Color.Accent)
+	case HealthBadgeBlocker:
+		return severityDot(gtx, th.Color.Err)
+	default:
+		return severityDot(gtx, th.Color.Warn)
 	}
-	col := th.Color.Warn
-	if kind == HealthBadgeBlocker {
-		col = th.Color.Err
-	}
-	return severityDot(gtx, col)
 }

--- a/internal/ui/logviewer.go
+++ b/internal/ui/logviewer.go
@@ -2,44 +2,105 @@ package ui
 
 import (
 	"context"
+	"fmt"
+	"image/color"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
 
+	"gioui.org/font"
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
 
+	"github.com/PeterBooker/locorum/internal/applog"
+	"github.com/PeterBooker/locorum/internal/docker"
 	"github.com/PeterBooker/locorum/internal/sites"
 )
 
-// LogViewer renders the container log viewer panel with service selector and output area.
+// logViewerRingSize caps the number of lines held in memory per
+// service stream. Older lines are dropped when the ring fills — the
+// on-disk container log retains everything.
+const logViewerRingSize = 5000
+
+// errorLineRegex marks lines worth highlighting in red. Cheap; defer
+// full syntax-highlighting indefinitely (the §7.7 plan calls this out).
+var errorLineRegex = regexp.MustCompile(`(?i)\b(error|fatal|panic|exception|fail(?:ed)?)\b`)
+
+// LogViewer is the Logs tab. Replaces the prior batched-Refresh viewer
+// with a streaming follow that:
+//
+//   - holds the last logViewerRingSize lines in memory
+//   - re-attaches automatically on container restart (driven by
+//     SiteManager.StreamLogs)
+//   - lets the user pause / resume the visible feed without losing the
+//     in-flight stream (incoming lines still fill the ring while paused;
+//     resume snaps to the latest)
+//   - highlights any line matching errorLineRegex in red
+//   - exports the ring to <datadir>/logs/<slug>-<service>-<ts>.log
+//
+// The streaming context is owned by the viewer; switching service or
+// switching site cancels the current stream and starts a new one.
 type LogViewer struct {
 	state *UIState
 	sm    *sites.SiteManager
 
 	serviceDropdown *Dropdown
-	refreshBtn      widget.Clickable
+	pauseBtn        widget.Clickable
+	resumeBtn       widget.Clickable
+	clearBtn        widget.Clickable
+	exportBtn       widget.Clickable
+	highlightBox    widget.Bool
 	output          *OutputView
+
+	mu        sync.Mutex
+	siteID    string
+	siteSlug  string
+	service   string
+	cancel    context.CancelFunc
+	ring      []logLineCached
+	ringHead  int
+	ringFill  int
+	paused    bool
+	highlight bool
+	frozen    string // last-rendered visible buffer; updated when not paused
+}
+
+type logLineCached struct {
+	t       time.Time
+	stderr  bool
+	text    string
+	isError bool
 }
 
 func NewLogViewer(state *UIState, sm *sites.SiteManager) *LogViewer {
-	return &LogViewer{
+	lv := &LogViewer{
 		state:           state,
 		sm:              sm,
 		serviceDropdown: NewDropdown([]string{"web", "php", "database", "redis"}),
 		output:          NewOutputView(),
+		ring:            make([]logLineCached, logViewerRingSize),
+		highlight:       true,
 	}
+	lv.highlightBox.Value = true
+	return lv
 }
 
+// Layout draws the controls + scrollback. Called every frame; the
+// streamed lines arrive on a background goroutine and are read here under
+// the mutex.
 func (lv *LogViewer) Layout(gtx layout.Context, th *Theme, siteID string) layout.Dimensions {
-	logOutput, _, logLoading := lv.state.GetLogState()
+	body := lv.snapshot()
 
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-		// Section title
 		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 			lbl := material.H6(th.Theme, "Container Logs")
 			return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, lbl.Layout)
 		}),
-		// Controls: dropdown + refresh
 		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 			return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 				return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
@@ -49,38 +110,242 @@ func (lv *LogViewer) Layout(gtx layout.Context, th *Theme, siteID string) layout
 					}),
 					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 						return layout.Inset{Left: th.Spacing.MD}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
-							if logLoading {
-								return Loader(gtx, th, th.Dims.LoaderSizeSM)
+							if lv.paused {
+								return SecondaryButton(gtx, th, &lv.resumeBtn, "Resume")
 							}
-							return SecondaryButton(gtx, th, &lv.refreshBtn, "Refresh")
+							return SecondaryButton(gtx, th, &lv.pauseBtn, "Pause")
+						})
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return layout.Inset{Left: th.Spacing.SM}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+							return SecondaryButton(gtx, th, &lv.clearBtn, "Clear")
+						})
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return layout.Inset{Left: th.Spacing.SM}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+							return SecondaryButton(gtx, th, &lv.exportBtn, "Export")
+						})
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return layout.Inset{Left: th.Spacing.MD}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+							cb := material.CheckBox(th.Theme, &lv.highlightBox, "Highlight errors")
+							cb.Color = th.Color.Fg
+							cb.IconColor = th.Color.Accent
+							cb.Size = unit.Dp(18)
+							cb.TextSize = th.Sizes.SM
+							cb.Font.Weight = font.Normal
+							return cb.Layout(gtx)
 						})
 					}),
 				)
 			})
 		}),
-		// Log output area
 		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 			return layout.Inset{Bottom: unit.Dp(20)}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
-				return lv.output.Layout(gtx, th, logOutput, "Click Refresh to load logs", th.Dims.OutputAreaMax)
+				placeholder := "Streaming logs… (start the site if nothing appears)"
+				return lv.output.Layout(gtx, th, body, placeholder, th.Dims.OutputAreaMax)
 			})
 		}),
 	)
 }
 
-// HandleUserInteractions processes the Refresh button click.
+// HandleUserInteractions reacts to control clicks AND ensures the
+// streaming goroutine is bound to the current site / service. Idempotent
+// — when the user has not switched anything, no work happens.
 func (lv *LogViewer) HandleUserInteractions(gtx layout.Context, siteID string) {
-	if lv.refreshBtn.Clicked(gtx) {
-		service := lv.serviceDropdown.Options[lv.serviceDropdown.Selected]
-		lv.state.SetLogLoading(true)
+	service := lv.serviceDropdown.Options[lv.serviceDropdown.Selected]
 
-		go func() {
-			output, err := lv.sm.GetContainerLogs(context.Background(), siteID, service, 100)
-			if err != nil {
-				lv.state.SetLogOutput(service, "Error: "+err.Error())
-			} else {
-				lv.state.SetLogOutput(service, output)
-			}
-			lv.state.SetLogLoading(false)
-		}()
+	lv.mu.Lock()
+	needsRestart := lv.siteID != siteID || lv.service != service
+	lv.mu.Unlock()
+	if needsRestart {
+		lv.startStream(siteID, service)
+	}
+
+	if lv.pauseBtn.Clicked(gtx) {
+		lv.mu.Lock()
+		lv.paused = true
+		lv.frozen = lv.renderLocked()
+		lv.mu.Unlock()
+	}
+	if lv.resumeBtn.Clicked(gtx) {
+		lv.mu.Lock()
+		lv.paused = false
+		lv.frozen = ""
+		lv.mu.Unlock()
+		lv.state.Invalidate()
+	}
+	if lv.clearBtn.Clicked(gtx) {
+		lv.mu.Lock()
+		lv.ringHead = 0
+		lv.ringFill = 0
+		lv.frozen = ""
+		lv.mu.Unlock()
+		lv.state.Invalidate()
+	}
+	if lv.highlightBox.Update(gtx) {
+		lv.mu.Lock()
+		lv.highlight = lv.highlightBox.Value
+		if lv.paused {
+			lv.frozen = lv.renderLocked()
+		}
+		lv.mu.Unlock()
+		lv.state.Invalidate()
+	}
+	if lv.exportBtn.Clicked(gtx) {
+		lv.exportToFile()
+	}
+}
+
+// startStream cancels any in-flight stream, resets the ring, and kicks
+// off a new SiteManager.StreamLogs goroutine.
+func (lv *LogViewer) startStream(siteID, service string) {
+	lv.mu.Lock()
+	if lv.cancel != nil {
+		lv.cancel()
+		lv.cancel = nil
+	}
+	lv.siteID = siteID
+	lv.service = service
+	lv.ringHead = 0
+	lv.ringFill = 0
+	lv.frozen = ""
+	site, _ := lv.sm.GetSite(siteID)
+	if site != nil {
+		lv.siteSlug = site.Slug
+	}
+	lv.mu.Unlock()
+
+	if siteID == "" {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	lv.mu.Lock()
+	lv.cancel = cancel
+	lv.mu.Unlock()
+
+	go func() {
+		ch, err := lv.sm.StreamLogs(ctx, siteID, service)
+		if err != nil {
+			lv.append(time.Now(), true, "[stream error: "+err.Error()+"]")
+			return
+		}
+		for line := range ch {
+			lv.append(line.Time, line.Stream == docker.LogStreamStderr, line.Text)
+		}
+	}()
+}
+
+func (lv *LogViewer) append(t time.Time, stderr bool, text string) {
+	lv.mu.Lock()
+	entry := logLineCached{
+		t:       t,
+		stderr:  stderr,
+		text:    text,
+		isError: errorLineRegex.MatchString(text),
+	}
+	lv.ring[lv.ringHead] = entry
+	lv.ringHead = (lv.ringHead + 1) % len(lv.ring)
+	if lv.ringFill < len(lv.ring) {
+		lv.ringFill++
+	}
+	lv.mu.Unlock()
+	lv.state.Invalidate()
+}
+
+// snapshot returns the visible buffer body. When paused, returns the
+// frozen body captured at pause time so the user can scroll a stable
+// view; otherwise re-renders from the live ring.
+func (lv *LogViewer) snapshot() string {
+	lv.mu.Lock()
+	defer lv.mu.Unlock()
+	if lv.paused && lv.frozen != "" {
+		return lv.frozen
+	}
+	return lv.renderLocked()
+}
+
+// renderLocked formats the ring into a single string. Caller must hold mu.
+//
+// Highlighting is *prefix-based* — we prepend "!! " to error lines when
+// the toggle is on. Gio's OutputView is a plain text widget; per-rune
+// styling would require a richer renderer. The marker is ugly but
+// honest: a future LayoutLogPanel could parse it back.
+func (lv *LogViewer) renderLocked() string {
+	if lv.ringFill == 0 {
+		return ""
+	}
+	var b strings.Builder
+	start := lv.ringHead - lv.ringFill
+	if start < 0 {
+		start += len(lv.ring)
+	}
+	for i := 0; i < lv.ringFill; i++ {
+		entry := lv.ring[(start+i)%len(lv.ring)]
+		if lv.highlight && entry.isError {
+			b.WriteString("!! ")
+		}
+		b.WriteString(entry.text)
+		if i < lv.ringFill-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// exportToFile writes the current ring to ~/.locorum/logs/<slug>-<svc>-<ts>.log.
+func (lv *LogViewer) exportToFile() {
+	lv.mu.Lock()
+	body := lv.renderLocked()
+	slug := lv.siteSlug
+	service := lv.service
+	lv.mu.Unlock()
+
+	if body == "" {
+		lv.state.ShowError("Nothing to export — log buffer is empty")
+		return
+	}
+	dir := applog.LogDir()
+	if dir == "" {
+		// Fall back to the user's home dir + .locorum/logs to maintain
+		// at least one canonical location even when applog.Init failed.
+		dir = filepath.Join(os.TempDir(), "locorum-logs")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			lv.state.ShowError("Export failed: " + err.Error())
+			return
+		}
+	}
+	ts := time.Now().Format("20060102-150405")
+	name := fmt.Sprintf("%s-%s-%s.log", slug, service, ts)
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		lv.state.ShowError("Export failed: " + err.Error())
+		return
+	}
+	lv.state.ShowError("Exported to " + path)
+}
+
+// Stop cancels any in-flight stream. Called when the SiteDetail is being
+// torn down (e.g. a future "close site" affordance).
+func (lv *LogViewer) Stop() {
+	lv.mu.Lock()
+	if lv.cancel != nil {
+		lv.cancel()
+		lv.cancel = nil
+	}
+	lv.mu.Unlock()
+}
+
+// LineRender is the colour helper used by callers that want to apply
+// the ringed entries directly (kept for future per-line styling).
+func LineRender(stderr, isError bool, th *Theme) color.NRGBA {
+	switch {
+	case isError:
+		return th.Color.Err
+	case stderr:
+		return th.Color.Fg2
+	default:
+		return th.Color.Fg
 	}
 }

--- a/internal/ui/navrail.go
+++ b/internal/ui/navrail.go
@@ -15,6 +15,7 @@ import (
 	"gioui.org/widget/material"
 
 	"github.com/PeterBooker/locorum/internal/sites"
+	"github.com/PeterBooker/locorum/internal/updatecheck"
 )
 
 // NavRail is the leftmost column: the brand mark, two top-level nav items
@@ -190,10 +191,18 @@ func (n *NavRail) layoutNavItem(
 	}
 
 	// Settings entry shows the System Health badge — only it; other
-	// nav items don't carry health meaning.
+	// nav items don't carry health meaning. The "update available"
+	// signal is OR-ed in: when no warn/blocker is present, the dot
+	// flips to accent to nudge the user toward Diagnostics.
 	badge := HealthBadgeNone
 	if key == NavViewSettings {
 		badge = HealthBadgeFor(n.state.HealthSnapshot())
+		if badge == HealthBadgeNone || badge == HealthBadgeInfo {
+			snap := n.state.UpdateBannerSnapshot()
+			if snap.HasUnreadUpdate(updatecheck.IsStrictlyNewer) {
+				badge = HealthBadgeUpdate
+			}
+		}
 	}
 
 	if collapsed {

--- a/internal/ui/notifications.go
+++ b/internal/ui/notifications.go
@@ -15,6 +15,24 @@ import (
 	"gioui.org/widget/material"
 )
 
+// NotifyAction is an optional button rendered next to an error/info banner.
+// ID is a stable identifier used by tests and slog. Label is the button text.
+// Run is invoked from HandleUserInteractions (the UI render goroutine) — it
+// MUST spawn its own goroutine for any blocking work, and any UIState
+// mutation must go through the existing UIState helpers (which lock and
+// invalidate internally). Mirrors the convention every other click handler
+// uses, and the field shape of health.Action so a future merge is mechanical.
+type NotifyAction struct {
+	ID    string
+	Label string
+	Run   func()
+}
+
+// HasRun reports whether the action carries a non-nil runner. The zero
+// value of NotifyAction is "no action" — callers pass it to ShowError
+// equivalents to mean "render plain banner."
+func (a NotifyAction) HasRun() bool { return a.Run != nil }
+
 // NotificationType determines the visual style of a notification.
 type NotificationType int
 

--- a/internal/ui/notifications_test.go
+++ b/internal/ui/notifications_test.go
@@ -1,0 +1,130 @@
+package ui
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestErrorBannerPlain(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	s.ShowError("boom")
+
+	got := s.ErrorBannerSnapshot()
+	if got.Message != "boom" {
+		t.Fatalf("Message = %q, want %q", got.Message, "boom")
+	}
+	if got.HasAction {
+		t.Fatalf("HasAction = true, want false")
+	}
+	if s.ActiveError() != "boom" {
+		t.Fatalf("ActiveError = %q, want %q", s.ActiveError(), "boom")
+	}
+}
+
+func TestErrorBannerWithActionRendersButton(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	s.ShowErrorWithAction("daemon down", NotifyAction{
+		ID:    "open-docker",
+		Label: "Show how",
+		Run:   func() {},
+	})
+
+	got := s.ErrorBannerSnapshot()
+	if !got.HasAction {
+		t.Fatalf("HasAction = false, want true")
+	}
+	if got.ActionID != "open-docker" {
+		t.Fatalf("ActionID = %q, want %q", got.ActionID, "open-docker")
+	}
+	if got.ActionLabel != "Show how" {
+		t.Fatalf("ActionLabel = %q, want %q", got.ActionLabel, "Show how")
+	}
+	if got.Busy {
+		t.Fatalf("Busy = true before trigger, want false")
+	}
+}
+
+func TestErrorBannerNilRunFallsBackToPlain(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	// Run==nil should be indistinguishable from ShowError.
+	s.ShowErrorWithAction("oops", NotifyAction{ID: "noop", Label: "Retry", Run: nil})
+	got := s.ErrorBannerSnapshot()
+	if got.HasAction {
+		t.Fatalf("HasAction = true with nil Run, want false")
+	}
+	if got.Message != "oops" {
+		t.Fatalf("Message = %q, want oops", got.Message)
+	}
+}
+
+func TestErrorBannerTriggerActionRunsOnceAndMarksBusy(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	var calls atomic.Int32
+	s.ShowErrorWithAction("port 80 is busy", NotifyAction{
+		ID:    "open-network",
+		Label: "Open Network",
+		Run: func() {
+			calls.Add(1)
+		},
+	})
+
+	if !s.TriggerErrorAction() {
+		t.Fatalf("TriggerErrorAction returned false on first call, want true")
+	}
+	// While busy, a second trigger must be a no-op.
+	if s.TriggerErrorAction() {
+		t.Fatalf("TriggerErrorAction returned true while busy, want false")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("Run invoked %d times, want 1", got)
+	}
+	got := s.ErrorBannerSnapshot()
+	if !got.Busy {
+		t.Fatalf("Busy = false after trigger, want true")
+	}
+}
+
+func TestErrorBannerClear(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	s.ShowErrorWithAction("transient", NotifyAction{ID: "x", Label: "Retry", Run: func() {}})
+	s.ClearErrorBanner()
+	if got := s.ErrorBannerSnapshot(); got.Message != "" {
+		t.Fatalf("after Clear, Message = %q, want empty", got.Message)
+	}
+	if s.TriggerErrorAction() {
+		t.Fatalf("TriggerErrorAction after Clear returned true, want false")
+	}
+}
+
+func TestErrorBannerExpires(t *testing.T) {
+	t.Parallel()
+	s := NewUIState()
+	s.ShowError("ephemeral")
+	// Force expiry by rewinding the clock-based field.
+	s.mu.Lock()
+	s.errorExpiry = time.Now().Add(-time.Second)
+	s.mu.Unlock()
+
+	if got := s.ActiveError(); got != "" {
+		t.Fatalf("ActiveError after expiry = %q, want empty", got)
+	}
+	if got := s.ErrorBannerSnapshot(); got.Message != "" {
+		t.Fatalf("Snapshot after expiry message = %q, want empty", got.Message)
+	}
+}
+
+func TestNotifyActionHasRun(t *testing.T) {
+	t.Parallel()
+	if (NotifyAction{}).HasRun() {
+		t.Fatalf("zero NotifyAction.HasRun() = true, want false")
+	}
+	if !(NotifyAction{Run: func() {}}).HasRun() {
+		t.Fatalf("NotifyAction{Run: f}.HasRun() = false, want true")
+	}
+}

--- a/internal/ui/privacycard.go
+++ b/internal/ui/privacycard.go
@@ -1,0 +1,81 @@
+package ui
+
+import (
+	"gioui.org/layout"
+	"gioui.org/unit"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+
+	settings "github.com/PeterBooker/locorum/internal/config"
+)
+
+// PrivacyCard is the Settings → Privacy panel: telemetry opt-in toggle
+// + reset-client-id button. Tied to the same KeyTelemetryOptIn /
+// KeyTelemetryClient settings that the first-launch modal flips, so a
+// user who declined at launch can come back here and opt in later (or
+// the reverse).
+//
+// Reset Telemetry ID clears the persisted client ID so the next event
+// generates a fresh one — useful when the user wants to disconnect
+// their session from prior history without disabling telemetry.
+type PrivacyCard struct {
+	state  *UIState
+	cfg    *settings.Config
+	toasts *Notifications
+
+	optIn       widget.Bool
+	resetIDBtn  widget.Clickable
+	syncedOptIn bool
+}
+
+func NewPrivacyCard(state *UIState, cfg *settings.Config, toasts *Notifications) *PrivacyCard {
+	p := &PrivacyCard{state: state, cfg: cfg, toasts: toasts}
+	if cfg != nil {
+		p.optIn.Value = cfg.TelemetryOptIn()
+		p.syncedOptIn = p.optIn.Value
+	}
+	return p
+}
+
+func (p *PrivacyCard) HandleUserInteractions(gtx layout.Context) {
+	if p.cfg == nil {
+		return
+	}
+	if p.optIn.Update(gtx) && p.optIn.Value != p.syncedOptIn {
+		p.syncedOptIn = p.optIn.Value
+		if err := p.cfg.SetTelemetryOptIn(p.optIn.Value); err != nil {
+			p.state.ShowError("Save telemetry preference: " + err.Error())
+		}
+	}
+	if p.resetIDBtn.Clicked(gtx) {
+		if err := p.cfg.SetTelemetryClientID(""); err != nil {
+			p.state.ShowError("Reset telemetry ID: " + err.Error())
+			return
+		}
+		p.toasts.ShowSuccess("Telemetry ID cleared — a fresh ID will be generated on the next opt-in event")
+	}
+}
+
+func (p *PrivacyCard) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	return panel(gtx, th, "Privacy", func(gtx layout.Context) layout.Dimensions {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				lbl := material.Body2(th.Theme, "Anonymous usage data helps us prioritise the right work. We never send file paths, URLs, or credentials.")
+				lbl.Color = th.Color.Fg2
+				lbl.TextSize = th.Sizes.Body
+				return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, lbl.Layout)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				cb := material.CheckBox(th.Theme, &p.optIn, "Send anonymous usage data")
+				cb.Color = th.Color.Fg
+				cb.IconColor = th.Color.Accent
+				cb.Size = unit.Dp(20)
+				cb.TextSize = th.Sizes.Body
+				return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, cb.Layout)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				return SecondaryButton(gtx, th, &p.resetIDBtn, "Reset Telemetry ID")
+			}),
+		)
+	})
+}

--- a/internal/ui/resetinfracard.go
+++ b/internal/ui/resetinfracard.go
@@ -1,0 +1,136 @@
+package ui
+
+import (
+	"context"
+	"sync/atomic"
+
+	"gioui.org/layout"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+
+	"github.com/PeterBooker/locorum/internal/sites"
+)
+
+// NewResetInfraCard builds the Diagnostics → "Reset Locorum
+// Infrastructure" card.
+//
+// resetFn does the actual wipe + bring-up. Wired from main.go to
+// app.App.ResetInfrastructure so the UI doesn't import internal/app.
+// reconcileFn marks every site as stopped after the wipe — the UI
+// passes sm.ReconcileState here so the site-list reflects reality.
+//
+// confirmation goes through a generic confirm dialog. While the action
+// is in flight the card disables the button (atomic guard) so a double-
+// click can't dispatch two resets at once. Errors surface as a toast
+// (via state.ShowError); success surfaces as a toast (via toasts.ShowSuccess).
+func NewResetInfraCard(state *UIState, sm *sites.SiteManager, toasts *Notifications, resetFn func(context.Context) error) *ResetInfraCard {
+	if resetFn == nil {
+		// A safety net: a nil resetFn means main.go forgot to wire the
+		// closure. Render the card disabled rather than crashing on click.
+		resetFn = func(context.Context) error { return errResetNotWired }
+	}
+
+	r := &resetInfraCardImpl{
+		state:   state,
+		sm:      sm,
+		toasts:  toasts,
+		resetFn: resetFn,
+	}
+	return &ResetInfraCard{
+		HandleUserInteractionsFn: r.HandleUserInteractions,
+		LayoutFn:                 r.Layout,
+	}
+}
+
+type resetInfraCardImpl struct {
+	state  *UIState
+	sm     *sites.SiteManager
+	toasts *Notifications
+
+	resetFn func(context.Context) error
+
+	openBtn     widget.Clickable
+	dialog      ConfirmDialog
+	confirmOpen bool
+	running     atomic.Bool
+}
+
+func (r *resetInfraCardImpl) HandleUserInteractions(gtx layout.Context) {
+	if r.openBtn.Clicked(gtx) && !r.running.Load() {
+		r.confirmOpen = true
+	}
+	if r.confirmOpen {
+		confirmed, cancelled := r.dialog.HandleUserInteractions(gtx)
+		if cancelled {
+			r.confirmOpen = false
+		}
+		if confirmed {
+			r.confirmOpen = false
+			r.run()
+		}
+	}
+}
+
+func (r *resetInfraCardImpl) run() {
+	if !r.running.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer r.running.Store(false)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if err := r.resetFn(ctx); err != nil {
+			r.state.ShowError("Reset failed: " + err.Error())
+			return
+		}
+		// Reflect the post-wipe truth in storage so the site list
+		// shows every site as stopped.
+		if r.sm != nil {
+			if err := r.sm.ReconcileState(); err != nil {
+				r.state.ShowError("Reset succeeded, but reconcile failed: " + err.Error())
+				return
+			}
+		}
+		r.toasts.ShowSuccess("Locorum infrastructure reset")
+		r.state.Invalidate()
+	}()
+}
+
+func (r *resetInfraCardImpl) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	return panel(gtx, th, "Reset Locorum Infrastructure", func(gtx layout.Context) layout.Dimensions {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				lbl := material.Body2(th.Theme, "Stop and recreate the global router, mail, and adminer containers. All running sites will be stopped. DB volumes are kept — site data is safe.")
+				lbl.Color = th.Color.Fg2
+				lbl.TextSize = th.Sizes.Body
+				return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, lbl.Layout)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				if r.running.Load() {
+					return Loader(gtx, th, th.Dims.LoaderSizeSM)
+				}
+				return DangerButton(gtx, th, &r.openBtn, "Reset Locorum Infrastructure")
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				if !r.confirmOpen {
+					return layout.Dimensions{}
+				}
+				return r.dialog.Layout(gtx, th, ConfirmDialogStyle{
+					Title:        "Reset infrastructure?",
+					Message:      "All running sites will be stopped. The router, mail, and adminer containers will be recreated. DB volumes are kept — site data is safe. Proceed?",
+					ConfirmLabel: "Reset",
+					ConfirmColor: th.Color.Err,
+				})
+			}),
+		)
+	})
+}
+
+// errResetNotWired is the safety-net error returned by NewResetInfraCard
+// when no resetFn was provided. Should never reach the user in a
+// correctly-wired build.
+var errResetNotWired = errResetNotWiredError{}
+
+type errResetNotWiredError struct{}
+
+func (errResetNotWiredError) Error() string { return "reset: not wired (developer error)" }

--- a/internal/ui/settingspanel.go
+++ b/internal/ui/settingspanel.go
@@ -25,10 +25,12 @@ import (
 // validated changes back through the typed setters. Validation errors
 // surface as a transient toast — never an uncaught panic.
 type SettingsPanel struct {
-	state         *UIState
-	sm            *sites.SiteManager
-	onThemeChange func(ThemeMode)
-	healthPanel   *HealthPanel
+	state           *UIState
+	sm              *sites.SiteManager
+	onThemeChange   func(ThemeMode)
+	healthPanel     *HealthPanel
+	diagnosticPanel *DiagnosticsPanel
+	privacyCard     *PrivacyCard
 
 	themeEnum widget.Enum
 	syncedTo  string // remembers which value we last seeded from settings
@@ -121,6 +123,18 @@ func NewSettingsPanel(state *UIState, sm *sites.SiteManager, onThemeChange func(
 // nil and the section is omitted from the layout.
 func (s *SettingsPanel) SetHealthPanel(hp *HealthPanel) { s.healthPanel = hp }
 
+// SetDiagnosticsPanel wires the Diagnostics card. Optional — when nil
+// the card is omitted from the layout.
+func (s *SettingsPanel) SetDiagnosticsPanel(dp *DiagnosticsPanel) { s.diagnosticPanel = dp }
+
+// SetPrivacyCard wires the Privacy card. Optional — when nil the card
+// is omitted (e.g. tests that don't construct a Config).
+func (s *SettingsPanel) SetPrivacyCard(p *PrivacyCard) { s.privacyCard = p }
+
+// DiagnosticsPanel returns the wired panel (or nil). Used by main.go
+// to fill in the §7.4 and §7.6 sub-cards once their subsystems exist.
+func (s *SettingsPanel) DiagnosticsPanel() *DiagnosticsPanel { return s.diagnosticPanel }
+
 // HandleUserInteractions watches the theme picker for selection
 // changes, syncs the engine→version dropdown, and persists any changed
 // defaults.
@@ -137,6 +151,12 @@ func (s *SettingsPanel) HandleUserInteractions(gtx layout.Context) {
 	s.persistDefaults(gtx)
 	if s.healthPanel != nil {
 		s.healthPanel.HandleUserInteractions(gtx)
+	}
+	if s.diagnosticPanel != nil {
+		s.diagnosticPanel.HandleUserInteractions(gtx)
+	}
+	if s.privacyCard != nil {
+		s.privacyCard.HandleUserInteractions(gtx)
 	}
 }
 
@@ -291,6 +311,18 @@ func (s *SettingsPanel) Layout(gtx layout.Context, th *Theme) layout.Dimensions 
 				}),
 				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 					return s.layoutNetworkAndTLS(gtx, th)
+				}),
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					if s.diagnosticPanel == nil {
+						return layout.Dimensions{}
+					}
+					return s.diagnosticPanel.Layout(gtx, th)
+				}),
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					if s.privacyCard == nil {
+						return layout.Dimensions{}
+					}
+					return s.privacyCard.Layout(gtx, th)
 				}),
 			)
 		})

--- a/internal/ui/sitedetail.go
+++ b/internal/ui/sitedetail.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"image"
 	"strings"
 	"time"
@@ -15,9 +16,11 @@ import (
 	"gioui.org/widget/material"
 	"github.com/sqweek/dialog"
 
+	"github.com/PeterBooker/locorum/internal/docker"
 	"github.com/PeterBooker/locorum/internal/sites"
 	"github.com/PeterBooker/locorum/internal/storage"
 	"github.com/PeterBooker/locorum/internal/types"
+	"github.com/PeterBooker/locorum/internal/utils"
 )
 
 const (
@@ -93,6 +96,12 @@ type SiteDetail struct {
 	// goroutine on every frame for the same site.
 	recentActivityLoadedFor string
 
+	// describeCache caches sm.Describe results so Layout never blocks on
+	// SQLite/Docker. Refreshed on site mount, OnSiteUpdated, plan
+	// completion, and DB-credentials card open.
+	describeCache *DescribeCache
+	copyJSONBtn   widget.Clickable
+
 	// Docker init error
 	retryInitBtn widget.Clickable
 }
@@ -116,10 +125,15 @@ func NewSiteDetail(state *UIState, sm *sites.SiteManager, toasts *Notifications)
 		activityTab:    NewActivityTab(state, sm),
 		profilingPanel: NewProfilingPanel(state, sm, toasts),
 	}
+	sd.describeCache = NewDescribeCache(sm, state)
 	sd.list.List.Axis = layout.Vertical
 	sd.publicDirEditor.SingleLine = true
 	return sd
 }
+
+// DescribeCache exposes the per-site description cache so other panels
+// (DB credentials' "include host port" toggle) can request a refresh.
+func (sd *SiteDetail) DescribeCache() *DescribeCache { return sd.describeCache }
 
 // HooksPanel exposes the hooks tab so the root UI can render its modal
 // overlays above the main chrome.
@@ -149,11 +163,20 @@ func (sd *SiteDetail) HandleUserInteractions(gtx layout.Context) {
 		}
 	}
 
+	// Warm the describe cache the first time we observe a site (or when
+	// the user switches to a different one). The describe cache itself
+	// debounces to one in-flight load per siteID.
+	sd.describeCache.Get(site.ID, false)
+
 	sd.handleHeaderActions(gtx, site)
 
 	// Per-tab interactions.
 	switch sd.activeTab {
 	case tabDatabase:
+		// Opening the Database tab implies the user cares about the
+		// published host port — re-warm the describe cache with that
+		// flag so the next "Copy as JSON" click ships HostPort.
+		sd.describeCache.Get(site.ID, true)
 		sd.dbCreds.HandleUserInteractions(gtx, site)
 		sd.snapshotsPanel.HandleUserInteractions(gtx, site)
 	case tabUtilities:
@@ -286,6 +309,12 @@ func (sd *SiteDetail) layoutHeaderActions(gtx layout.Context, th *Theme, site *t
 				return layout.Spacer{Width: unit.Dp(8)}.Layout(gtx)
 			}),
 			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				return th.Small(gtx, &sd.copyJSONBtn, "Copy as JSON")
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				return layout.Spacer{Width: unit.Dp(8)}.Layout(gtx)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 				if toggling {
 					return Loader(gtx, th, th.Dims.LoaderSizeSM)
 				}
@@ -331,6 +360,12 @@ func (sd *SiteDetail) layoutHeaderActions(gtx layout.Context, th *Theme, site *t
 			return layout.Spacer{Width: unit.Dp(8)}.Layout(gtx)
 		}),
 		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			return th.Small(gtx, &sd.copyJSONBtn, "Copy as JSON")
+		}),
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			return layout.Spacer{Width: unit.Dp(8)}.Layout(gtx)
+		}),
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 			if toggling {
 				return Loader(gtx, th, th.Dims.LoaderSizeSM)
 			}
@@ -345,28 +380,39 @@ func (sd *SiteDetail) handleHeaderActions(gtx layout.Context, site *types.Site) 
 		id := site.ID
 		sd.state.SetSiteToggling(id, true)
 		go func() {
-			if err := sd.sm.StartSite(context.Background(), id); err != nil {
-				sd.state.ShowError("Failed to start site: " + err.Error())
-			}
+			err := sd.sm.StartSite(context.Background(), id)
 			sd.state.SetSiteToggling(id, false)
+			SurfaceError(sd.state, "Failed to start site", err, nil)
 		}()
 	}
 	if sd.stopBtn.Clicked(gtx) && site.Started {
 		id := site.ID
 		sd.state.SetSiteToggling(id, true)
 		go func() {
-			if err := sd.sm.StopSite(context.Background(), id); err != nil {
-				sd.state.ShowError("Failed to stop site: " + err.Error())
-			}
+			err := sd.sm.StopSite(context.Background(), id)
 			sd.state.SetSiteToggling(id, false)
+			SurfaceError(sd.state, "Failed to stop site", err, nil)
 		}()
 	}
 	if sd.shellBtn.Clicked(gtx) && site.Started {
 		id := site.ID
+		slug := site.Slug
 		go func() {
-			if err := sd.sm.OpenSiteShell(id); err != nil {
-				sd.state.ShowError("Failed to open shell: " + err.Error())
+			err := sd.sm.OpenSiteShell(id)
+			if err == nil {
+				return
 			}
+			if errors.Is(err, utils.ErrNoTerminal) {
+				// No terminal launcher detected on PATH. Surface the
+				// command so the user can copy/paste it into the
+				// terminal of their choice.
+				cmd := "docker exec -it " + docker.SiteContainerName(slug, "php") + " /bin/bash"
+				sd.toasts.ShowInfo("No terminal found — run: " + cmd)
+				return
+			}
+			SurfaceError(sd.state, "Failed to open shell", err, func() {
+				_ = sd.sm.StartSite(context.Background(), id)
+			})
 		}()
 	}
 	if sd.filesBtn.Clicked(gtx) {
@@ -388,9 +434,10 @@ func (sd *SiteDetail) handleHeaderActions(gtx layout.Context, site *types.Site) 
 	if sd.openAdminBtn.Clicked(gtx) && site.Started {
 		id := site.ID
 		go func() {
-			if err := sd.sm.OpenAdminLogin(id); err != nil {
-				sd.state.ShowError("Failed to open admin: " + err.Error())
-			}
+			err := sd.sm.OpenAdminLogin(id)
+			SurfaceError(sd.state, "Failed to open admin", err, func() {
+				_ = sd.sm.StartSite(context.Background(), id)
+			})
 		}()
 	}
 	if sd.openSiteBtn.Clicked(gtx) && site.Started {
@@ -404,6 +451,20 @@ func (sd *SiteDetail) handleHeaderActions(gtx layout.Context, site *types.Site) 
 
 	if sd.cloneBtn.Clicked(gtx) {
 		sd.state.ShowCloneModal(site.ID, site.Name)
+	}
+	if sd.copyJSONBtn.Clicked(gtx) {
+		// Force a refresh to grab the latest description, including the
+		// host port if that toggle ever got opened on this site. The
+		// cached value is what we copy — async refresh fills the gap on
+		// the next click if cache was empty.
+		body := sd.describeCache.AsJSON(site.ID)
+		if body == "" {
+			sd.toasts.ShowInfo("Site description still loading — try again in a moment")
+			sd.describeCache.Get(site.ID, false)
+		} else {
+			CopyToClipboard(gtx, body)
+			sd.toasts.ShowSuccess("Site description copied as JSON")
+		}
 	}
 	if sd.exportBtn.Clicked(gtx) && site.Started {
 		id := site.ID

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -61,8 +61,12 @@ type UIState struct {
 	siteToggling map[string]bool // site ID -> whether start/stop is in progress
 
 	// Error banner state
-	errorMessage string
-	errorExpiry  time.Time
+	errorMessage     string
+	errorExpiry      time.Time
+	errorActionID    string
+	errorActionLabel string
+	errorActionRun   func()
+	errorActionBusy  bool
 
 	// Delete confirmation modal
 	showDeleteConfirm bool
@@ -148,6 +152,16 @@ type UIState struct {
 	// surfaced by the disk-low check. Zero before the first reading.
 	// Guarded by mu (top-level UIState mutex) — same as servicesHealth.
 	diskFreeBytes int64
+
+	// updateAvailable / updateURL / updateNotes / updateDismissed
+	// snapshot the latest update-check result for the Settings card and
+	// the nav rail dot. Empty updateAvailable = no banner; non-empty
+	// + matches updateDismissed = also no banner (user clicked "Dismiss
+	// this version"). Compared as semver via the updatecheck package.
+	updateAvailable string
+	updateURL       string
+	updateNotes     string
+	updateDismissed string
 }
 
 // activitySiteCache mirrors a slice of recent activity rows for one site.
@@ -352,6 +366,63 @@ func (s *UIState) HealthHydrateSeen(keys []string) {
 	s.healthSeenMu.Unlock()
 }
 
+// ─── Update-check banner ────────────────────────────────────────────────────
+
+// UpdateBannerSnapshot is a frame-stable copy of the update-check state
+// for the Settings → Diagnostics card and the nav rail dot.
+type UpdateBannerSnapshot struct {
+	Available string // version string (empty = no upgrade)
+	URL       string
+	Notes     string
+	Dismissed string
+}
+
+// HasUnreadUpdate reports whether there's an upgrade available that the
+// user has not already dismissed. Comparison is delegated to the caller
+// (updatecheck.IsStrictlyNewer) so this package stays semver-blind.
+// Cheap; safe to call from the nav rail every frame.
+func (u UpdateBannerSnapshot) HasUnreadUpdate(newer func(latest, dismissed string) bool) bool {
+	if u.Available == "" {
+		return false
+	}
+	if u.Dismissed == "" {
+		return true
+	}
+	return newer(u.Available, u.Dismissed)
+}
+
+// SetUpdateAvailable publishes the latest update-check answer.
+func (s *UIState) SetUpdateAvailable(version, url, notes string) {
+	s.mu.Lock()
+	s.updateAvailable = version
+	s.updateURL = url
+	s.updateNotes = notes
+	s.mu.Unlock()
+	s.Invalidate()
+}
+
+// SetUpdateDismissed records the version the user has clicked
+// "Dismiss this version" on. Call after the persisted setting has
+// been written, so the in-memory snapshot stays consistent.
+func (s *UIState) SetUpdateDismissed(version string) {
+	s.mu.Lock()
+	s.updateDismissed = version
+	s.mu.Unlock()
+	s.Invalidate()
+}
+
+// UpdateBannerSnapshot returns the current update-check state.
+func (s *UIState) UpdateBannerSnapshot() UpdateBannerSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return UpdateBannerSnapshot{
+		Available: s.updateAvailable,
+		URL:       s.updateURL,
+		Notes:     s.updateNotes,
+		Dismissed: s.updateDismissed,
+	}
+}
+
 // SetDiskFreeBytes stores the most recent host-filesystem free-byte reading
 // for the top status bar. The runner publishes this via the disk-low check;
 // main.go pulls it out and pushes here on the same cadence the services-
@@ -504,21 +575,69 @@ func (s *UIState) IsSiteToggling(id string) bool {
 
 // ─── Error Banner ───────────────────────────────────────────────────────────
 
+// errorBannerTTL caps how long an error banner stays visible before
+// auto-dismiss. Banners with an action button stay longer because the user
+// has to read, understand, and click — eight seconds isn't enough.
+const (
+	errorBannerTTL       = 8 * time.Second
+	errorBannerActionTTL = 30 * time.Second
+)
+
+// ErrorBannerSnapshot is a frame-stable copy of the error banner state.
+// The Layout pass reads it once per frame so it can render the message and
+// (optionally) an action button without holding the state mutex.
+type ErrorBannerSnapshot struct {
+	Message     string
+	ActionID    string
+	ActionLabel string
+	HasAction   bool
+	Busy        bool
+}
+
 // ShowError sets the error banner message with an 8-second auto-dismiss.
+// Any prior action button is cleared — call ShowErrorWithAction if you
+// want a button.
 func (s *UIState) ShowError(msg string) {
+	s.setError(msg, NotifyAction{}, errorBannerTTL)
+}
+
+// ShowErrorWithAction sets the error banner with an optional action
+// button. The TTL is 30 s (vs 8 s for plain errors) to give the user time
+// to act. If a.Run is nil the call behaves identically to ShowError.
+func (s *UIState) ShowErrorWithAction(msg string, a NotifyAction) {
+	ttl := errorBannerTTL
+	if a.HasRun() {
+		ttl = errorBannerActionTTL
+	}
+	s.setError(msg, a, ttl)
+}
+
+func (s *UIState) setError(msg string, a NotifyAction, ttl time.Duration) {
 	s.mu.Lock()
 	s.errorMessage = msg
-	s.errorExpiry = time.Now().Add(8 * time.Second)
+	s.errorExpiry = time.Now().Add(ttl)
+	if a.HasRun() {
+		s.errorActionID = a.ID
+		s.errorActionLabel = a.Label
+		s.errorActionRun = a.Run
+	} else {
+		s.errorActionID = ""
+		s.errorActionLabel = ""
+		s.errorActionRun = nil
+	}
+	s.errorActionBusy = false
 	s.mu.Unlock()
 	s.Invalidate()
 
 	go func() {
-		time.Sleep(8 * time.Second)
+		time.Sleep(ttl)
 		s.Invalidate()
 	}()
 }
 
 // ActiveError returns the current error message if it hasn't expired, or "".
+// Preserved for callers that don't care about the action button. New code
+// should prefer ErrorBannerSnapshot.
 func (s *UIState) ActiveError() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -527,9 +646,73 @@ func (s *UIState) ActiveError() string {
 	}
 	if time.Now().After(s.errorExpiry) {
 		s.errorMessage = ""
+		s.errorActionID = ""
+		s.errorActionLabel = ""
+		s.errorActionRun = nil
+		s.errorActionBusy = false
 		return ""
 	}
 	return s.errorMessage
+}
+
+// ErrorBannerSnapshot returns a frame-stable snapshot of the banner state.
+// The Run callback is intentionally not exposed — callers wire clicks
+// through TriggerErrorAction so the busy-flag handshake stays atomic.
+func (s *UIState) ErrorBannerSnapshot() ErrorBannerSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.errorMessage == "" {
+		return ErrorBannerSnapshot{}
+	}
+	if time.Now().After(s.errorExpiry) {
+		s.errorMessage = ""
+		s.errorActionID = ""
+		s.errorActionLabel = ""
+		s.errorActionRun = nil
+		s.errorActionBusy = false
+		return ErrorBannerSnapshot{}
+	}
+	return ErrorBannerSnapshot{
+		Message:     s.errorMessage,
+		ActionID:    s.errorActionID,
+		ActionLabel: s.errorActionLabel,
+		HasAction:   s.errorActionRun != nil,
+		Busy:        s.errorActionBusy,
+	}
+}
+
+// TriggerErrorAction atomically claims the busy slot and invokes the
+// banner's action callback. Returns true if an action was started, false
+// when no callback is registered or one is already in flight. The action
+// is responsible for clearing its own busy state via ClearErrorBanner
+// when it completes (success) or by leaving the banner visible until
+// auto-dismiss (failure).
+func (s *UIState) TriggerErrorAction() bool {
+	s.mu.Lock()
+	if s.errorActionRun == nil || s.errorActionBusy {
+		s.mu.Unlock()
+		return false
+	}
+	s.errorActionBusy = true
+	action := s.errorActionRun
+	s.mu.Unlock()
+	s.Invalidate()
+	action()
+	return true
+}
+
+// ClearErrorBanner immediately dismisses the error banner. Called from
+// action callbacks after they've kicked off the requested follow-up work
+// (e.g. starting a site) so the banner doesn't hang around.
+func (s *UIState) ClearErrorBanner() {
+	s.mu.Lock()
+	s.errorMessage = ""
+	s.errorActionID = ""
+	s.errorActionLabel = ""
+	s.errorActionRun = nil
+	s.errorActionBusy = false
+	s.mu.Unlock()
+	s.Invalidate()
 }
 
 // ─── Delete Confirmation ────────────────────────────────────────────────────

--- a/internal/ui/telemetrymodal.go
+++ b/internal/ui/telemetrymodal.go
@@ -1,0 +1,130 @@
+package ui
+
+import (
+	"gioui.org/font"
+	"gioui.org/layout"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+
+	settings "github.com/PeterBooker/locorum/internal/config"
+	"github.com/PeterBooker/locorum/internal/utils"
+)
+
+// telemetryPrivacyURL is the placeholder link surfaced by the modal's
+// "Read privacy doc" button. The doc itself is gated on UX.md §13 — until
+// it lands, the URL points at the repo so users at least see the canonical
+// project page.
+const telemetryPrivacyURL = "https://github.com/PeterBooker/locorum#telemetry"
+
+// TelemetryModal is the first-launch opt-in dialog. Shown once per
+// install (gated on KeyTelemetryDecided). The user has three choices:
+// Opt in, Decline, or Read privacy doc. Any of the first two flips
+// KeyTelemetryDecided=true and persists the chosen TelemetryOptIn; the
+// privacy doc opens an external URL without dismissing the modal so the
+// user can read and then choose.
+type TelemetryModal struct {
+	state *UIState
+	cfg   *settings.Config
+
+	optIn   widget.Clickable
+	decline widget.Clickable
+	docs    widget.Clickable
+
+	anim *modalShowState
+}
+
+// NewTelemetryModal binds the modal to the persistent settings store
+// and the UI state. Pass nil cfg in tests; the buttons then update only
+// the in-memory state and never touch storage.
+func NewTelemetryModal(state *UIState, cfg *settings.Config) *TelemetryModal {
+	return &TelemetryModal{state: state, cfg: cfg, anim: NewModalAnim()}
+}
+
+// Show reports whether the modal should render this frame. True only on
+// first launch (KeyTelemetryDecided still false). When cfg is nil the
+// modal is permanently hidden — a defensive default for tests.
+func (m *TelemetryModal) Show() bool {
+	if m.cfg == nil {
+		return false
+	}
+	return !m.cfg.TelemetryDecided()
+}
+
+// HandleUserInteractions reads the three button clicks. Returns true
+// when the modal should be torn down (the user clicked Opt-in or
+// Decline). The caller can then trigger a redraw / unmount.
+func (m *TelemetryModal) HandleUserInteractions(gtx layout.Context) bool {
+	if !m.Show() {
+		return false
+	}
+	if m.docs.Clicked(gtx) {
+		_ = utils.OpenURL(telemetryPrivacyURL)
+		// Don't dismiss — the user is reading the policy.
+	}
+	if m.optIn.Clicked(gtx) {
+		m.persistDecision(true)
+		return true
+	}
+	if m.decline.Clicked(gtx) {
+		m.persistDecision(false)
+		return true
+	}
+	return false
+}
+
+func (m *TelemetryModal) persistDecision(optIn bool) {
+	if m.cfg == nil {
+		return
+	}
+	if err := m.cfg.SetTelemetryOptIn(optIn); err != nil {
+		m.state.ShowError("Save telemetry choice: " + err.Error())
+		return
+	}
+	if err := m.cfg.SetTelemetryDecided(true); err != nil {
+		m.state.ShowError("Save telemetry choice: " + err.Error())
+		return
+	}
+	m.state.Invalidate()
+}
+
+// Layout renders the modal over the supplied gtx. Caller is responsible
+// for only calling this when Show() reports true; layering it under
+// Stack/Stacked in the root layout preserves the existing modal shape.
+func (m *TelemetryModal) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	m.anim.Show()
+	return AnimatedModalOverlay(gtx, th, m.anim, func(gtx layout.Context) layout.Dimensions {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				lbl := material.H6(th.Theme, "Help improve Locorum?")
+				lbl.Color = th.Color.Fg
+				lbl.Font.Weight = font.SemiBold
+				return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, lbl.Layout)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				body := "Locorum can send anonymous usage data — site lifecycle counts, feature use, and crash reports — so we can prioritise the right work. We never send file paths, URLs, or credentials."
+				lbl := material.Body2(th.Theme, body)
+				lbl.Color = th.Color.Fg2
+				lbl.TextSize = th.Sizes.Body
+				return layout.Inset{Bottom: th.Spacing.MD}.Layout(gtx, lbl.Layout)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return PrimaryButton(gtx, th, &m.optIn, "Opt in")
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return layout.Inset{Left: th.Spacing.SM}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+							return SecondaryButton(gtx, th, &m.decline, "Decline")
+						})
+					}),
+					layout.Flexed(1, func(gtx layout.Context) layout.Dimensions {
+						return layout.Dimensions{Size: gtx.Constraints.Min}
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return th.Small(gtx, &m.docs, "Read privacy doc")
+					}),
+				)
+			}),
+		)
+	})
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -34,11 +34,14 @@ type UI struct {
 	// Modals
 	CloneModal    *CloneModal
 	HealthBlocker *HealthBlockerModal
+	Telemetry     *TelemetryModal
 	deleteDialog  ConfirmDialog
 	deletePurge   widget.Bool
 
-	// Banner action button (e.g. "Set up trusted HTTPS").
+	// Banner action buttons. noticeBtn is the persistent info banner;
+	// errorBtn is the transient error banner's optional action.
 	noticeBtn widget.Clickable
+	errorBtn  widget.Clickable
 }
 
 func New(sm *sites.SiteManager) *UI {
@@ -66,9 +69,14 @@ func New(sm *sites.SiteManager) *UI {
 		}
 		state.Invalidate()
 	})
+	ui.Settings.SetDiagnosticsPanel(NewDiagnosticsPanel(state, sm, ui.Toasts))
+	if cfg != nil {
+		ui.Settings.SetPrivacyCard(NewPrivacyCard(state, cfg, ui.Toasts))
+	}
 	ui.SiteDetail = NewSiteDetail(state, sm, ui.Toasts)
 	ui.NewSite = NewNewSiteModal(state, sm, ui.Toasts)
 	ui.CloneModal = NewCloneModal(state, sm, ui.Toasts)
+	ui.Telemetry = NewTelemetryModal(state, cfg)
 
 	// Wire up backend callbacks to update UI state
 	sm.OnSitesUpdated = func(updatedSites []types.Site) {
@@ -76,6 +84,9 @@ func New(sm *sites.SiteManager) *UI {
 	}
 	sm.OnSiteUpdated = func(site *types.Site) {
 		state.UpdateSite(*site)
+		if dc := ui.SiteDetail.DescribeCache(); dc != nil {
+			dc.Invalidate(site.ID)
+		}
 	}
 
 	// Hook callbacks update the live-output panel.
@@ -93,6 +104,9 @@ func New(sm *sites.SiteManager) *UI {
 	}
 	sm.OnPlanDone = func(siteID string, r orch.Result) {
 		state.LifecyclePlanDone(siteID, r)
+		if dc := ui.SiteDetail.DescribeCache(); dc != nil {
+			dc.Invalidate(siteID)
+		}
 	}
 	sm.OnPullProgress = func(siteID string, p docker.PullProgress) {
 		state.LifecyclePullProgress(siteID, p)
@@ -134,12 +148,15 @@ func (ui *UI) HandleUserInteractions(gtx layout.Context) {
 	if ui.HealthBlocker != nil && ui.HealthBlocker.HasBlocker() {
 		ui.HealthBlocker.HandleUserInteractions(gtx)
 	}
+	if ui.Telemetry != nil && ui.Telemetry.Show() {
+		ui.Telemetry.HandleUserInteractions(gtx)
+	}
 }
 
 func (ui *UI) Layout(gtx layout.Context) layout.Dimensions {
 	ui.HandleUserInteractions(gtx)
 
-	errMsg := ui.State.ActiveError()
+	errBanner := ui.State.ErrorBannerSnapshot()
 	notice := ui.State.NoticeSnapshot()
 
 	return layout.Stack{}.Layout(gtx,
@@ -155,10 +172,10 @@ func (ui *UI) Layout(gtx layout.Context) layout.Dimensions {
 					return ui.layoutNoticeBanner(gtx, notice)
 				}),
 				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-					if errMsg == "" {
+					if errBanner.Message == "" {
 						return layout.Dimensions{}
 					}
-					return ui.layoutErrorBanner(gtx, errMsg)
+					return ui.layoutErrorBanner(gtx, errBanner)
 				}),
 				layout.Flexed(1, func(gtx layout.Context) layout.Dimensions {
 					return ui.layoutColumns(gtx)
@@ -184,6 +201,12 @@ func (ui *UI) Layout(gtx layout.Context) layout.Dimensions {
 			// after the regular modal layer so it sits on top.
 			if ui.HealthBlocker != nil && ui.HealthBlocker.HasBlocker() {
 				return ui.HealthBlocker.Layout(gtx, ui.Theme)
+			}
+			return layout.Dimensions{}
+		}),
+		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+			if ui.Telemetry != nil && ui.Telemetry.Show() {
+				return ui.Telemetry.Layout(gtx, ui.Theme)
 			}
 			return layout.Dimensions{}
 		}),
@@ -261,17 +284,36 @@ func (ui *UI) layoutDeleteConfirm(gtx layout.Context, th *Theme, siteName string
 	})
 }
 
-func (ui *UI) layoutErrorBanner(gtx layout.Context, msg string) layout.Dimensions {
+func (ui *UI) layoutErrorBanner(gtx layout.Context, b ErrorBannerSnapshot) layout.Dimensions {
 	th := ui.Theme
+	if ui.errorBtn.Clicked(gtx) && b.HasAction && !b.Busy {
+		ui.State.TriggerErrorAction()
+	}
 	return FillBackground(gtx, th.Color.DangerBg, func(gtx layout.Context) layout.Dimensions {
 		return layout.Inset{
 			Top: unit.Dp(10), Bottom: unit.Dp(10),
 			Left: th.Spacing.LG, Right: th.Spacing.LG,
 		}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
-			lbl := material.Body2(th.Theme, msg)
-			lbl.Color = th.Color.DangerFg
-			lbl.TextSize = th.Sizes.Body
-			return lbl.Layout(gtx)
+			return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
+				layout.Flexed(1, func(gtx layout.Context) layout.Dimensions {
+					lbl := material.Body2(th.Theme, b.Message)
+					lbl.Color = th.Color.DangerFg
+					lbl.TextSize = th.Sizes.Body
+					return lbl.Layout(gtx)
+				}),
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					if !b.HasAction {
+						return layout.Dimensions{}
+					}
+					return layout.Inset{Left: th.Spacing.MD}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+						label := b.ActionLabel
+						if b.Busy {
+							label = "Working…"
+						}
+						return th.SmallGated(gtx, &ui.errorBtn, label, !b.Busy)
+					})
+				}),
+			)
 		})
 	})
 }

--- a/internal/ui/updatebannercard.go
+++ b/internal/ui/updatebannercard.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"gioui.org/layout"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+
+	settings "github.com/PeterBooker/locorum/internal/config"
+	"github.com/PeterBooker/locorum/internal/updatecheck"
+	"github.com/PeterBooker/locorum/internal/utils"
+)
+
+// NewUpdateBannerCard builds the Diagnostics → "Update available" sub-
+// card. The card only renders when:
+//
+//   - state.UpdateBannerSnapshot().Available is non-empty AND
+//   - the available version is strictly newer than the dismissed one.
+//
+// onDismiss is called with the available version string after a click —
+// it must persist via cfg.SetUpdateDismissedVersion AND call
+// state.SetUpdateDismissed so the in-memory snapshot stays consistent.
+// onView opens the release URL in the user's default browser.
+//
+// cfg is captured for the dismiss writeback. Pass nil during tests; the
+// card then no-ops the dismiss button persistence step (the in-memory
+// snapshot still updates).
+func NewUpdateBannerCard(state *UIState, cfg *settings.Config) *UpdateBannerCard {
+	u := &updateBannerImpl{state: state, cfg: cfg}
+	return &UpdateBannerCard{
+		HandleUserInteractionsFn: u.HandleUserInteractions,
+		LayoutFn:                 u.Layout,
+	}
+}
+
+type updateBannerImpl struct {
+	state *UIState
+	cfg   *settings.Config
+
+	viewBtn    widget.Clickable
+	dismissBtn widget.Clickable
+}
+
+func (u *updateBannerImpl) HandleUserInteractions(gtx layout.Context) {
+	snap := u.state.UpdateBannerSnapshot()
+	if !snap.HasUnreadUpdate(updatecheck.IsStrictlyNewer) {
+		return
+	}
+	if u.viewBtn.Clicked(gtx) && snap.URL != "" {
+		_ = utils.OpenURL(snap.URL)
+	}
+	if u.dismissBtn.Clicked(gtx) {
+		if u.cfg != nil {
+			_ = u.cfg.SetUpdateDismissedVersion(snap.Available)
+		}
+		u.state.SetUpdateDismissed(snap.Available)
+	}
+}
+
+func (u *updateBannerImpl) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	snap := u.state.UpdateBannerSnapshot()
+	if !snap.HasUnreadUpdate(updatecheck.IsStrictlyNewer) {
+		return layout.Dimensions{}
+	}
+	return panel(gtx, th, "Update available", func(gtx layout.Context) layout.Dimensions {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				lbl := material.Body2(th.Theme, "Locorum v"+snap.Available+" is available.")
+				lbl.Color = th.Color.Fg
+				lbl.TextSize = th.Sizes.Body
+				return layout.Inset{Bottom: th.Spacing.SM}.Layout(gtx, lbl.Layout)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return PrimaryButton(gtx, th, &u.viewBtn, "View release notes")
+					}),
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return layout.Inset{Left: th.Spacing.SM}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+							return SecondaryButton(gtx, th, &u.dismissBtn, "Dismiss this version")
+						})
+					}),
+				)
+			}),
+		)
+	})
+}

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -1,0 +1,317 @@
+// Package updatecheck queries GitHub Releases for newer versions of
+// Locorum and persists the answer between launches. The result feeds the
+// Settings → Diagnostics card and the small badge on the nav rail
+// Settings entry.
+//
+// Design choices:
+//   - One HTTP call per launch (gated by mtime throttle) — no chatty
+//     background polling.
+//   - No auto-update; the user clicks "Download" which opens the
+//     release page in the default browser. Signed-binary distribution
+//     is enough friction for v1.
+//   - Channel = stable | beta. Stable picks the highest semver with no
+//     prerelease tag; beta accepts any tag.
+//   - Tiny semver compare lives here so we don't pull
+//     golang.org/x/mod/semver for three-component compares.
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultRepoOwner / DefaultRepoName point at the canonical Locorum
+// release stream. Overridable via Options.RepoOwner/RepoName for test or
+// for a future fork.
+const (
+	DefaultRepoOwner = "PeterBooker"
+	DefaultRepoName  = "locorum"
+)
+
+// Channel is the user's desired release stream.
+type Channel string
+
+const (
+	ChannelStable Channel = "stable"
+	ChannelBeta   Channel = "beta"
+)
+
+// throttle caps how often we call the GitHub API. Four hours is more
+// than long enough for "check on app start" UX while keeping us well
+// under the 60 unauthenticated requests/hour budget.
+const throttle = 4 * time.Hour
+
+// httpTimeout caps a single fetch.
+const httpTimeout = 10 * time.Second
+
+// userAgent identifies the client. GitHub requires a User-Agent on
+// every API request; sending the version helps debugging.
+var userAgent = "locorum-updatecheck/1"
+
+// Result is what Check returns: the latest version string (semver
+// without a leading "v"), the URL to the release page, and the
+// human-readable release notes. All fields are empty when no upgrade
+// is available.
+type Result struct {
+	Latest string
+	URL    string
+	Notes  string
+}
+
+// Options controls Check. Zero values pick sensible defaults.
+type Options struct {
+	RepoOwner string
+	RepoName  string
+	Channel   Channel
+	// HTTPClient overrides the default client (used by tests).
+	HTTPClient *http.Client
+	// StatePath is where the throttle mtime lives. Empty = no throttle.
+	StatePath string
+	// Now is the wall-clock used by the throttle; tests set it.
+	Now func() time.Time
+}
+
+// Check returns the highest version on the configured channel that is
+// strictly greater than `current`. When the throttle file says we
+// checked recently, returns (Result{}, ErrThrottled, nil) — the caller
+// reads the previously-cached available version from settings.
+//
+// Network errors propagate; a 4xx/5xx from GitHub returns a wrapped
+// error so the caller can log and continue.
+func Check(ctx context.Context, current string, opts Options) (Result, error) {
+	opts = withDefaults(opts)
+	if opts.StatePath != "" && !shouldRun(opts.StatePath, opts.Now()) {
+		return Result{}, ErrThrottled
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases", opts.RepoOwner, opts.RepoName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return Result{}, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("updatecheck: fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return Result{}, fmt.Errorf("updatecheck: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var releases []githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return Result{}, fmt.Errorf("updatecheck: decode: %w", err)
+	}
+
+	// Touch the throttle file regardless of what we found — a successful
+	// API hit "counts" against the budget.
+	if opts.StatePath != "" {
+		_ = touch(opts.StatePath, opts.Now())
+	}
+
+	pick := pickRelease(releases, opts.Channel)
+	if pick == nil {
+		return Result{}, nil
+	}
+	latest := strings.TrimPrefix(pick.TagName, "v")
+	if !isStrictlyNewer(latest, current) {
+		return Result{}, nil
+	}
+	return Result{
+		Latest: latest,
+		URL:    pick.HTMLURL,
+		Notes:  pick.Body,
+	}, nil
+}
+
+// IsStrictlyNewer reports whether `latest` is a strictly higher semver
+// than `current`. Exposed for callers that want to compare the
+// dismissed-version setting against a freshly-fetched latest without
+// re-running the GitHub call.
+func IsStrictlyNewer(latest, current string) bool { return isStrictlyNewer(latest, current) }
+
+// ErrThrottled is returned by Check when the throttle file says we
+// checked too recently. Not really an error — the caller logs and
+// surfaces the previously-cached value.
+var ErrThrottled = errors.New("updatecheck: throttled")
+
+// ── internals ─────────────────────────────────────────────────────────
+
+type githubRelease struct {
+	TagName    string `json:"tag_name"`
+	HTMLURL    string `json:"html_url"`
+	Name       string `json:"name"`
+	Body       string `json:"body"`
+	Prerelease bool   `json:"prerelease"`
+	Draft      bool   `json:"draft"`
+}
+
+func withDefaults(opts Options) Options {
+	if opts.RepoOwner == "" {
+		opts.RepoOwner = DefaultRepoOwner
+	}
+	if opts.RepoName == "" {
+		opts.RepoName = DefaultRepoName
+	}
+	if opts.Channel == "" {
+		opts.Channel = ChannelStable
+	}
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = &http.Client{Timeout: httpTimeout}
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return opts
+}
+
+func pickRelease(rs []githubRelease, ch Channel) *githubRelease {
+	var best *githubRelease
+	bestSem := semver{}
+	for i := range rs {
+		r := &rs[i]
+		if r.Draft {
+			continue
+		}
+		if ch == ChannelStable && r.Prerelease {
+			continue
+		}
+		s, ok := parseSemver(r.TagName)
+		if !ok {
+			continue
+		}
+		if best == nil || compareSemver(s, bestSem) > 0 {
+			best = r
+			bestSem = s
+		}
+	}
+	return best
+}
+
+// shouldRun reports whether the throttle file is older than `throttle`.
+// Missing / unreadable file = run.
+func shouldRun(path string, now time.Time) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return true
+	}
+	return now.Sub(info.ModTime()) >= throttle
+}
+
+// touch creates / refreshes the throttle file's mtime to `now`.
+func touch(path string, now time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	_ = f.Close()
+	return os.Chtimes(path, now, now)
+}
+
+// ── tiny semver ──────────────────────────────────────────────────────
+
+type semver struct {
+	major, minor, patch int
+	pre                 string
+}
+
+// parseSemver parses "v1.2.3" or "1.2.3" or "1.2.3-beta.1". Returns
+// false on garbage; the caller skips those entries.
+func parseSemver(tag string) (semver, bool) {
+	tag = strings.TrimPrefix(tag, "v")
+	pre := ""
+	if i := strings.IndexByte(tag, '-'); i >= 0 {
+		pre = tag[i+1:]
+		tag = tag[:i]
+	}
+	if i := strings.IndexByte(tag, '+'); i >= 0 {
+		tag = tag[:i]
+	}
+	parts := strings.SplitN(tag, ".", 3)
+	if len(parts) < 2 {
+		return semver{}, false
+	}
+	mj, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return semver{}, false
+	}
+	mn, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return semver{}, false
+	}
+	pt := 0
+	if len(parts) == 3 {
+		pt, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return semver{}, false
+		}
+	}
+	return semver{major: mj, minor: mn, patch: pt, pre: pre}, true
+}
+
+// compareSemver returns -1 / 0 / +1 in the usual ordering. A version
+// without a prerelease tag is greater than the same triple WITH one
+// (semver §11). Two prerelease strings compare lexicographically — good
+// enough for "beta.1" < "beta.2"; documented limitation for exotic
+// dotted suffixes.
+func compareSemver(a, b semver) int {
+	switch {
+	case a.major != b.major:
+		return cmpInt(a.major, b.major)
+	case a.minor != b.minor:
+		return cmpInt(a.minor, b.minor)
+	case a.patch != b.patch:
+		return cmpInt(a.patch, b.patch)
+	}
+	if a.pre == b.pre {
+		return 0
+	}
+	if a.pre == "" {
+		return 1
+	}
+	if b.pre == "" {
+		return -1
+	}
+	return strings.Compare(a.pre, b.pre)
+}
+
+func cmpInt(a, b int) int {
+	switch {
+	case a > b:
+		return 1
+	case a < b:
+		return -1
+	}
+	return 0
+}
+
+func isStrictlyNewer(latest, current string) bool {
+	la, ok := parseSemver(latest)
+	if !ok {
+		return false
+	}
+	cu, ok := parseSemver(current)
+	if !ok {
+		// "dev" or other non-semver current strings: be conservative
+		// and don't surface an upgrade banner — we don't know if the
+		// user is running ahead of latest.
+		return false
+	}
+	return compareSemver(la, cu) > 0
+}

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -1,0 +1,155 @@
+package updatecheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseAndCompareSemver(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.2.3", "1.2.3", 0},
+		{"1.2.4", "1.2.3", 1},
+		{"1.10.0", "1.9.9", 1},
+		{"v2.0.0", "1.99.99", 1},
+		{"1.0.0-beta", "1.0.0", -1},
+		{"1.0.0-beta.2", "1.0.0-beta.1", 1},
+		{"1.0.0", "1.0.0+build.5", 0}, // build metadata ignored
+	}
+	for _, c := range cases {
+		a, ok := parseSemver(c.a)
+		if !ok {
+			t.Fatalf("parse %q failed", c.a)
+		}
+		b, ok := parseSemver(c.b)
+		if !ok {
+			t.Fatalf("parse %q failed", c.b)
+		}
+		if got := compareSemver(a, b); got != c.want {
+			t.Errorf("compare(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestIsStrictlyNewerHandlesDev(t *testing.T) {
+	t.Parallel()
+	if IsStrictlyNewer("1.0.0", "dev") {
+		t.Fatalf("dev current should not surface an upgrade")
+	}
+	if !IsStrictlyNewer("1.10.0", "1.9.9") {
+		t.Fatalf("1.10.0 vs 1.9.9: expected newer")
+	}
+	if IsStrictlyNewer("1.0.0", "1.0.0") {
+		t.Fatalf("equal versions should not be newer")
+	}
+}
+
+func TestPickReleasePrefersHighestStable(t *testing.T) {
+	t.Parallel()
+	rs := []githubRelease{
+		{TagName: "v1.0.0"},
+		{TagName: "v1.2.3"},
+		{TagName: "v1.2.4-beta", Prerelease: true},
+		{TagName: "v0.9.0"},
+		{TagName: "draft", Draft: true},
+	}
+	got := pickRelease(rs, ChannelStable)
+	if got == nil || got.TagName != "v1.2.3" {
+		t.Fatalf("stable pick = %+v, want v1.2.3", got)
+	}
+
+	beta := pickRelease(rs, ChannelBeta)
+	if beta == nil || beta.TagName != "v1.2.4-beta" {
+		t.Fatalf("beta pick = %+v, want v1.2.4-beta", beta)
+	}
+}
+
+func TestCheckSurfacesNewerVersion(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"tag_name":"v2.0.0","html_url":"https://example/2.0.0","body":"notes"},
+			{"tag_name":"v1.0.0","html_url":"https://example/1.0.0"}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	res, err := Check(context.Background(), "1.0.0", Options{
+		HTTPClient: &http.Client{Transport: rewriteTo(srv.URL)},
+	})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Latest != "2.0.0" {
+		t.Fatalf("Latest = %q, want 2.0.0", res.Latest)
+	}
+	if res.URL == "" {
+		t.Fatalf("URL empty")
+	}
+}
+
+func TestCheckNoUpgradeWhenCurrentIsNewer(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"tag_name":"v1.0.0"}]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	res, err := Check(context.Background(), "1.5.0", Options{
+		HTTPClient: &http.Client{Transport: rewriteTo(srv.URL)},
+	})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Latest != "" {
+		t.Fatalf("Latest = %q, want empty", res.Latest)
+	}
+}
+
+func TestThrottle(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	state := filepath.Join(dir, "throttle")
+	now := time.Now()
+	if !shouldRun(state, now) {
+		t.Fatalf("missing file should run")
+	}
+	if err := touch(state, now); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	if shouldRun(state, now.Add(time.Hour)) {
+		t.Fatalf("1h since touch — should NOT run")
+	}
+	if !shouldRun(state, now.Add(throttle+time.Minute)) {
+		t.Fatalf("after throttle window — should run")
+	}
+}
+
+// rewriteTo returns an http.RoundTripper that redirects every request
+// to the given base URL, preserving path + query. Lets tests exercise
+// Check's HTTP plumbing without exposing the URL builder.
+func rewriteTo(base string) http.RoundTripper {
+	bu, _ := url.Parse(base)
+	return &rewriteTransport{scheme: bu.Scheme, host: bu.Host}
+}
+
+type rewriteTransport struct {
+	scheme, host string
+}
+
+func (r *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	u := *req.URL
+	u.Scheme = r.scheme
+	u.Host = r.host
+	clone.URL = &u
+	return http.DefaultTransport.RoundTrip(clone)
+}

--- a/internal/utils/logrotate.go
+++ b/internal/utils/logrotate.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+// RotateIfLarge rotates logPath when it exceeds maxBytes, preserving up to
+// keep historical files (logPath.1 .. logPath.<keep>). The newest backup is
+// always logPath.1; older backups shift outward by one. The file rotated
+// past keep is unlinked.
+//
+// If logPath does not exist or is below the threshold, RotateIfLarge is a
+// no-op and returns nil. keep <= 0 is normalised to 1 — the rotate always
+// keeps at least one historical copy. Best-effort cleanup: an unlink error
+// for the oldest backup is logged via errors.Join with the rename outcome
+// so the caller still sees the operational outcome.
+func RotateIfLarge(logPath string, maxBytes int64, keep int) error {
+	if maxBytes <= 0 {
+		return fmt.Errorf("logrotate: maxBytes must be > 0")
+	}
+	if keep <= 0 {
+		keep = 1
+	}
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.Size() < maxBytes {
+		return nil
+	}
+
+	// Drop the oldest backup if it would exceed `keep`.
+	oldest := fmt.Sprintf("%s.%d", logPath, keep)
+	if err := os.Remove(oldest); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		// Non-fatal: log layer keeps working; we just may briefly have
+		// keep+1 files on disk.
+		return fmt.Errorf("logrotate: remove oldest %q: %w", oldest, err)
+	}
+
+	// Shift logPath.<n> -> logPath.<n+1>, descending so we never clobber.
+	for i := keep - 1; i >= 1; i-- {
+		from := fmt.Sprintf("%s.%d", logPath, i)
+		to := fmt.Sprintf("%s.%d", logPath, i+1)
+		if err := os.Rename(from, to); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("logrotate: rename %q -> %q: %w", from, to, err)
+		}
+	}
+
+	// Finally, current → .1.
+	target := logPath + ".1"
+	if err := os.Rename(logPath, target); err != nil {
+		return fmt.Errorf("logrotate: rename %q -> %q: %w", logPath, target, err)
+	}
+	return nil
+}

--- a/internal/utils/terminal.go
+++ b/internal/utils/terminal.go
@@ -1,0 +1,195 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// ErrNoTerminal is returned by OpenInTerminal when no platform terminal
+// launcher could be detected. Callers branch on errors.Is to fall back
+// to copying the command to the clipboard with a "no terminal found —
+// command copied" toast.
+var ErrNoTerminal = errors.New("no terminal emulator found")
+
+// OpenInTerminal launches the platform's preferred terminal and runs
+// the given argv inside it.
+//
+// There is no portable way to "pre-type the command without executing"
+// — Terminal.app, wt.exe, kitty, et al. all take a command and run it.
+// Callers that want the user to inspect or edit the command first
+// should use the clipboard fallback path (catch ErrNoTerminal *or* an
+// explicit toast on success that mentions the command copied).
+//
+// Per platform:
+//
+//   - Linux: $TERMINAL → x-terminal-emulator → kitty → alacritty → foot
+//     → wezterm → ghostty → gnome-terminal → konsole → xfce4-terminal →
+//     xterm.
+//   - macOS: Terminal.app via osascript. (iTerm precedence is a
+//     follow-up — see UX.md §13.)
+//   - Windows: wt.exe if on PATH, else `cmd /c start cmd /k <cmd>`.
+//   - WSL (Linux running inside Windows): wt.exe through wsl.exe -- so
+//     the spawned terminal lives on the Windows side.
+//
+// The returned process is detached (Start, not Run) so the caller never
+// blocks waiting for the user to close the terminal.
+func OpenInTerminal(argv []string) error {
+	if len(argv) == 0 {
+		return fmt.Errorf("OpenInTerminal: empty argv")
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return openInTerminalMac(argv)
+	case "windows":
+		return openInTerminalWindows(argv)
+	default:
+		if isWSL() {
+			return openInTerminalWSL(argv)
+		}
+		return openInTerminalLinux(argv)
+	}
+}
+
+func openInTerminalMac(argv []string) error {
+	// osascript needs the command as a single double-quoted string.
+	// Escape embedded quotes and backslashes so a path containing them
+	// doesn't break out of the script.
+	full := shellQuote(argv)
+	script := fmt.Sprintf(`tell application "Terminal" to do script "%s"`, escapeAppleScript(full))
+	cmd := exec.Command("osascript", "-e", script)
+	HideConsole(cmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("osascript: %w", err)
+	}
+	return nil
+}
+
+func openInTerminalWindows(argv []string) error {
+	if _, err := exec.LookPath("wt.exe"); err == nil {
+		args := append([]string{}, argv...)
+		c := exec.Command("wt.exe", args...)
+		HideConsole(c)
+		return c.Start()
+	}
+	full := shellQuote(argv)
+	c := exec.Command("cmd.exe", "/C", "start", "cmd.exe", "/K", full)
+	HideConsole(c)
+	return c.Start()
+}
+
+func openInTerminalWSL(argv []string) error {
+	distro := os.Getenv("WSL_DISTRO_NAME")
+	if distro == "" {
+		// Fall back to the Linux launcher set inside WSL — better than
+		// silently no-oping when the env var is missing.
+		return openInTerminalLinux(argv)
+	}
+	if _, err := exec.LookPath("wt.exe"); err == nil {
+		args := append([]string{"wsl.exe", "-d", distro, "--"}, argv...)
+		c := exec.Command("wt.exe", args...)
+		HideConsole(c)
+		return c.Start()
+	}
+	full := shellQuote(argv)
+	c := exec.Command("cmd.exe", "/C", "start", "wsl.exe", "-d", distro, "--", full)
+	HideConsole(c)
+	return c.Start()
+}
+
+func openInTerminalLinux(argv []string) error {
+	type termCandidate struct {
+		name   string
+		prefix []string
+	}
+	terminals := []termCandidate{
+		{"kitty", nil},
+		{"alacritty", []string{"-e"}},
+		{"foot", []string{"-e"}},
+		{"wezterm", []string{"start", "--"}},
+		{"ghostty", []string{"-e"}},
+		{"x-terminal-emulator", []string{"-e"}},
+		{"gnome-terminal", []string{"--"}},
+		{"konsole", []string{"-e"}},
+		{"xfce4-terminal", []string{"-e"}},
+		{"xterm", []string{"-e"}},
+	}
+	if envTerm := os.Getenv("TERMINAL"); envTerm != "" {
+		if _, err := exec.LookPath(envTerm); err == nil {
+			prefix := []string{"-e"}
+			for _, t := range terminals {
+				if t.name == envTerm {
+					prefix = t.prefix
+					break
+				}
+			}
+			args := append(append([]string{}, prefix...), argv...)
+			c := exec.Command(envTerm, args...)
+			HideConsole(c)
+			return c.Start()
+		}
+	}
+	for _, t := range terminals {
+		if _, err := exec.LookPath(t.name); err == nil {
+			args := append(append([]string{}, t.prefix...), argv...)
+			c := exec.Command(t.name, args...)
+			HideConsole(c)
+			return c.Start()
+		}
+	}
+	return ErrNoTerminal
+}
+
+// shellQuote joins argv into a single command string suitable for
+// passing through cmd /K or osascript do-script. Each token is wrapped
+// in double quotes when it contains whitespace or shell metacharacters;
+// embedded double quotes and backslashes are escaped.
+func shellQuote(argv []string) string {
+	var b strings.Builder
+	for i, a := range argv {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		if needsQuoting(a) {
+			b.WriteByte('"')
+			for _, r := range a {
+				if r == '"' || r == '\\' {
+					b.WriteByte('\\')
+				}
+				b.WriteRune(r)
+			}
+			b.WriteByte('"')
+		} else {
+			b.WriteString(a)
+		}
+	}
+	return b.String()
+}
+
+func needsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '"' || r == '\\' || r == '$' || r == '`' {
+			return true
+		}
+	}
+	return false
+}
+
+// escapeAppleScript escapes embedded backslashes and double quotes for
+// inclusion inside a tell-application-do-script literal.
+func escapeAppleScript(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r == '"' || r == '\\' {
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/internal/utils/terminal_test.go
+++ b/internal/utils/terminal_test.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrNoTerminalIsSentinel(t *testing.T) {
+	t.Parallel()
+	wrapped := wrapNoTerminal()
+	if !errors.Is(wrapped, ErrNoTerminal) {
+		t.Fatalf("errors.Is on wrapped ErrNoTerminal returned false")
+	}
+}
+
+func wrapNoTerminal() error { return ErrNoTerminal }
+
+func TestShellQuote(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		argv []string
+		want string
+	}{
+		{[]string{"docker", "exec", "-it", "name", "/bin/bash"}, "docker exec -it name /bin/bash"},
+		{[]string{"echo", "hello world"}, `echo "hello world"`},
+		{[]string{"echo", `she said "hi"`}, `echo "she said \"hi\""`},
+		{[]string{"path", `c:\windows\system32`}, `path "c:\\windows\\system32"`},
+	}
+	for _, c := range cases {
+		if got := shellQuote(c.argv); got != c.want {
+			t.Errorf("shellQuote(%v) = %q, want %q", c.argv, got, c.want)
+		}
+	}
+}
+
+func TestNeedsQuoting(t *testing.T) {
+	t.Parallel()
+	yes := []string{"", "has space", `has"quote`, `has\backslash`, `has$var`, "has`tick"}
+	no := []string{"plain", "with-dashes", "name123", "/usr/bin/foo"}
+	for _, s := range yes {
+		if !needsQuoting(s) {
+			t.Errorf("needsQuoting(%q) = false, want true", s)
+		}
+	}
+	for _, s := range no {
+		if needsQuoting(s) {
+			t.Errorf("needsQuoting(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestEscapeAppleScript(t *testing.T) {
+	t.Parallel()
+	if got := escapeAppleScript(`a "b" c`); got != `a \"b\" c` {
+		t.Errorf("escapeAppleScript = %q", got)
+	}
+	if got := escapeAppleScript(`back\slash`); got != `back\\slash` {
+		t.Errorf("escapeAppleScript = %q", got)
+	}
+}
+
+func TestOpenInTerminalEmptyArgvFails(t *testing.T) {
+	t.Parallel()
+	if err := OpenInTerminal(nil); err == nil {
+		t.Fatalf("nil argv should return error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"gioui.org/unit"
 
 	application "github.com/PeterBooker/locorum/internal/app"
+	"github.com/PeterBooker/locorum/internal/applog"
 	settings "github.com/PeterBooker/locorum/internal/config"
 	"github.com/PeterBooker/locorum/internal/daemon"
 	"github.com/PeterBooker/locorum/internal/docker"
@@ -25,8 +26,10 @@ import (
 	"github.com/PeterBooker/locorum/internal/router/traefik"
 	"github.com/PeterBooker/locorum/internal/sites"
 	"github.com/PeterBooker/locorum/internal/storage"
+	"github.com/PeterBooker/locorum/internal/telemetry"
 	tlspkg "github.com/PeterBooker/locorum/internal/tls"
 	"github.com/PeterBooker/locorum/internal/ui"
+	"github.com/PeterBooker/locorum/internal/updatecheck"
 	"github.com/PeterBooker/locorum/internal/utils"
 	"github.com/PeterBooker/locorum/internal/version"
 )
@@ -77,6 +80,17 @@ func main() {
 		log.Fatalln("Error getting home dir:", err)
 	}
 
+	// Install the structured-log handler before any other startup work so
+	// every record (including the "starting Locorum" line above is missed,
+	// which is fine — that one is a single banner, not a debug source).
+	logCloser, logErr := applog.Init(filepath.Join(homeDir, ".locorum", "logs"))
+	if logErr != nil {
+		// Stderr-only handler is already installed by Init's fallback;
+		// surface the file-open failure once and continue.
+		slog.Warn("applog: file logging disabled", "err", logErr.Error())
+	}
+	defer func() { _ = logCloser.Close() }()
+
 	d := docker.New()
 
 	st, err := storage.NewSQLiteStorage(context.Background())
@@ -89,6 +103,21 @@ func main() {
 	if err != nil {
 		log.Fatalln("Error loading settings:", err)
 	}
+
+	// Apply the persisted Debug Mode toggle to the slog handler. Cheap;
+	// safe to call before or after applog.Init.
+	applog.SetDebug(cfg.DebugLogging())
+
+	// Telemetry: noop sink today (UX.md §5.1, Phase A). The real
+	// transport lands once the privacy doc + vendor decision do — Phase
+	// B swaps SetDefault here for a PostHog (or self-rolled) sink, all
+	// without touching the call sites.
+	telemetry.SetDefault(telemetry.Noop{})
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = telemetry.Flush(ctx)
+	}()
 
 	mkcert := tlspkg.NewMkcert(
 		filepath.Join(homeDir, ".locorum", "certs"),
@@ -138,6 +167,22 @@ func main() {
 	}
 
 	userInterface := ui.New(sm)
+
+	// Wire the Diagnostics → Reset Infrastructure card. The closure
+	// captures `a` so the UI doesn't import internal/app — invariant
+	// 1 (UI's strict diet) stays intact.
+	if dp := userInterface.Settings.DiagnosticsPanel(); dp != nil {
+		dp.SetResetInfraCard(ui.NewResetInfraCard(
+			userInterface.State, sm, userInterface.Toasts,
+			func(ctx context.Context) error { return a.ResetInfrastructure(ctx) },
+		))
+		dp.SetUpdateBanner(ui.NewUpdateBannerCard(userInterface.State, cfg))
+	}
+
+	// Hydrate the update-banner state from settings before the first
+	// frame so the dot doesn't flicker on launch.
+	userInterface.State.SetUpdateAvailable(cfg.UpdateLastAvailable(), "", "")
+	userInterface.State.SetUpdateDismissed(cfg.UpdateDismissedVersion())
 
 	// Hydrate the toast-suppression set from the persisted JSON so we
 	// don't re-toast findings the user already saw on a previous run.
@@ -288,6 +333,10 @@ func main() {
 	}()
 
 	go pollServicesHealth(d, userInterface.State)
+
+	if cfg.UpdateCheckEnabled() {
+		go runUpdateCheck(homeDir, cfg, userInterface.State)
+	}
 
 	go func() {
 		w := &app.Window{}
@@ -460,6 +509,34 @@ func currentServicesHealth(d *docker.Docker, requiredRoles []string) ui.Services
 		return ui.ServicesHealth{Status: ui.ServicesHealthDegraded}
 	default:
 		return ui.ServicesHealth{Status: ui.ServicesHealthHealthy}
+	}
+}
+
+// runUpdateCheck queries GitHub Releases (gated by the throttle file)
+// and pushes the result into UIState. Failures are logged at warn — the
+// app keeps working without the banner.
+func runUpdateCheck(homeDir string, cfg *settings.Config, state *ui.UIState) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	statePath := filepath.Join(homeDir, ".locorum", "state", "last_update_check.json")
+	res, err := updatecheck.Check(ctx, version.Version, updatecheck.Options{
+		Channel:   updatecheck.Channel(cfg.UpdateCheckChannel()),
+		StatePath: statePath,
+	})
+	if err != nil {
+		if err == updatecheck.ErrThrottled {
+			return
+		}
+		slog.Warn("update check failed", "err", err.Error())
+		return
+	}
+	if res.Latest == "" {
+		return
+	}
+	state.SetUpdateAvailable(res.Latest, res.URL, res.Notes)
+	if err := cfg.SetUpdateLastAvailable(res.Latest); err != nil {
+		slog.Warn("update check: persist last_available", "err", err.Error())
 	}
 }
 


### PR DESCRIPTION
# UX enhancements

Implements the eight sub-sections of `LEARNINGS.md` §7, sequenced per
`UX.md`. Two cross-cutting foundations land first; the remaining work
rides on them.

## What's new

**Foundations**
- Action-bearing error banner. `UIState.ShowErrorWithAction` lets a
  toast carry a button; the existing `ShowError` keeps working.
- Structured `slog` handler at `~/.locorum/logs/locorum.log` with size
  rotation and a runtime Debug Mode toggle.

**Typed errors with one-click fixes** (§7.1)
- New sentinels: `docker.ErrDaemonUnreachable`, `router.ErrPortInUse`,
  `tls.ErrMkcertMissing`, `sites.ErrSiteNotRunning`.
- `ui.SurfaceError` maps each sentinel to a banner action ("How to start
  Docker", "Open Settings", "Show me how", "Start site").

**Settings → Diagnostics card** (§7.2, §7.6)
- Debug Mode toggle, Open Log Folder, Copy Last 200 Lines.
- Reset Locorum Infrastructure button + confirm modal. Re-uses extracted
  `app.WipeLabelled` / `app.BringUpGlobals`. Volumes preserved.

**Site description** (§7.5)
- Per-site `SiteDescription` cache; Layout never blocks on SQLite or
  Docker. Header gets a Copy as JSON button (matches the agent IPC
  shape).

**Streaming log viewer** (§7.7)
- New `Engine.StreamContainerLogs` (+ fake), `SiteManager.StreamLogs`
  with reattach. Log viewer now follows live with Pause/Resume, a
  5,000-line ring, error-line highlighting, and Export.

**Update check** (§7.4)
- `internal/updatecheck` queries GitHub Releases (channel-aware, mtime
  throttled, in-package semver compare). Surfaces an accent dot on the
  Settings nav item and a card on Diagnostics with View notes / Dismiss
  this version.

**Open shell** (§7.8)
- New `utils.OpenInTerminal` + `ErrNoTerminal` with platform-correct
  fallbacks. Per-service shell binary selection (Alpine → `sh`, others →
  `bash`). Clipboard-fallback toast when no terminal is found.

**Telemetry scaffold — Phase A** (§7.3)
- `internal/telemetry` Sink interface + always-installed Noop. First-
  launch opt-in modal (gated on a new `KeyTelemetryDecided` so the
  unset/false ambiguity goes away). Settings → Privacy card with toggle
  and Reset Telemetry ID. No transport ships yet — Phase B is gated on a
  written privacy doc.
