### PR TITLE
Implement DDEV Learnings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,8 +5,11 @@ import (
 	"embed"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path"
+	"strconv"
+	"time"
 
 	"github.com/PeterBooker/locorum/internal/assets"
 	"github.com/PeterBooker/locorum/internal/docker"
@@ -16,6 +19,18 @@ import (
 
 	"github.com/docker/docker/client"
 )
+
+// preLaunchProbeTimeout caps each TCP probe of host ports 80/443 issued
+// before we attempt the router create. A listener-present case answers
+// in microseconds; the timeout exists only to avoid an indefinite hang
+// against a misbehaving local proxy that accepts the SYN but never
+// replies.
+const preLaunchProbeTimeout = 200 * time.Millisecond
+
+// preLaunchProbePorts is the canonical pair of host-bound ports the
+// router needs. Centralised here so a future port change (extremely
+// unlikely — see F14 design note) is one constant edit, not a sweep.
+var preLaunchProbePorts = []int{80, 443}
 
 // App owns process-wide initialisation: filesystem layout, Docker readiness,
 // global containers, and router lifecycle.
@@ -121,6 +136,25 @@ func (a *App) WipeLabelled(ctx context.Context) error {
 // Each step propagates the underlying error verbatim. The router itself
 // returns sentinels (router.ErrPortInUse) the UI can branch on.
 func (a *App) BringUpGlobals(ctx context.Context) error {
+	// Pre-launch probe: if a foreign process already owns 80 or 443,
+	// short-circuit with router.ErrPortInUse rather than letting the
+	// Docker SDK surface a deeper, less-actionable "port is already
+	// allocated" error after pulling the router image. F14 design
+	// note: we deliberately do NOT fall back to ephemeral ports —
+	// URL stability of https://<slug>.localhost is load-bearing for
+	// browser cookie scope, mkcert SANs, hard-coded WP siteurl, and
+	// the user's documentation. The user must free the port instead.
+	//
+	// At this moment in the lifecycle the router container is *not*
+	// running (BringUpGlobals creates it below), so any existing
+	// listener on the host port cannot be ours.
+	if held := probeHeldRouterPort(ctx); held > 0 {
+		err := fmt.Errorf("%w: port %d is held by another process", router.ErrPortInUse, held)
+		slog.Warn("pre-launch port probe: foreign listener detected; refusing to create router",
+			"port", held)
+		return err
+	}
+
 	if _, err := a.d.EnsureNetwork(ctx, docker.GlobalNetworkSpec()); err != nil {
 		return fmt.Errorf("create global network: %w", err)
 	}
@@ -164,6 +198,41 @@ func (a *App) ensureGlobalContainer(ctx context.Context, spec docker.ContainerSp
 		return fmt.Errorf("start %s: %w", spec.Name, err)
 	}
 	return nil
+}
+
+// probeHeldRouterPort dials each port in [preLaunchProbePorts] and
+// returns the first one that already has a listener. Returns 0 when all
+// ports look free. Used by [BringUpGlobals] to short-circuit before
+// pulling the router image when a foreign process holds 80 or 443.
+//
+// Pure read-only TCP probe — never binds. A successful dial means a
+// listener accepted the SYN; we close immediately. The probe is bounded
+// by [preLaunchProbeTimeout] per port, which is several orders of
+// magnitude faster than the BringUpGlobals image pull, so the cost is
+// negligible.
+func probeHeldRouterPort(ctx context.Context) int {
+	for _, port := range preLaunchProbePorts {
+		if isPortHeld(ctx, port) {
+			return port
+		}
+	}
+	return 0
+}
+
+// isPortHeld is the per-port half of [probeHeldRouterPort]. Factored
+// out so a future caller (status bar, CLI sub-command) can reuse the
+// dial without picking up the router-port iteration.
+func isPortHeld(ctx context.Context, port int) bool {
+	if port <= 0 || port > 65535 {
+		return false
+	}
+	d := net.Dialer{Timeout: preLaunchProbeTimeout}
+	conn, err := d.DialContext(ctx, "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 func (a *App) Shutdown(ctx context.Context) error {

--- a/internal/health/bundled.go
+++ b/internal/health/bundled.go
@@ -43,6 +43,14 @@ type BundledOpts struct {
 	// traefik.ContainerName.
 	RouterContainerName string
 
+	// PortHolderSink, if non-nil, receives the formatted output of the
+	// port-holder lookup (lsof / Get-NetTCPConnection) when the user
+	// clicks the "Show port holders" action on a port-conflict finding.
+	// Implementations are expected to surface the text to the user
+	// (typically by pushing into a UIState modal). Called from the
+	// runner's action goroutine — must not block.
+	PortHolderSink func(port int, text string)
+
 	// DiskWarnBytes / DiskBlockerBytes override the disk thresholds.
 	// Zero values fall back to DefaultDiskWarnBytes /
 	// DefaultDiskBlockerBytes.
@@ -92,8 +100,8 @@ func Bundled(opts BundledOpts) []Check {
 		}))
 		if opts.RouterContainerName != "" {
 			out = append(out,
-				NewPortConflictCheck(opts.Engine, 80, opts.RouterContainerName),
-				NewPortConflictCheck(opts.Engine, 443, opts.RouterContainerName),
+				NewPortConflictCheck(opts.Engine, 80, opts.RouterContainerName, opts.PortHolderSink),
+				NewPortConflictCheck(opts.Engine, 443, opts.RouterContainerName, opts.PortHolderSink),
 			)
 		}
 	}

--- a/internal/health/checks_mkcert.go
+++ b/internal/health/checks_mkcert.go
@@ -11,6 +11,15 @@ import (
 // — sites still serve over HTTPS, but browsers show an untrusted-cert
 // warning until the user runs `mkcert -install`.
 //
+// When mkcert is fully set up, the same check looks one level deeper at
+// the host's [tls.Capabilities] and emits an [SeverityInfo] Note for
+// each trust store that mkcert from a GUI process couldn't have
+// touched. Today: Java keystore (when JAVA_HOME / `java` is detected)
+// and Firefox-on-Windows (which lazily creates its NSS DB on first
+// launch). The plan owner-note is explicit: Locorum doesn't try to
+// manipulate these stores from a GUI launch context — it surfaces the
+// gap so the developer takes the one explicit step from a real shell.
+//
 // This is essentially the same data the persistent notice banner already
 // surfaces (see main.go:refreshTLSNotice), but living in the health
 // system means the System Health panel can show it alongside everything
@@ -41,24 +50,51 @@ func (c *MkcertCheck) Run(ctx context.Context) ([]Finding, error) {
 	if err != nil {
 		return nil, err
 	}
-	if status.Installed && status.CATrusted {
-		return nil, nil
+	if !status.Installed || !status.CATrusted {
+		f := Finding{
+			ID:          c.ID(),
+			Severity:    SeverityWarn,
+			Title:       "Trusted HTTPS not configured",
+			Detail:      status.Message,
+			Remediation: "Install mkcert and run `mkcert -install` so browsers trust Locorum-issued certificates.",
+			HelpURL:     "https://github.com/FiloSottile/mkcert#installation",
+		}
+		if c.installer != nil {
+			f.Action = &Action{
+				Label:   "Set up trusted HTTPS",
+				Run:     c.installer,
+				Timeout: 60 * time.Second,
+			}
+		}
+		return []Finding{f}, nil
 	}
 
-	f := Finding{
-		ID:          c.ID(),
-		Severity:    SeverityWarn,
-		Title:       "Trusted HTTPS not configured",
-		Detail:      status.Message,
-		Remediation: "Install mkcert and run `mkcert -install` so browsers trust Locorum-issued certificates.",
-		HelpURL:     "https://github.com/FiloSottile/mkcert#installation",
+	// Trusted HTTPS is otherwise set up. Look for incomplete trust
+	// store coverage — these are Info-level (browsers still trust the
+	// cert; only specific developer tooling needs the extra step).
+	caps := c.prov.Capabilities(ctx)
+	var out []Finding
+	if caps.JavaPresent {
+		out = append(out, Finding{
+			ID:       "mkcert-java-trust",
+			Severity: SeverityInfo,
+			Title:    "Java apps don't trust the Locorum CA",
+			Detail: "JAVA_HOME or `java` is on PATH on this host, but mkcert from a GUI process " +
+				"can't reach Java's cacerts keystore.",
+			Remediation: "Re-run `mkcert -install` from a terminal where JAVA_HOME resolves; Spring Boot, Tomcat, and SBT will then trust Locorum certificates.",
+			HelpURL:     "https://github.com/FiloSottile/mkcert#supported-root-stores",
+		})
 	}
-	if c.installer != nil {
-		f.Action = &Action{
-			Label:   "Set up trusted HTTPS",
-			Run:     c.installer,
-			Timeout: 60 * time.Second,
-		}
+	if caps.FirefoxOnWindows {
+		out = append(out, Finding{
+			ID:       "mkcert-firefox-windows",
+			Severity: SeverityInfo,
+			Title:    "Firefox on Windows may not trust the Locorum CA",
+			Detail: "Firefox lazily creates its NSS database on first launch. If you ran " +
+				"`mkcert -install` before launching Firefox, the keystore wasn't populated yet.",
+			Remediation: "Open Firefox once, close it, then re-run `mkcert -install` (or use the action above).",
+			HelpURL:     "https://github.com/FiloSottile/mkcert#supported-root-stores",
+		})
 	}
-	return []Finding{f}, nil
+	return out, nil
 }

--- a/internal/health/checks_mkcert_test.go
+++ b/internal/health/checks_mkcert_test.go
@@ -1,0 +1,146 @@
+package health
+
+import (
+	"context"
+	"testing"
+
+	tlspkg "github.com/PeterBooker/locorum/internal/tls"
+	"github.com/PeterBooker/locorum/internal/tls/fake"
+)
+
+// TestMkcertCheckMissingFiresWarn covers the existing "no mkcert / no
+// CA" branch. The Note must be Warn (not Info) because the user can't
+// get trusted HTTPS at all without acting on it.
+func TestMkcertCheckMissingFiresWarn(t *testing.T) {
+	prov := fake.New()
+	prov.AvailableStatus = tlspkg.Status{Installed: false, CATrusted: false, Message: "mkcert not found"}
+
+	c := NewMkcertCheck(prov, nil)
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(out))
+	}
+	if out[0].Severity != SeverityWarn {
+		t.Errorf("severity = %v, want SeverityWarn", out[0].Severity)
+	}
+	if out[0].ID != "mkcert-missing" {
+		t.Errorf("ID = %q, want mkcert-missing", out[0].ID)
+	}
+}
+
+// TestMkcertCheckCapabilitiesAllClear covers the steady state: mkcert
+// installed, CA trusted, no extra trust-store gaps. No findings expected.
+func TestMkcertCheckCapabilitiesAllClear(t *testing.T) {
+	prov := fake.New()
+	// fake.New() default already has Installed+CATrusted true and
+	// CapabilitiesValue zero (no Java, no Firefox-on-Windows).
+
+	c := NewMkcertCheck(prov, nil)
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected zero findings, got %d: %+v", len(out), out)
+	}
+}
+
+// TestMkcertCheckSurfaceJavaCapability locks in F19's load-bearing
+// behaviour: when mkcert is OK *and* Java is detected on the host, the
+// check emits a single Info finding pointing at the cacerts gap. No
+// blocker / no warn — this is informational so the user knows Spring /
+// Tomcat / SBT need the manual step but the rest of the toolchain is
+// fine.
+func TestMkcertCheckSurfaceJavaCapability(t *testing.T) {
+	prov := fake.New()
+	prov.CapabilitiesValue = tlspkg.Capabilities{JavaPresent: true}
+
+	c := NewMkcertCheck(prov, nil)
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(out), out)
+	}
+	if out[0].ID != "mkcert-java-trust" {
+		t.Errorf("ID = %q, want mkcert-java-trust", out[0].ID)
+	}
+	if out[0].Severity != SeverityInfo {
+		t.Errorf("severity = %v, want SeverityInfo", out[0].Severity)
+	}
+	if out[0].Remediation == "" {
+		t.Errorf("Remediation should be set")
+	}
+}
+
+// TestMkcertCheckSurfaceFirefoxCapability covers the Firefox-on-Windows
+// half of the capability surface. Same Info-level + remediation copy.
+func TestMkcertCheckSurfaceFirefoxCapability(t *testing.T) {
+	prov := fake.New()
+	prov.CapabilitiesValue = tlspkg.Capabilities{FirefoxOnWindows: true}
+
+	c := NewMkcertCheck(prov, nil)
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(out))
+	}
+	if out[0].ID != "mkcert-firefox-windows" {
+		t.Errorf("ID = %q, want mkcert-firefox-windows", out[0].ID)
+	}
+	if out[0].Severity != SeverityInfo {
+		t.Errorf("severity = %v, want SeverityInfo", out[0].Severity)
+	}
+}
+
+// TestMkcertCheckSurfaceBothCapabilities covers a host that has both
+// Java and Firefox-on-Windows; we should see one finding per gap, both
+// Info-level, no double-counting.
+func TestMkcertCheckSurfaceBothCapabilities(t *testing.T) {
+	prov := fake.New()
+	prov.CapabilitiesValue = tlspkg.Capabilities{
+		JavaPresent:      true,
+		FirefoxOnWindows: true,
+	}
+
+	c := NewMkcertCheck(prov, nil)
+	out, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 findings, got %d: %+v", len(out), out)
+	}
+	for _, f := range out {
+		if f.Severity != SeverityInfo {
+			t.Errorf("finding %q severity = %v, want SeverityInfo", f.ID, f.Severity)
+		}
+	}
+}
+
+// TestMkcertCheckMissingDoesNotProbeCapabilities ensures the
+// Capabilities probe is short-circuited when mkcert is missing — the
+// Java / Firefox notes only make sense once the base CA is trusted.
+// We assert this by giving the fake a Java-present capability AND a
+// missing status; the output must still be the single mkcert-missing
+// Warn (no Info notes).
+func TestMkcertCheckMissingDoesNotProbeCapabilities(t *testing.T) {
+	prov := fake.New()
+	prov.AvailableStatus = tlspkg.Status{Installed: false}
+	prov.CapabilitiesValue = tlspkg.Capabilities{JavaPresent: true, FirefoxOnWindows: true}
+
+	c := NewMkcertCheck(prov, nil)
+	out, _ := c.Run(context.Background())
+	if len(out) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(out), out)
+	}
+	if out[0].ID != "mkcert-missing" {
+		t.Errorf("ID = %q, want mkcert-missing only when not installed", out[0].ID)
+	}
+}

--- a/internal/health/checks_paths.go
+++ b/internal/health/checks_paths.go
@@ -59,8 +59,14 @@ func (c *WSLMntCCheck) Run(ctx context.Context) ([]Finding, error) {
 	return out, nil
 }
 
-// WindowsLongPathCheck warns when any registered site root would breach
-// Windows' MAX_PATH limit once WordPress's deepest plugin path is appended.
+// WindowsLongPathCheck flags registered sites whose root path would
+// breach Windows' MAX_PATH limit once WordPress's deepest plugin path is
+// appended. Severity is conditional: when the OS has LongPathsEnabled
+// set, the kernel handles the overflow and we emit a soft Warn (some
+// legacy plugins still don't honour the manifest opt-in). When the flag
+// is unset, the site cannot reliably function and we emit a Blocker —
+// the lifecycle layer's AddSite/StartSite refuse to start the same site
+// for the same reason; the panel surfaces the rationale.
 type WindowsLongPathCheck struct {
 	platformInfo *platform.Info
 	sites        SiteRootLister
@@ -87,16 +93,25 @@ func (c *WindowsLongPathCheck) Run(ctx context.Context) ([]Finding, error) {
 		if !platform.IsLongPath(root) {
 			continue
 		}
-		out = append(out, Finding{
+		f := Finding{
 			ID:       c.ID(),
 			DedupKey: root,
-			Severity: SeverityWarn,
-			Title:    "Path may exceed Windows 260-character limit",
-			Detail: "The site at " + root + " is long enough that some WordPress plugin assets " +
-				"may exceed Windows MAX_PATH.",
-			Remediation: "Move the site under a shorter path, or enable LongPathsEnabled in the registry.",
-			HelpURL:     "https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation",
-		})
+			HelpURL:  "https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation",
+		}
+		if c.platformInfo.LongPathsEnabled {
+			f.Severity = SeverityWarn
+			f.Title = "Path may exceed Windows 260-character limit"
+			f.Detail = "The site at " + root + " is long enough that some WordPress plugin assets " +
+				"may exceed Windows MAX_PATH. LongPathsEnabled is set, but not every plugin honours it."
+			f.Remediation = "Move the site under a shorter path for the strongest guarantee."
+		} else {
+			f.Severity = SeverityBlocker
+			f.Title = "Path exceeds Windows 260-character limit"
+			f.Detail = "The site at " + root + " breaches Windows MAX_PATH and LongPathsEnabled is not set; " +
+				"Locorum will refuse to start it until the path is shortened or the registry flag is enabled."
+			f.Remediation = "Move the site under a shorter path (≤ 200 chars), or enable LongPathsEnabled in the registry (admin) and restart Locorum."
+		}
+		out = append(out, f)
 	}
 	return out, nil
 }

--- a/internal/health/checks_port.go
+++ b/internal/health/checks_port.go
@@ -22,19 +22,28 @@ type PortConflictCheck struct {
 	port      int
 	routerCN  string // container name to attribute the bind to (locorum-global-router)
 	humanPort string // for finding text ("80", "443")
+
+	// holdersSink, when non-nil, attaches a "Show port holders" Action to
+	// every finding produced by this check. The sink receives the
+	// formatted lookup text (lsof rows on Unix, Get-NetTCPConnection on
+	// Windows) and is expected to surface it to the user (typically by
+	// pushing it into a UIState modal). See [BundledOpts.PortHolderSink].
+	holdersSink func(port int, text string)
 }
 
 // NewPortConflictCheck constructs a check for a single port. The router's
 // container name is a parameter so the health package doesn't depend on
 // internal/router/traefik (which would drag genmark + tls + docker spec
 // templating into our import graph). The Bundled() factory passes
-// traefik.ContainerName.
-func NewPortConflictCheck(engine docker.Engine, port int, routerContainerName string) *PortConflictCheck {
+// traefik.ContainerName. holdersSink is optional — pass nil to omit the
+// inline action.
+func NewPortConflictCheck(engine docker.Engine, port int, routerContainerName string, holdersSink func(port int, text string)) *PortConflictCheck {
 	return &PortConflictCheck{
-		engine:    engine,
-		port:      port,
-		routerCN:  routerContainerName,
-		humanPort: strconv.Itoa(port),
+		engine:      engine,
+		port:        port,
+		routerCN:    routerContainerName,
+		humanPort:   strconv.Itoa(port),
+		holdersSink: holdersSink,
 	}
 }
 
@@ -52,13 +61,27 @@ func (c *PortConflictCheck) Run(ctx context.Context) ([]Finding, error) {
 		// Locorum's own bind. Nothing to warn about.
 		return nil, nil
 	}
-	return []Finding{{
+	f := Finding{
 		ID:       c.ID(),
 		Severity: SeverityWarn,
 		Title:    "Port " + c.humanPort + " is held by another process",
 		Detail: "Another process is listening on 127.0.0.1:" + c.humanPort +
 			". Locorum's router cannot bind it; sites may be unreachable.",
-		Remediation: "Stop the conflicting service (`lsof -iTCP:" + c.humanPort + "` lists candidates), then re-check.",
+		Remediation: "Stop the conflicting service, then re-check. Click the action below to identify it.",
 		HelpURL:     "https://docs.locorum.dev/troubleshooting/ports",
-	}}, nil
+	}
+	if c.holdersSink != nil {
+		port := c.port
+		sink := c.holdersSink
+		f.Action = &Action{
+			Label:   "Show port holders",
+			Timeout: portHolderLookupTimeout + time.Second,
+			Run: func(actCtx context.Context) error {
+				text, _ := lookupPortHolders(actCtx, port)
+				sink(port, text)
+				return nil
+			},
+		}
+	}
+	return []Finding{f}, nil
 }

--- a/internal/health/checks_test.go
+++ b/internal/health/checks_test.go
@@ -139,7 +139,7 @@ func TestPortConflictCheckOurRouter(t *testing.T) {
 	})
 	_ = e.StartContainer(context.Background(), "locorum-global-router")
 
-	c := NewPortConflictCheck(e, port, "locorum-global-router")
+	c := NewPortConflictCheck(e, port, "locorum-global-router", nil)
 	out, err := c.Run(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -159,7 +159,7 @@ func TestPortConflictCheckForeignBind(t *testing.T) {
 
 	e := fake.New() // no router container
 
-	c := NewPortConflictCheck(e, port, "locorum-global-router")
+	c := NewPortConflictCheck(e, port, "locorum-global-router", nil)
 	out, _ := c.Run(context.Background())
 	if len(out) != 1 {
 		t.Fatalf("expected 1 conflict warning; got %d", len(out))
@@ -169,6 +169,50 @@ func TestPortConflictCheckForeignBind(t *testing.T) {
 	}
 	if out[0].ID != "port-conflict-"+strconv.Itoa(port) {
 		t.Errorf("ID mismatch: %q", out[0].ID)
+	}
+}
+
+// TestPortConflictCheckAttachesShowHoldersActionWhenSinkProvided locks
+// in the F14 wiring: when the bundled options carry a non-nil
+// PortHolderSink, every conflict finding gains a one-click action that
+// pipes the platform-specific holder text into the sink. The action's
+// Run is exercised here so the goroutine path is covered in CI.
+func TestPortConflictCheckAttachesShowHoldersActionWhenSinkProvided(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	e := fake.New() // no router container ⇒ foreign bind
+	var (
+		sinkPort int
+		sinkText string
+	)
+	sink := func(p int, text string) {
+		sinkPort = p
+		sinkText = text
+	}
+	c := NewPortConflictCheck(e, port, "locorum-global-router", sink)
+	out, _ := c.Run(context.Background())
+	if len(out) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(out))
+	}
+	if out[0].Action == nil {
+		t.Fatal("expected an Action attached when sink is provided")
+	}
+	if out[0].Action.Run == nil {
+		t.Fatal("Action.Run must be non-nil")
+	}
+	if err := out[0].Action.Run(context.Background()); err != nil {
+		t.Fatalf("Action.Run returned %v; expected nil", err)
+	}
+	if sinkPort != port {
+		t.Errorf("sink saw port %d, want %d", sinkPort, port)
+	}
+	if sinkText == "" {
+		t.Errorf("sink received empty text; expected lookupPortHolders output")
 	}
 }
 
@@ -182,7 +226,7 @@ func TestPortConflictCheckNoListener(t *testing.T) {
 	ln.Close()
 
 	e := fake.New()
-	c := NewPortConflictCheck(e, port, "locorum-global-router")
+	c := NewPortConflictCheck(e, port, "locorum-global-router", nil)
 	out, _ := c.Run(context.Background())
 	if len(out) != 0 {
 		t.Errorf("expected no finding when nothing listens; got %+v", out)

--- a/internal/health/portholders_unix.go
+++ b/internal/health/portholders_unix.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// portHolderLookupTimeout caps the lsof shell-out. lsof typically returns
+// in well under 100 ms even when many connections exist; a longer hang is
+// almost always lsof waiting on a pipe / FIFO and we'd rather surface an
+// empty result than freeze the action button.
+const portHolderLookupTimeout = 3 * time.Second
+
+// lookupPortHolders shells out to lsof to enumerate processes holding
+// `port`. Returns the human-readable lsof header + matching rows on
+// success; on failure returns a remediation-shaped string the UI can
+// surface to the user (e.g. "lsof not found on PATH"). Both return paths
+// are nil-error: the caller treats this as informational data, not a
+// fault to log.
+//
+// On WSL hosts the result reflects only Linux-side processes; if a
+// Windows-side service is holding the port (IIS, Skype, etc.) it will
+// not appear here. We add a one-line note in that case so the user
+// knows where else to look.
+func lookupPortHolders(ctx context.Context, port int) (string, error) {
+	bin, err := exec.LookPath("lsof")
+	if err != nil {
+		return "lsof was not found on PATH. Install lsof, or use `ss -ltnp 'sport = :" +
+			strconv.Itoa(port) + "'` from a privileged shell to identify the holder.", nil
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, portHolderLookupTimeout)
+	defer cancel()
+
+	// -nP suppresses DNS + service-name resolution (faster, deterministic).
+	// -iTCP:<port> matches IPv4+IPv6 TCP sockets bound to the port.
+	// -sTCP:LISTEN narrows to listening sockets — established outbound
+	// connections to a remote port:80 are not relevant here.
+	cmd := exec.CommandContext(cctx, bin, "-nP", "-iTCP:"+strconv.Itoa(port), "-sTCP:LISTEN")
+	out, runErr := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(out))
+
+	if cctx.Err() != nil {
+		return "lsof timed out after " + portHolderLookupTimeout.String() +
+			". Run `lsof -nP -iTCP:" + strconv.Itoa(port) + " -sTCP:LISTEN` manually.", nil
+	}
+	// lsof exits 1 with no output when nothing matches; that's a successful
+	// "no listener" answer in our model. Anything else with output is the
+	// usual "rows of processes" case.
+	if text == "" {
+		if runErr != nil {
+			return fmt.Sprintf("No listener visible to lsof on port %d. Permission may be required (try `sudo lsof -nP -iTCP:%d -sTCP:LISTEN`).", port, port), nil
+		}
+		return fmt.Sprintf("No process is listening on port %d.", port), nil
+	}
+	return text, nil
+}

--- a/internal/health/portholders_windows.go
+++ b/internal/health/portholders_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package health
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// portHolderLookupTimeout caps the PowerShell shell-out. The Get-NetTCPConnection
+// + Get-Process pipeline is fast on a typical Windows host but starting
+// powershell.exe itself costs ~200 ms cold; a 5-second cap is generous.
+const portHolderLookupTimeout = 5 * time.Second
+
+// lookupPortHolders shells out to PowerShell to enumerate processes
+// holding `port` on Windows. The pipeline returns process name + PID +
+// command-line for each listener, which is enough to point the user at
+// the offending application without requiring admin privileges.
+//
+// Both return paths are nil-error: the caller treats this as
+// informational data, not a fault to log.
+func lookupPortHolders(ctx context.Context, port int) (string, error) {
+	if _, err := exec.LookPath("powershell.exe"); err != nil {
+		return "PowerShell is not on PATH. Open an admin terminal and run " +
+			"`Get-NetTCPConnection -LocalPort " + strconv.Itoa(port) + "` to identify the holder.", nil
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, portHolderLookupTimeout)
+	defer cancel()
+
+	// -NoProfile shaves 100-200 ms off cold-start; -NonInteractive
+	// prevents an accidental Read-Host prompt from blocking forever.
+	// The script is hand-built (not %d formatted) to avoid any prompt
+	// injection from the port number.
+	script := "$conns = Get-NetTCPConnection -LocalPort " + strconv.Itoa(port) +
+		" -State Listen -ErrorAction SilentlyContinue; " +
+		"if ($null -eq $conns) { 'No process is listening on port " + strconv.Itoa(port) + ".'; return }; " +
+		"$conns | ForEach-Object { " +
+		"$p = Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue; " +
+		"$name = if ($p) { $p.ProcessName } else { '<unknown>' }; " +
+		"'{0,-22} {1,-7} {2,-6} {3}' -f $_.LocalAddress, $_.LocalPort, $_.OwningProcess, $name " +
+		"}"
+
+	cmd := exec.CommandContext(cctx, "powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script)
+	out, _ := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(out))
+
+	if cctx.Err() != nil {
+		return "Get-NetTCPConnection timed out after " + portHolderLookupTimeout.String() +
+			". Run the command manually from PowerShell.", nil
+	}
+	if text == "" {
+		return "No process is listening on port " + strconv.Itoa(port) + ".", nil
+	}
+	header := "ADDRESS                PORT    PID    PROCESS\n"
+	return header + text, nil
+}

--- a/internal/platform/longpath_other.go
+++ b/internal/platform/longpath_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package platform
+
+// readLongPathsEnabled is the non-Windows stub. The MAX_PATH limit is a
+// Windows-only concern; on Linux/macOS we report "off" and the IsLongPath
+// check (which is also gated by runtime.GOOS) renders the field unused.
+func readLongPathsEnabled() bool {
+	return false
+}

--- a/internal/platform/longpath_windows.go
+++ b/internal/platform/longpath_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package platform
+
+import (
+	"errors"
+	"log/slog"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// longPathsRegistryKey is the canonical location of the LongPathsEnabled
+// flag — set in Win10 1607+ to opt the OS into >MAX_PATH file paths for
+// processes that also opt in via their manifest. Older Windows builds
+// don't carry the value at all; we treat that case as "off".
+const (
+	longPathsRegistryKey   = `SYSTEM\CurrentControlSet\Control\FileSystem`
+	longPathsRegistryValue = `LongPathsEnabled`
+)
+
+// readLongPathsEnabled returns whether the OS has the LongPathsEnabled
+// flag set to 1. Treats every failure mode (missing key, missing value,
+// access denied, non-DWORD type) as "off" — the safer direction for a
+// gating check that errs on the side of refusing to create a site whose
+// path might breach MAX_PATH.
+//
+// All non-NotFound failures are logged at debug level so an operator
+// can diagnose why a Windows host with the flag set is being treated as
+// off (e.g. the GUI is running under a service account without registry
+// read permission).
+func readLongPathsEnabled() bool {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, longPathsRegistryKey, registry.QUERY_VALUE)
+	if err != nil {
+		if !errors.Is(err, registry.ErrNotExist) {
+			slog.Debug("platform: open LongPathsEnabled key", "err", err.Error())
+		}
+		return false
+	}
+	defer k.Close()
+
+	v, _, err := k.GetIntegerValue(longPathsRegistryValue)
+	if err != nil {
+		if !errors.Is(err, registry.ErrNotExist) {
+			slog.Debug("platform: read LongPathsEnabled value", "err", err.Error())
+		}
+		return false
+	}
+	return v == 1
+}

--- a/internal/platform/paths.go
+++ b/internal/platform/paths.go
@@ -68,8 +68,10 @@ func DockerPath(p string) string {
 // MAX_PATH limit.
 //
 // Returns false on non-Windows hosts — Linux/macOS path limits are far
-// higher and IsLongPath would just produce noise. The check is informational;
-// a true result does NOT block site creation, just adds a yellow note.
+// higher and IsLongPath would just produce noise. The check answers a
+// pure path question; whether the result is a hard error or a soft
+// warning is decided by the caller in conjunction with
+// [Info.LongPathsEnabled] (see [LongPathBlocking]).
 func IsLongPath(p string) bool {
 	if runtime.GOOS != "windows" {
 		return false
@@ -83,6 +85,27 @@ func IsLongPath(p string) bool {
 		return false
 	}
 	return len(p)+1+WPMaxPluginPathSuffix > WindowsMaxPath
+}
+
+// LongPathBlocking reports whether p is a *blocking* long-path problem on
+// the host described by info: i.e. the path would breach MAX_PATH AND the
+// OS does not have the LongPathsEnabled registry flag set. When the flag
+// is set, the OS handles the overflow and the caller should downgrade the
+// finding to a soft note.
+//
+// Pure: no I/O, no globals, safe to call on every keystroke. Returns
+// false for nil info, empty p, or non-Windows hosts.
+func LongPathBlocking(p string, info *Info) bool {
+	if info == nil {
+		return false
+	}
+	if info.OS != "windows" {
+		return false
+	}
+	if info.LongPathsEnabled {
+		return false
+	}
+	return IsLongPath(p)
 }
 
 // IsMntC reports whether p is on Windows-host-mounted DrvFS under WSL2

--- a/internal/platform/paths_test.go
+++ b/internal/platform/paths_test.go
@@ -72,6 +72,45 @@ func TestIsMntDrvFsPath(t *testing.T) {
 	}
 }
 
+// TestLongPathBlocking covers the registry-aware severity decision used
+// by sites.ValidateSitePath: a path that breaches MAX_PATH only blocks
+// when the OS does *not* have LongPathsEnabled set.
+func TestLongPathBlocking(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// IsLongPath is short-circuited to false on non-Windows; assert
+		// LongPathBlocking inherits that behaviour and never blocks on
+		// Linux/macOS regardless of the registry shape.
+		long := strings.Repeat("a", 500)
+		off := &Info{OS: "linux", LongPathsEnabled: false}
+		if LongPathBlocking(long, off) {
+			t.Errorf("LongPathBlocking must return false on non-Windows hosts")
+		}
+		return
+	}
+	threshold := WindowsMaxPath - 1 - WPMaxPluginPathSuffix
+	long := strings.Repeat("a", threshold+1)
+	short := strings.Repeat("a", threshold)
+
+	off := &Info{OS: "windows", LongPathsEnabled: false}
+	on := &Info{OS: "windows", LongPathsEnabled: true}
+
+	if !LongPathBlocking(long, off) {
+		t.Error("long path on Windows with LongPathsEnabled=false MUST block")
+	}
+	if LongPathBlocking(long, on) {
+		t.Error("long path on Windows with LongPathsEnabled=true must not block (OS handles it)")
+	}
+	if LongPathBlocking(short, off) {
+		t.Error("short path must not block regardless of registry state")
+	}
+	if LongPathBlocking("", off) {
+		t.Error("empty path must not block")
+	}
+	if LongPathBlocking(long, nil) {
+		t.Error("nil info must not block")
+	}
+}
+
 // TestIsMntCRespectsWSLActive confirms the public IsMntC short-circuits on
 // non-WSL hosts even when the path *would* match. Test installs a fake
 // platform.Info via NewForTest so we don't depend on the build host.

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -72,6 +72,14 @@ type Info struct {
 
 	// Hostname is best-effort; "" if os.Hostname errored.
 	Hostname string
+
+	// LongPathsEnabled is true when the host is Windows AND the
+	// HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled
+	// registry value is 1. False on every other host (including
+	// Windows without the value, which is the legacy MAX_PATH regime).
+	// Consumers branch on this to decide whether a path that would
+	// breach MAX_PATH is a hard error or a tolerable one.
+	LongPathsEnabled bool
 }
 
 // WSLInfo carries the Windows-Subsystem-for-Linux specifics. Active is the
@@ -166,14 +174,15 @@ func detect(ctx context.Context) *Info {
 	host, _ := os.Hostname()
 
 	info := &Info{
-		OS:           runtime.GOOS,
-		Arch:         runtime.GOARCH,
-		Username:     username,
-		UID:          uid,
-		GID:          gid,
-		HomeDir:      homeDir,
-		Hostname:     host,
-		UnderRosetta: isUnderRosetta(),
+		OS:               runtime.GOOS,
+		Arch:             runtime.GOARCH,
+		Username:         username,
+		UID:              uid,
+		GID:              gid,
+		HomeDir:          homeDir,
+		Hostname:         host,
+		UnderRosetta:     isUnderRosetta(),
+		LongPathsEnabled: readLongPathsEnabled(),
 	}
 
 	info.WSL = detectWSL(ctx)

--- a/internal/sites/checkpath_test.go
+++ b/internal/sites/checkpath_test.go
@@ -1,0 +1,80 @@
+package sites
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/PeterBooker/locorum/internal/platform"
+)
+
+// TestCheckPathBlockingPassesWhenPlatformUninit covers the safety
+// fallback: if platform.Init has not been called (e.g. early-startup
+// scripted callers, certain CLI sub-commands), the check is a no-op
+// rather than a panic. Production callers always run after Init, so this
+// is purely a defence in depth.
+func TestCheckPathBlockingPassesWhenPlatformUninit(t *testing.T) {
+	restore := platform.NewForTest(nil)
+	defer restore()
+
+	sm := &SiteManager{}
+	if err := sm.checkPathBlocking("/whatever"); err != nil {
+		t.Errorf("uninit platform should not block: %v", err)
+	}
+}
+
+// TestCheckPathBlockingNoOpOnLinux confirms the check is silent for
+// every Linux/macOS host even on absurd path lengths — the long-path
+// limit is a Windows-only concern.
+func TestCheckPathBlockingNoOpOnLinux(t *testing.T) {
+	info := &platform.Info{OS: "linux", LongPathsEnabled: false}
+	restore := platform.NewForTest(info)
+	defer restore()
+
+	sm := &SiteManager{}
+	if err := sm.checkPathBlocking(strings.Repeat("a", 500)); err != nil {
+		t.Errorf("linux host should not block long paths: %v", err)
+	}
+}
+
+// TestCheckPathBlockingFailsOnWindowsWithoutLongPaths is the load-bearing
+// case for F12: a long path on a Windows host without LongPathsEnabled
+// produces ErrPathTooLong wrapping the validate.go remediation message.
+// The IsLongPath gate is runtime.GOOS-bound, so on Linux test runners
+// we skip the assertion side and only assert the success path above.
+func TestCheckPathBlockingFailsOnWindowsWithoutLongPaths(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("IsLongPath is runtime.GOOS-gated; full enforcement only observable on Windows")
+	}
+	info := &platform.Info{OS: "windows", LongPathsEnabled: false}
+	restore := platform.NewForTest(info)
+	defer restore()
+
+	sm := &SiteManager{}
+	long := strings.Repeat("a", 200)
+	err := sm.checkPathBlocking(long)
+	if err == nil {
+		t.Fatal("expected ErrPathTooLong, got nil")
+	}
+	if !errors.Is(err, ErrPathTooLong) {
+		t.Errorf("expected errors.Is(err, ErrPathTooLong) == true; err = %v", err)
+	}
+}
+
+// TestCheckPathBlockingPassesWhenLongPathsEnabled ensures the registry
+// opt-in downgrades the gate. Same runtime.GOOS guard as above.
+func TestCheckPathBlockingPassesWhenLongPathsEnabled(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("IsLongPath is runtime.GOOS-gated; full enforcement only observable on Windows")
+	}
+	info := &platform.Info{OS: "windows", LongPathsEnabled: true}
+	restore := platform.NewForTest(info)
+	defer restore()
+
+	sm := &SiteManager{}
+	long := strings.Repeat("a", 200)
+	if err := sm.checkPathBlocking(long); err != nil {
+		t.Errorf("LongPathsEnabled=true should not block long paths: %v", err)
+	}
+}

--- a/internal/sites/errors.go
+++ b/internal/sites/errors.go
@@ -8,3 +8,10 @@ import "errors"
 // site" action that kicks off StartSite (it does NOT auto-retry the
 // original action; the user re-clicks once the site is healthy).
 var ErrSiteNotRunning = errors.New("site is not running")
+
+// ErrPathTooLong is returned by [SiteManager.AddSite] and the start-site
+// lifecycle when the site's root path would breach Windows' MAX_PATH and
+// the OS does not have LongPathsEnabled. UI code branches on errors.Is
+// to render a precise remediation dialog. Linux/macOS hosts never see
+// this error — the underlying check returns false on non-Windows.
+var ErrPathTooLong = errors.New("site path exceeds Windows MAX_PATH and LongPathsEnabled is not set")

--- a/internal/sites/sites.go
+++ b/internal/sites/sites.go
@@ -33,6 +33,7 @@ import (
 	"github.com/PeterBooker/locorum/internal/git"
 	"github.com/PeterBooker/locorum/internal/hooks"
 	"github.com/PeterBooker/locorum/internal/orch"
+	"github.com/PeterBooker/locorum/internal/platform"
 	"github.com/PeterBooker/locorum/internal/router"
 	"github.com/PeterBooker/locorum/internal/secrets"
 	"github.com/PeterBooker/locorum/internal/sites/configyaml"
@@ -422,7 +423,34 @@ func generatePassword(n int) (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+// checkPathBlocking refuses with a precise typed error when the site's
+// path triggers a [PathSeverityBlock] note for the current platform. It's
+// the single chokepoint AddSite + StartSite share — keep new lifecycle
+// methods consistent by funnelling through it rather than re-deriving the
+// check inline.
+func (sm *SiteManager) checkPathBlocking(filesDir string) error {
+	if !platform.IsInitialized() {
+		return nil
+	}
+	notes := ValidateSitePath(filesDir, platform.Get())
+	for _, n := range notes {
+		if n.Severity != PathSeverityBlock {
+			continue
+		}
+		return fmt.Errorf("%w: %s", ErrPathTooLong, n.Remediation)
+	}
+	return nil
+}
+
 func (sm *SiteManager) AddSite(site types.Site) error {
+	// Refuse paths that would breach Windows MAX_PATH on a host without
+	// LongPathsEnabled. The UI's debounced ValidateSitePath already
+	// disables the Create button in that case, but enforce here too so
+	// scripted callers (CLI, MCP, daemon RPC) get the same protection.
+	if err := sm.checkPathBlocking(site.FilesDir); err != nil {
+		return err
+	}
+
 	site.ID = uuid.NewString()
 	site.Slug = slug.Make(site.Name)
 	site.Domain = slug.Make(site.Name) + ".localhost"
@@ -486,6 +514,14 @@ func (sm *SiteManager) StartSite(ctx context.Context, id string) error {
 	}
 	if site == nil {
 		return fmt.Errorf("site %q not found", id)
+	}
+
+	// Backstop sites whose path was tolerable when registered but is no
+	// longer valid (LongPathsEnabled was disabled, or the row was
+	// imported from a Linux host). Refuse to spin containers on a path
+	// the OS can't actually serve.
+	if err := sm.checkPathBlocking(site.FilesDir); err != nil {
+		return err
 	}
 
 	mu := sm.siteMutex(id)

--- a/internal/sites/validate.go
+++ b/internal/sites/validate.go
@@ -4,37 +4,67 @@ import (
 	"github.com/PeterBooker/locorum/internal/platform"
 )
 
-// PathNote is a single warning produced by [ValidateSitePath]. Severity is
-// always "warn" — the modal allows submission either way; the note exists
-// to set expectations ("this site is going to feel slow" / "Windows MAX_PATH
-// could bite later").
+// PathNoteSeverity classifies a [PathNote] as either a soft warning the
+// user can dismiss or a hard error that should block site creation /
+// start. The zero value (Warn) is the historical default — every existing
+// caller that constructs PathNote without setting Severity keeps the same
+// behaviour.
+type PathNoteSeverity int8
+
+const (
+	// PathSeverityWarn is informational. The new-site modal renders an
+	// amber banner; the user may submit anyway.
+	PathSeverityWarn PathNoteSeverity = 0
+
+	// PathSeverityBlock is a hard error. The form's submit button is
+	// disabled and [SiteManager.AddSite] / [SiteManager.StartSite]
+	// refuse with [ErrPathTooLong].
+	PathSeverityBlock PathNoteSeverity = 1
+)
+
+// PathNote is a single warning produced by [ValidateSitePath]. The
+// modal allows submission only when [Severity] is [PathSeverityWarn] for
+// every note in the slice; a single [PathSeverityBlock] disables the
+// Create button and the create call refuses regardless.
 //
 // We don't reuse health.Finding here because the lifecycle is different:
 // these are surfaced inline next to the path field, not in the System Health
 // panel. Sharing a struct would couple the new-site modal to the runner
 // machinery for no benefit.
 type PathNote struct {
+	// Severity selects between soft warn (default) and hard block.
+	Severity PathNoteSeverity
+
 	// Title is the short heading. ~40 chars.
 	Title string
 
 	// Detail is the single-sentence explanation.
 	Detail string
 
+	// Remediation is an imperative one-liner ("Use a shorter path or
+	// enable LongPathsEnabled"). Only set for blocking notes; warn
+	// notes lean on Detail to convey the same.
+	Remediation string
+
 	// HelpURL is an optional documentation link.
 	HelpURL string
 }
 
-// ValidateSitePath returns 0..n warning notes for path p on a host described
-// by info. Pure: no I/O, no globals, no clock. Safe to call on every
+// ValidateSitePath returns 0..n notes for path p on a host described by
+// info. Pure: no I/O, no globals, no clock. Safe to call on every
 // keystroke (the caller debounces before re-rendering, but the function
 // itself is microsecond-cheap).
 //
 // Cases checked:
 //
 //   - WSL host with site under /mnt/c (or any /mnt/<letter>/) — DrvFS is
-//     much slower than native ext4 for the WordPress workload.
+//     much slower than native ext4 for the WordPress workload. Warn.
 //   - Windows host where the path's expected longest descendant exceeds
-//     MAX_PATH — some plugin assets will fail to resolve.
+//     MAX_PATH. Severity depends on [platform.Info.LongPathsEnabled]:
+//     when the OS has the long-path opt-in set, this is a Warn (the OS
+//     handles it, but some legacy plugins still won't). When the flag is
+//     off (or the registry value couldn't be read), it's a Block — the
+//     create call refuses to proceed.
 //
 // Empty path → no notes (the form's "required" check handles emptiness;
 // we don't double up).
@@ -54,12 +84,40 @@ func ValidateSitePath(p string, info *platform.Info) []PathNote {
 	}
 
 	if info.OS == "windows" && platform.IsLongPath(p) {
-		notes = append(notes, PathNote{
-			Title:   "Path may exceed Windows 260-character limit",
-			Detail:  "Some WordPress plugin assets may fail to resolve. Use a shorter root path, or enable LongPathsEnabled in the registry.",
-			HelpURL: "https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation",
-		})
+		switch {
+		case info.LongPathsEnabled:
+			// The OS's long-path opt-in is set. Most things will work,
+			// but some plugins / tooling don't honour the manifest opt-in
+			// and will still hit MAX_PATH. Keep as a soft warning so the
+			// user can choose to use a shorter path anyway.
+			notes = append(notes, PathNote{
+				Severity: PathSeverityWarn,
+				Title:    "Path may exceed Windows 260-character limit",
+				Detail:   "LongPathsEnabled is set, but some WordPress plugins still don't opt in to long paths and may fail at install time.",
+				HelpURL:  "https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation",
+			})
+		default:
+			notes = append(notes, PathNote{
+				Severity:    PathSeverityBlock,
+				Title:       "Path exceeds Windows 260-character limit",
+				Detail:      "Windows MAX_PATH is 260 characters; this path's deepest WordPress asset would breach it.",
+				Remediation: "Use a shorter path (≤ 200 characters), or enable LongPathsEnabled in the registry (admin) and restart Locorum.",
+				HelpURL:     "https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation",
+			})
+		}
 	}
 
 	return notes
+}
+
+// HasBlockingNote reports whether any note in notes carries
+// [PathSeverityBlock]. Convenience for the UI form's submit-gating logic
+// and for [SiteManager.AddSite] / [SiteManager.StartSite] preflight.
+func HasBlockingNote(notes []PathNote) bool {
+	for _, n := range notes {
+		if n.Severity == PathSeverityBlock {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/sites/validate_test.go
+++ b/internal/sites/validate_test.go
@@ -28,6 +28,9 @@ func TestValidateSitePathWSLMntC(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 note, got %d", len(got))
 	}
+	if got[0].Severity != PathSeverityWarn {
+		t.Errorf("WSL mnt/c note should be warn, got %v", got[0].Severity)
+	}
 	if !strings.Contains(strings.ToLower(got[0].Title), "slow") {
 		t.Errorf("expected 'slow' in title, got %q", got[0].Title)
 	}
@@ -50,4 +53,79 @@ func TestValidateSitePathLinuxIsAlwaysClean(t *testing.T) {
 	if len(got) != 0 {
 		t.Errorf("linux + long path should produce no notes; long-path is windows-only; got %v", got)
 	}
+}
+
+// TestValidateSitePathWindowsLongBlocksWhenRegistryOff covers the F12
+// Plan §1: on a Windows host whose registry has LongPathsEnabled = 0
+// (or unread), a long path must produce a [PathSeverityBlock] note so
+// AddSite refuses and the UI gates the Create button. We construct the
+// platform.Info directly rather than relying on the runtime.GOOS-gated
+// IsLongPath: the Linux test runner can't observe runtime.GOOS=windows,
+// so the long-path leg is skipped on non-Windows builds. The point of
+// the test is to lock in the *severity* for cases that *do* trigger.
+func TestValidateSitePathWindowsLongBlocksWhenRegistryOff(t *testing.T) {
+	// IsLongPath is gated on runtime.GOOS=="windows", so this test is a
+	// no-op on Linux. The non-Windows assertion lives in
+	// TestValidateSitePathLinuxIsAlwaysClean above; here we only assert
+	// that *if* the leg fires, severity matches the registry state.
+	info := &platform.Info{OS: "windows", LongPathsEnabled: false}
+	long := strings.Repeat("a", 200)
+	notes := ValidateSitePath(long, info)
+	if !platform.IsLongPath(long) {
+		// Cross-platform: IsLongPath bails on non-Windows runtimes.
+		// Skip the assertion rather than fail the test on Linux CI.
+		if len(notes) != 0 {
+			t.Fatalf("non-Windows runtime: expected no notes, got %d", len(notes))
+		}
+		t.Skip("IsLongPath is runtime.GOOS-gated; skipping severity check on non-Windows host")
+	}
+	if len(notes) != 1 {
+		t.Fatalf("expected 1 note, got %d", len(notes))
+	}
+	if notes[0].Severity != PathSeverityBlock {
+		t.Errorf("LongPathsEnabled=false: expected blocking severity, got %v", notes[0].Severity)
+	}
+	if notes[0].Remediation == "" {
+		t.Errorf("blocking note should set Remediation; got empty")
+	}
+}
+
+// TestValidateSitePathWindowsLongWarnsWhenRegistryOn covers the
+// downgrade leg: with LongPathsEnabled = 1 the OS handles the overflow,
+// so we keep the note as a soft Warn rather than a Block.
+func TestValidateSitePathWindowsLongWarnsWhenRegistryOn(t *testing.T) {
+	info := &platform.Info{OS: "windows", LongPathsEnabled: true}
+	long := strings.Repeat("a", 200)
+	notes := ValidateSitePath(long, info)
+	if !platform.IsLongPath(long) {
+		t.Skip("IsLongPath is runtime.GOOS-gated; skipping severity check on non-Windows host")
+	}
+	if len(notes) != 1 {
+		t.Fatalf("expected 1 note, got %d", len(notes))
+	}
+	if notes[0].Severity != PathSeverityWarn {
+		t.Errorf("LongPathsEnabled=true: expected warn severity, got %v", notes[0].Severity)
+	}
+}
+
+// TestHasBlockingNote covers the helper used by the new-site modal and
+// the SiteManager preflight.
+func TestHasBlockingNote(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if HasBlockingNote(nil) {
+			t.Errorf("nil notes should not be blocking")
+		}
+	})
+	t.Run("only warns", func(t *testing.T) {
+		notes := []PathNote{{Severity: PathSeverityWarn}, {Severity: PathSeverityWarn}}
+		if HasBlockingNote(notes) {
+			t.Errorf("only-warns should not be blocking")
+		}
+	})
+	t.Run("contains blocker", func(t *testing.T) {
+		notes := []PathNote{{Severity: PathSeverityWarn}, {Severity: PathSeverityBlock}}
+		if !HasBlockingNote(notes) {
+			t.Errorf("any blocker should be blocking")
+		}
+	})
 }

--- a/internal/tls/capabilities.go
+++ b/internal/tls/capabilities.go
@@ -1,0 +1,65 @@
+package tls
+
+import (
+	"context"
+	"os"
+	"os/exec"
+)
+
+// Capabilities reports which downstream trust stores the user's host
+// environment cares about. mkcert installs into the OS root store and
+// (on Linux/macOS) the per-user NSS store automatically; everything
+// else needs the user to run `mkcert -install` from a context where the
+// relevant tooling is in PATH. We can't do that from a GUI process
+// (launchctl strips JAVA_HOME on macOS, and we lack the shell context
+// in general), so the contract is: detect, surface, let the user act.
+//
+// Each field answers "should the user care about this trust store on
+// this machine?". When true *and* mkcert is installed, the user's next
+// step is documented in the matching health Note.
+type Capabilities struct {
+	// JavaPresent is true when a Java toolchain is detectable on the
+	// host (JAVA_HOME set, or `java` on PATH). Spring Boot / Tomcat /
+	// SBT users in this bucket need to re-run `mkcert -install` from a
+	// terminal where JAVA_HOME resolves so the cacerts keystore picks
+	// up the local CA.
+	JavaPresent bool
+
+	// FirefoxOnWindows is true when the host is Windows AND a Firefox
+	// install is detectable. Firefox on Windows uses its own NSS DB
+	// that mkcert can only populate after Firefox has been launched at
+	// least once (NSS lazy-creates the profile dir on first run). The
+	// remediation copy in the matching Note tells the user to launch
+	// Firefox once and re-run the install.
+	FirefoxOnWindows bool
+}
+
+// detectJavaPresent is the cross-platform half of [Capabilities]. The
+// signal is the union of two cheap probes — JAVA_HOME being set, or
+// `java` resolving on PATH. Either alone is enough; both being false
+// means mkcert's Java keystore branch wouldn't have anything to write
+// to, so the user doesn't need a Note.
+func detectJavaPresent() bool {
+	if v := os.Getenv("JAVA_HOME"); v != "" {
+		return true
+	}
+	if _, err := exec.LookPath("java"); err == nil {
+		return true
+	}
+	return false
+}
+
+// Capabilities reports the host's trust-store environment for the
+// caller. Pure best-effort — every probe failure short-circuits to
+// "not detected" and the caller treats a zero-value Capabilities as
+// "no extra notes needed".
+//
+// Cheap: JAVA_HOME is an env-var read; `java` PATH lookup is a stat;
+// the Firefox-on-Windows leg short-circuits on non-Windows hosts
+// without doing any I/O.
+func (m *Mkcert) Capabilities(_ context.Context) Capabilities {
+	return Capabilities{
+		JavaPresent:      detectJavaPresent(),
+		FirefoxOnWindows: detectFirefoxOnWindows(),
+	}
+}

--- a/internal/tls/capabilities_other.go
+++ b/internal/tls/capabilities_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package tls
+
+// detectFirefoxOnWindows is the non-Windows stub. The Firefox-on-other-
+// OS trust paths are handled by mkcert's own NSS branch (Linux + macOS)
+// without further user action, so there's no Note to surface.
+func detectFirefoxOnWindows() bool {
+	return false
+}

--- a/internal/tls/capabilities_test.go
+++ b/internal/tls/capabilities_test.go
@@ -1,0 +1,83 @@
+package tls
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestDetectJavaPresentEnvWins exercises the JAVA_HOME branch. We can't
+// rely on the test host having (or not having) java on PATH, so we
+// scope the assertion to the env-var leg by setting/unsetting
+// JAVA_HOME and stripping `java` from PATH for the duration of the
+// test.
+func TestDetectJavaPresentEnvWins(t *testing.T) {
+	t.Setenv("JAVA_HOME", "/somewhere/jdk")
+	t.Setenv("PATH", "") // make `which java` fail regardless of host
+	if !detectJavaPresent() {
+		t.Errorf("JAVA_HOME=/somewhere/jdk should make detectJavaPresent return true")
+	}
+}
+
+// TestDetectJavaPresentBothMissing covers the negative case. Empty
+// JAVA_HOME + a PATH that can't resolve `java` must yield false. We
+// point PATH at an empty temp dir so LookPath fails deterministically.
+func TestDetectJavaPresentBothMissing(t *testing.T) {
+	empty := t.TempDir()
+	t.Setenv("JAVA_HOME", "")
+	t.Setenv("PATH", empty)
+	if detectJavaPresent() {
+		t.Errorf("no JAVA_HOME and no `java` on PATH should yield false")
+	}
+}
+
+// TestDetectJavaPresentPathLookup exercises the LookPath leg by
+// dropping a fake `java` executable in a temp dir and pointing PATH at
+// it. The probe doesn't invoke the binary; it only stat's it, so the
+// fake doesn't need to be functional.
+func TestDetectJavaPresentPathLookup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH lookup semantics on Windows differ; the env-var leg covers detection there")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "java")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("JAVA_HOME", "")
+	t.Setenv("PATH", dir)
+	if !detectJavaPresent() {
+		t.Errorf("`java` on PATH should make detectJavaPresent return true")
+	}
+}
+
+// TestMkcertCapabilitiesIntegratesProbes confirms the Capabilities
+// method wires the per-OS probes through. JavaPresent must reflect the
+// env-var probe; FirefoxOnWindows must be false on non-Windows hosts
+// (the stub returns false there) regardless of the env.
+func TestMkcertCapabilitiesIntegratesProbes(t *testing.T) {
+	t.Setenv("JAVA_HOME", "/somewhere/jdk")
+	t.Setenv("PATH", "")
+	m := NewMkcert(t.TempDir(), t.TempDir())
+	got := m.Capabilities(context.Background())
+	if !got.JavaPresent {
+		t.Errorf("expected JavaPresent=true; got %+v", got)
+	}
+	if runtime.GOOS != "windows" && got.FirefoxOnWindows {
+		t.Errorf("FirefoxOnWindows must be false on non-Windows hosts; got %+v", got)
+	}
+}
+
+// TestDetectFirefoxOnWindowsIsFalseElsewhere locks in the build-tag
+// stub: every non-Windows build returns false unconditionally so the
+// MkcertCheck never surfaces a Firefox-on-Windows note off-platform.
+func TestDetectFirefoxOnWindowsIsFalseElsewhere(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub-coverage test; the Windows leg has its own probe")
+	}
+	if detectFirefoxOnWindows() {
+		t.Errorf("non-Windows host returned FirefoxOnWindows=true")
+	}
+}

--- a/internal/tls/capabilities_windows.go
+++ b/internal/tls/capabilities_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package tls
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// detectFirefoxOnWindows checks the canonical install paths for a
+// Firefox executable. We deliberately avoid the registry — registry
+// reads from a Wayland/XWayland-shaped context have surprising failure
+// modes, and the install paths are stable across every Firefox version
+// shipped in the last decade.
+//
+// Returns false on any miss (including ENOENT for ProgramFiles).
+func detectFirefoxOnWindows() bool {
+	envKeys := []string{"ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"}
+	for _, key := range envKeys {
+		base := os.Getenv(key)
+		if base == "" {
+			continue
+		}
+		candidate := filepath.Join(base, "Mozilla Firefox", "firefox.exe")
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tls/fake/fake.go
+++ b/internal/tls/fake/fake.go
@@ -25,6 +25,11 @@ type Provider struct {
 	// AvailableErr forces Available to error.
 	AvailableErr error
 
+	// CapabilitiesValue is what Capabilities returns. Zero value means
+	// "no extra trust stores to surface" — tests that need the Java or
+	// Firefox-on-Windows code paths set it explicitly.
+	CapabilitiesValue tls.Capabilities
+
 	// IssueErr forces the next Issue to error, then clears.
 	IssueErr error
 
@@ -54,6 +59,12 @@ func (p *Provider) Available(_ context.Context) (tls.Status, error) {
 		return tls.Status{}, p.AvailableErr
 	}
 	return p.AvailableStatus, nil
+}
+
+func (p *Provider) Capabilities(_ context.Context) tls.Capabilities {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.CapabilitiesValue
 }
 
 func (p *Provider) Issue(_ context.Context, spec tls.CertSpec) (tls.CertPath, error) {

--- a/internal/tls/provider.go
+++ b/internal/tls/provider.go
@@ -13,6 +13,14 @@ type Provider interface {
 	// installed. Cheap; callers may invoke this on every UI tick.
 	Available(ctx context.Context) (Status, error)
 
+	// Capabilities reports environment-derived gaps in trust-store
+	// coverage. Used by the System Health panel to surface "you have
+	// Java installed; mkcert from a GUI process didn't touch the
+	// cacerts keystore" style notes after Available reports OK.
+	// Best-effort: each leg short-circuits to a zero value on probe
+	// failure.
+	Capabilities(ctx context.Context) Capabilities
+
 	// Issue creates or refreshes a cert covering the given hostnames and
 	// returns its on-disk paths. Idempotent: regenerates only if the
 	// existing cert's SANs do not match the spec (so repeated calls are

--- a/internal/ui/erractions.go
+++ b/internal/ui/erractions.go
@@ -68,11 +68,17 @@ func SurfaceError(state *UIState, prefix string, err error, starter func()) {
 			},
 		)
 	case errors.Is(err, router.ErrPortInUse):
+		// We deliberately do NOT fall back to ephemeral ports — the
+		// stable https://<slug>.localhost URL is load-bearing for
+		// browser cookies, mkcert SANs, hard-coded WP siteurl, and
+		// user-facing docs. The user must free the conflicting port.
+		// The System Health panel surfaces a one-click "Show port
+		// holders" action that runs lsof / Get-NetTCPConnection.
 		state.ShowErrorWithAction(
-			"A required network port is already in use. Choose a different port in Settings.",
+			"Port 80 or 443 is in use. Stop the conflicting process — System Health can list candidates.",
 			NotifyAction{
-				ID:    "open-network-settings",
-				Label: "Open Settings",
+				ID:    "open-system-health",
+				Label: "Open System Health",
 				Run: func() {
 					state.SetNavView(NavViewSettings)
 					state.ClearErrorBanner()

--- a/internal/ui/erractions_test.go
+++ b/internal/ui/erractions_test.go
@@ -41,8 +41,8 @@ func TestSurfaceErrorPortInUse(t *testing.T) {
 	wrapped := fmt.Errorf("router: %w", router.ErrPortInUse)
 	SurfaceError(s, "ignored", wrapped, nil)
 	got := s.ErrorBannerSnapshot()
-	if got.ActionID != "open-network-settings" {
-		t.Fatalf("ActionID = %q, want open-network-settings", got.ActionID)
+	if got.ActionID != "open-system-health" {
+		t.Fatalf("ActionID = %q, want open-system-health", got.ActionID)
 	}
 }
 

--- a/internal/ui/newsite.go
+++ b/internal/ui/newsite.go
@@ -195,11 +195,22 @@ func (m *NewSiteModal) HandleUserInteractions(gtx layout.Context) {
 		multisiteMap := []string{"", "subdirectory", "subdomain"}
 		multisite := multisiteMap[m.multisiteDropdown.Selected]
 
-		if name == "" {
+		// Refuse submit when the path picked up a hard-blocking
+		// note (today: Windows MAX_PATH without LongPathsEnabled).
+		// AddSite enforces the same rule for scripted callers; the
+		// in-form check is a UX aid so the user gets immediate
+		// feedback instead of an error toast after the goroutine
+		// fires.
+		notes := m.pathNotesSnapshot()
+
+		switch {
+		case name == "":
 			m.state.ShowError("Site name is required")
-		} else if filesDir == "" {
+		case filesDir == "":
 			m.state.ShowError("Files directory is required")
-		} else {
+		case sites.HasBlockingNote(notes):
+			m.state.ShowError("Choose a shorter path; this one exceeds Windows' 260-character limit.")
+		default:
 			go func() {
 				site := types.Site{
 					Name:         name,
@@ -417,8 +428,10 @@ func (m *NewSiteModal) layoutForm(gtx layout.Context, th *Theme) layout.Dimensio
 	)
 }
 
-// layoutPathNotes renders the inline yellow validation notes beneath the
-// directory picker. Empty when there's nothing to warn about.
+// layoutPathNotes renders the inline validation notes beneath the
+// directory picker. Empty when there's nothing to warn about. Blocker
+// notes render with the error palette and an extra remediation line so
+// the user knows the form's Create button won't fire.
 func (m *NewSiteModal) layoutPathNotes(gtx layout.Context, th *Theme) layout.Dimensions {
 	notes := m.pathNotesSnapshot()
 	if len(notes) == 0 {
@@ -427,13 +440,17 @@ func (m *NewSiteModal) layoutPathNotes(gtx layout.Context, th *Theme) layout.Dim
 	children := make([]layout.FlexChild, 0, len(notes))
 	for _, n := range notes {
 		children = append(children, layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			bg, fg := th.Color.WarnSoft, th.Color.Warn
+			if n.Severity == sites.PathSeverityBlock {
+				bg, fg = th.Color.ErrSoft, th.Color.Err
+			}
 			return layout.Inset{Top: th.Spacing.XS}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
-				return RoundedFill(gtx, th.Color.WarnSoft, th.Radii.R2, func(gtx layout.Context) layout.Dimensions {
+				return RoundedFill(gtx, bg, th.Radii.R2, func(gtx layout.Context) layout.Dimensions {
 					return layout.UniformInset(unit.Dp(8)).Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 							layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 								lbl := material.Body2(th.Theme, n.Title)
-								lbl.Color = th.Color.Warn
+								lbl.Color = fg
 								lbl.TextSize = th.Sizes.Body
 								lbl.Font.Weight = font.SemiBold
 								return lbl.Layout(gtx)
@@ -446,6 +463,15 @@ func (m *NewSiteModal) layoutPathNotes(gtx layout.Context, th *Theme) layout.Dim
 								lbl.Color = th.Color.Fg2
 								lbl.TextSize = th.Sizes.Body
 								return layout.Inset{Top: unit.Dp(2)}.Layout(gtx, lbl.Layout)
+							}),
+							layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+								if n.Remediation == "" {
+									return layout.Dimensions{}
+								}
+								lbl := material.Body2(th.Theme, "→ "+n.Remediation)
+								lbl.Color = th.Color.Fg2
+								lbl.TextSize = th.Sizes.Mono
+								return layout.Inset{Top: unit.Dp(4)}.Layout(gtx, lbl.Layout)
 							}),
 						)
 					})

--- a/internal/ui/portholdersmodal.go
+++ b/internal/ui/portholdersmodal.go
@@ -1,0 +1,126 @@
+package ui
+
+import (
+	"strconv"
+
+	"gioui.org/font"
+	"gioui.org/layout"
+	"gioui.org/unit"
+	"gioui.org/widget"
+	"gioui.org/widget/material"
+)
+
+// PortHoldersModal renders the multi-line lsof / Get-NetTCPConnection
+// output the user gets when they click "Show port holders" on a
+// port-conflict health finding. Single-instance because two port
+// conflicts almost always share a root cause and the user only needs to
+// see one — the state layer overwrites on each push.
+//
+// The modal is read-only: there's no Try-to-kill button. We deliberately
+// don't offer a "kill PID" action because:
+//   - We can't safely identify whether a foreign process is something
+//     the user wants stopped (e.g. their staging Apache, OS firewall).
+//   - On macOS / Windows the kill would need an elevation prompt we
+//     can't service from a GUI process without a separate helper.
+type PortHoldersModal struct {
+	state *UIState
+
+	closeBtn widget.Clickable
+	scroll   widget.List
+
+	keys *ModalFocus
+	anim *modalShowState
+}
+
+// NewPortHoldersModal builds the modal. Wired into the root UI's
+// HandleUserInteractions + Layout passes.
+func NewPortHoldersModal(state *UIState) *PortHoldersModal {
+	m := &PortHoldersModal{
+		state: state,
+		keys:  NewModalFocus(),
+		anim:  NewModalAnim(),
+	}
+	m.scroll.Axis = layout.Vertical
+	return m
+}
+
+// HandleUserInteractions processes Close clicks + Escape key. Called by
+// the root UI before Layout when the modal is visible.
+func (m *PortHoldersModal) HandleUserInteractions(gtx layout.Context) {
+	show, _, _ := m.state.GetPortHoldersModal()
+	if !show {
+		return
+	}
+	keys := ProcessModalKeys(gtx, m.keys.Tag)
+	if m.closeBtn.Clicked(gtx) || keys.Escape {
+		m.state.DismissPortHoldersModal()
+		m.keys.OnHide()
+		m.anim.Hide()
+	}
+}
+
+// Layout renders the modal. Returns zero dims when the modal is hidden
+// so the caller's tree collapses cleanly.
+func (m *PortHoldersModal) Layout(gtx layout.Context, th *Theme) layout.Dimensions {
+	show, port, text := m.state.GetPortHoldersModal()
+	if !show {
+		return layout.Dimensions{}
+	}
+
+	m.anim.Show()
+	return AnimatedModalOverlay(gtx, th, m.anim, func(gtx layout.Context) layout.Dimensions {
+		m.keys.Layout(gtx)
+
+		title := "Port " + strconv.Itoa(port) + " is held by:"
+		if port == 0 {
+			title = "Port holder details"
+		}
+
+		body := text
+		if body == "" {
+			body = "(no output)"
+		}
+
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				lbl := material.H6(th.Theme, title)
+				lbl.Color = th.Color.TextStrong
+				lbl.Font.Weight = font.SemiBold
+				return layout.Inset{Bottom: th.Spacing.MD}.Layout(gtx, lbl.Layout)
+			}),
+			// Output area. The shell-out result can be a few hundred
+			// chars (a busy port can list many sockets in IPv4 + IPv6
+			// pairs) — wrap it in a scrollable list of one tall label
+			// so it stays bounded by the modal frame.
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				return RoundedFill(gtx, th.Color.Bg2, th.Radii.R2, func(gtx layout.Context) layout.Dimensions {
+					return layout.UniformInset(unit.Dp(12)).Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+						// Cap modal height so a runaway lsof output
+						// doesn't push the close button off-screen.
+						gtx.Constraints.Max.Y = gtx.Dp(unit.Dp(280))
+						return material.List(th.Theme, &m.scroll).Layout(gtx, 1, func(gtx layout.Context, _ int) layout.Dimensions {
+							lbl := material.Body2(th.Theme, body)
+							lbl.Color = th.Color.Fg
+							lbl.TextSize = th.Sizes.Mono
+							lbl.Font = MonoFont
+							return lbl.Layout(gtx)
+						})
+					})
+				})
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				lbl := material.Body2(th.Theme, "Stop the listed process and re-check from the System Health panel.")
+				lbl.Color = th.Color.TextSecondary
+				lbl.TextSize = th.Sizes.Body
+				return layout.Inset{Top: th.Spacing.SM, Bottom: th.Spacing.MD}.Layout(gtx, lbl.Layout)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				return layout.Flex{Axis: layout.Horizontal, Spacing: layout.SpaceStart}.Layout(gtx,
+					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+						return PrimaryButton(gtx, th, &m.closeBtn, "Close")
+					}),
+				)
+			}),
+		)
+	})
+}

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -153,6 +153,15 @@ type UIState struct {
 	// Guarded by mu (top-level UIState mutex) — same as servicesHealth.
 	diskFreeBytes int64
 
+	// Port-holders modal state. Populated when the user clicks "Show
+	// port holders" on a port-conflict health finding. The action's
+	// goroutine pushes the lookup text + port number here; the modal
+	// reads via [GetPortHoldersModal] on every frame and disappears
+	// when [DismissPortHoldersModal] is called.
+	showPortHoldersModal bool
+	portHoldersPort      int
+	portHoldersText      string
+
 	// updateAvailable / updateURL / updateNotes / updateDismissed
 	// snapshot the latest update-check result for the Settings card and
 	// the nav rail dot. Empty updateAvailable = no banner; non-empty
@@ -915,6 +924,41 @@ func (s *UIState) SetCloneLoading(loading bool) {
 	s.cloneLoading = loading
 	s.mu.Unlock()
 	s.Invalidate()
+}
+
+// ─── Port Holders Modal ─────────────────────────────────────────────────────
+
+// ShowPortHoldersModal pushes a port-holder lookup result into the
+// modal. Called from the [health.Action] goroutine wired up by the
+// PortHolderSink in main.go. Multiple calls overwrite — the modal is
+// single-instance because two port conflicts almost always share a
+// root cause and the user only needs to see one.
+func (s *UIState) ShowPortHoldersModal(port int, text string) {
+	s.mu.Lock()
+	s.showPortHoldersModal = true
+	s.portHoldersPort = port
+	s.portHoldersText = text
+	s.mu.Unlock()
+	s.Invalidate()
+}
+
+// DismissPortHoldersModal hides the modal and clears the cached text.
+// Called by the modal's Close button.
+func (s *UIState) DismissPortHoldersModal() {
+	s.mu.Lock()
+	s.showPortHoldersModal = false
+	s.portHoldersPort = 0
+	s.portHoldersText = ""
+	s.mu.Unlock()
+	s.Invalidate()
+}
+
+// GetPortHoldersModal returns the current modal state. Layout reads
+// this once per frame; the bool is the "should render" gate.
+func (s *UIState) GetPortHoldersModal() (show bool, port int, text string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.showPortHoldersModal, s.portHoldersPort, s.portHoldersText
 }
 
 func (s *UIState) IsCloneLoading() bool {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -35,6 +35,7 @@ type UI struct {
 	CloneModal    *CloneModal
 	HealthBlocker *HealthBlockerModal
 	Telemetry     *TelemetryModal
+	PortHolders   *PortHoldersModal
 	deleteDialog  ConfirmDialog
 	deletePurge   widget.Bool
 
@@ -77,6 +78,7 @@ func New(sm *sites.SiteManager) *UI {
 	ui.NewSite = NewNewSiteModal(state, sm, ui.Toasts)
 	ui.CloneModal = NewCloneModal(state, sm, ui.Toasts)
 	ui.Telemetry = NewTelemetryModal(state, cfg)
+	ui.PortHolders = NewPortHoldersModal(state)
 
 	// Wire up backend callbacks to update UI state
 	sm.OnSitesUpdated = func(updatedSites []types.Site) {
@@ -151,6 +153,9 @@ func (ui *UI) HandleUserInteractions(gtx layout.Context) {
 	if ui.Telemetry != nil && ui.Telemetry.Show() {
 		ui.Telemetry.HandleUserInteractions(gtx)
 	}
+	if show, _, _ := ui.State.GetPortHoldersModal(); show {
+		ui.PortHolders.HandleUserInteractions(gtx)
+	}
 }
 
 func (ui *UI) Layout(gtx layout.Context) layout.Dimensions {
@@ -209,6 +214,15 @@ func (ui *UI) Layout(gtx layout.Context) layout.Dimensions {
 				return ui.Telemetry.Layout(gtx, ui.Theme)
 			}
 			return layout.Dimensions{}
+		}),
+		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+			if ui.PortHolders == nil {
+				return layout.Dimensions{}
+			}
+			if show, _, _ := ui.State.GetPortHoldersModal(); !show {
+				return layout.Dimensions{}
+			}
+			return ui.PortHolders.Layout(gtx, ui.Theme)
 		}),
 		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
 			return ui.Toasts.Layout(gtx, ui.Theme)

--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func main() {
 	mkcertInstaller := func(ctx context.Context) error {
 		return mkcert.InstallCA(ctx)
 	}
-	runner := newHealthRunner(plat, d, mkcert, mkcertInstaller, sm, cfg, homeDir)
+	runner := newHealthRunner(plat, d, mkcert, mkcertInstaller, sm, cfg, homeDir, userInterface.State)
 	defer func() { _ = runner.Close() }()
 
 	if cfg.HealthEnabled() {
@@ -378,12 +378,22 @@ func main() {
 // newHealthRunner builds the production runner with the bundled checks.
 // Cadence and thresholds come from the user's config; missing keys fall
 // back to documented defaults.
-func newHealthRunner(plat *platform.Info, d *docker.Docker, mkcert *tlspkg.Mkcert, mkInstaller func(context.Context) error, sm *sites.SiteManager, cfg *settings.Config, homeDir string) *health.Runner {
+func newHealthRunner(plat *platform.Info, d *docker.Docker, mkcert *tlspkg.Mkcert, mkInstaller func(context.Context) error, sm *sites.SiteManager, cfg *settings.Config, homeDir string, state *ui.UIState) *health.Runner {
 	cadence := time.Duration(cfg.HealthCadenceMinutes()) * time.Minute
 	if cadence <= 0 {
 		cadence = 5 * time.Minute
 	}
 	const gb = int64(1024 * 1024 * 1024)
+	// Port-holder action sink: fires from the health runner's action
+	// goroutine; pushes the lookup result into the modal-state slot
+	// the UI reads on every frame. Captures the *UIState pointer so
+	// the closure stays callable across the runner's lifetime.
+	portHolderSink := func(port int, text string) {
+		if state == nil {
+			return
+		}
+		state.ShowPortHoldersModal(port, text)
+	}
 	checks := health.Bundled(health.BundledOpts{
 		Platform:            plat,
 		Engine:              d,
@@ -392,6 +402,7 @@ func newHealthRunner(plat *platform.Info, d *docker.Docker, mkcert *tlspkg.Mkcer
 		Sites:               sm,
 		HostStatfsPath:      homeDir,
 		RouterContainerName: traefik.ContainerName,
+		PortHolderSink:      portHolderSink,
 		DiskWarnBytes:       int64(cfg.HealthDiskWarnGB()) * gb,
 		DiskBlockerBytes:    int64(cfg.HealthDiskBlockerGB()) * gb,
 	})


### PR DESCRIPTION
## F12 — Windows long-path becomes a hard-fail

- `internal/platform/longpath_windows.go` reads
  `HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled`
  once at `platform.Init` and caches the result on `platform.Info`.
  Treats every failure mode (missing key, access-denied) as `false`.
- `internal/sites/validate.go` adds a `Severity` field to `PathNote`.
  A path that breaches MAX_PATH while the registry flag is off becomes
  a `PathSeverityBlock` note with remediation copy.
- `SiteManager.AddSite` and `SiteManager.StartSite` share a
  `checkPathBlocking` chokepoint and refuse with the new
  `ErrPathTooLong` sentinel, so scripted callers (CLI, MCP, daemon
  RPC) get the same protection as the GUI.
- New-site modal disables the Create button on a blocking note and
  renders the row in the error palette.
- `health.WindowsLongPathCheck` mirrors the severity decision:
  Blocker when the registry flag is off, Warn when it's on.

## F14 — Port-conflict UX (probe + holder lookup; no fallback)

- `internal/health/portholders_unix.go` (lsof) and
  `portholders_windows.go` (`Get-NetTCPConnection`) enumerate
  processes holding port 80/443. Bounded by a 3–5 s timeout; falls
  back to a remediation-shaped string when the platform tool isn't on
  PATH.
- `health.PortConflictCheck` attaches a "Show port holders" Action to
  every conflict finding when the bundled `PortHolderSink` is non-nil.
  Result flows through `UIState.ShowPortHoldersModal` into a new
  single-instance `PortHoldersModal`.
- `app.BringUpGlobals` runs a pre-launch TCP probe of 80/443 *before*
  attempting the router create — short-circuits with
  `router.ErrPortInUse` so the UI shows the friendly typed-error path
  instead of a noisy SDK stack trace.
- `LEARNINGS.md` §2.5 + `FOOTGUNS.md` F14 document the design choice
  to **not** fall back to ephemeral ports (URL stability is
  load-bearing for cookie scope, mkcert SANs, hard-coded WP
  `siteurl`, and user docs). The previous "choose a different port in
  Settings" copy in `erractions.go` was misleading and is now "Open
  System Health".

## F19 — mkcert capability surfacing

- `internal/tls/capabilities.go` (+ `_windows`/`_other` build-tag
  pair) probes `JAVA_HOME` / `which java` and Firefox-on-Windows.
  No mkcert output parsing; no GUI-from-launchctl manipulation.
- `Provider.Capabilities(ctx)` returned alongside `Available`. Fake
  provider gets a `CapabilitiesValue` switch for tests.
- `health.MkcertCheck` emits Info-level findings
  (`mkcert-java-trust`, `mkcert-firefox-windows`) when mkcert is
  otherwise OK but Java / Firefox-on-Windows is detected — text
  directs the user to re-run `mkcert -install` from the right
  context.

## Scope

- F12, F14, F19 promoted from 🟡 Partial → ✅ Verified in
  `FOOTGUNS.md`.
- F2, F15, F20 remain ⛔ Future-gated (mutagen / telemetry transport).
- All ✅ Verified items elsewhere in `FOOTGUNS.md` were code-audited
  and matched their docs — no other changes needed.
